### PR TITLE
[Chore] Fix mypy configuration for FastAPI/Pydantic compatibility

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,12 @@ ignore_missing_imports = true
 strict = true
 disallow_subclassing_any = false
 disallow_untyped_decorators = false
+untyped_calls_exclude = ["redis"]
+plugins = ["pydantic.mypy"]
+
+[tool.pydantic-mypy]
+init_typed = true
+warn_required_dynamic_aliases = true
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest-asyncio==0.24.0
 pytest-cov==5.0.0
 ruff==0.6.9
 mypy==1.11.2
+pydantic==2.11.7


### PR DESCRIPTION
### Motivation
- Mypy needs the Pydantic mypy plugin to correctly type-check FastAPI/Pydantic models and settings. 
- Strict-mode mypy was failing on calls into untyped third-party Redis APIs which should be excluded from strict call checks. 

### Description
- Enabled the Pydantic mypy plugin by adding `plugins = ["pydantic.mypy"]` to `backend/pyproject.toml`. 
- Added `untyped_calls_exclude = ["redis"]` to `backend/pyproject.toml` to avoid false-positive `no-untyped-call` errors from the Redis client. 
- Added a `[tool.pydantic-mypy]` section with `init_typed = true` and `warn_required_dynamic_aliases = true` in `backend/pyproject.toml`. 
- Added `pydantic==2.11.7` to `backend/requirements-dev.txt` so the mypy plugin can be imported in dev/CI environments. 

### Testing
- Ran `cd backend && mypy app` and it completed successfully with no issues. 
- Ran `cd backend && pytest -q` and the test suite passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b083d2b1cc83258d10d8a80833e762)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies and enhanced static type checking configuration to improve code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->