### PR TITLE
feat: implement Phase 3 Locations CRUD backend

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from app.core.config import get_settings
 from app.db.base import Base
-from app.models import User  # noqa: F401
+from app.models import Location, User  # noqa: F401
 
 config = context.config
 

--- a/backend/alembic/versions/20260903_000002_create_locations_table.py
+++ b/backend/alembic/versions/20260903_000002_create_locations_table.py
@@ -1,0 +1,34 @@
+"""create locations table
+
+Revision ID: 20260903_000002
+Revises: 20260901_000001
+Create Date: 2026-09-03 00:00:02
+"""
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260903_000002"
+down_revision: str | None = "20260901_000001"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "locations",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("room", sa.String(length=100), nullable=False),
+        sa.Column("furniture", sa.String(length=100), nullable=False),
+        sa.Column("shelf", sa.String(length=100), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("locations")

--- a/backend/app/api/locations.py
+++ b/backend/app/api/locations.py
@@ -1,0 +1,68 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies.auth import get_current_user
+from app.db.session import get_db_session
+from app.models.user import User
+from app.schemas.location import LocationCreateRequest, LocationResponse, LocationUpdateRequest
+from app.services.location import (
+    create_location,
+    delete_location,
+    get_location_or_404,
+    list_locations,
+    update_location,
+)
+
+router = APIRouter(prefix="/api/v1/locations", tags=["locations"])
+
+
+@router.get("", response_model=list[LocationResponse])
+async def read_locations(
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> list[LocationResponse]:
+    locations = await list_locations(session)
+    return [LocationResponse.model_validate(location) for location in locations]
+
+
+@router.post("", response_model=LocationResponse, status_code=status.HTTP_201_CREATED)
+async def create_location_endpoint(
+    payload: LocationCreateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> LocationResponse:
+    location = await create_location(session, payload)
+    return LocationResponse.model_validate(location)
+
+
+@router.get("/{location_id}", response_model=LocationResponse)
+async def read_location(
+    location_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> LocationResponse:
+    location = await get_location_or_404(session, location_id)
+    return LocationResponse.model_validate(location)
+
+
+@router.patch("/{location_id}", response_model=LocationResponse)
+async def update_location_endpoint(
+    location_id: uuid.UUID,
+    payload: LocationUpdateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> LocationResponse:
+    location = await update_location(session, location_id, payload)
+    return LocationResponse.model_validate(location)
+
+
+@router.delete("/{location_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_location_endpoint(
+    location_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> Response:
+    await delete_location(session, location_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ import structlog
 
 from app.api.auth import router as auth_router
 from app.api.health import router as health_router
+from app.api.locations import router as locations_router
 from app.core.config import get_settings
 from app.db.session import SessionLocal
 from app.services.user_seed import seed_admin_user
@@ -31,6 +32,7 @@ def create_app() -> FastAPI:
     app = FastAPI(title=settings.app_name, lifespan=lifespan)
     app.include_router(health_router)
     app.include_router(auth_router)
+    app.include_router(locations_router)
     return app
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.location import Location
 from app.models.user import User
 
-__all__ = ["User"]
+__all__ = ["User", "Location"]

--- a/backend/app/models/location.py
+++ b/backend/app/models/location.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+import uuid
+
+from sqlalchemy import DateTime, String, Uuid, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class Location(Base):
+    __tablename__ = "locations"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    room: Mapped[str] = mapped_column(String(100), nullable=False)
+    furniture: Mapped[str] = mapped_column(String(100), nullable=False)
+    shelf: Mapped[str] = mapped_column(String(100), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/schemas/location.py
+++ b/backend/app/schemas/location.py
@@ -1,19 +1,26 @@
 from datetime import datetime
 import uuid
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class LocationCreateRequest(BaseModel):
-    room: str
-    furniture: str
-    shelf: str
+    room: str = Field(min_length=1, max_length=100)
+    furniture: str = Field(min_length=1, max_length=100)
+    shelf: str = Field(min_length=1, max_length=100)
 
 
 class LocationUpdateRequest(BaseModel):
-    room: str | None = None
-    furniture: str | None = None
-    shelf: str | None = None
+    room: str | None = Field(default=None, min_length=1, max_length=100)
+    furniture: str | None = Field(default=None, min_length=1, max_length=100)
+    shelf: str | None = Field(default=None, min_length=1, max_length=100)
+
+    @model_validator(mode="after")
+    def reject_explicit_nulls(self) -> "LocationUpdateRequest":
+        for field_name in ("room", "furniture", "shelf"):
+            if field_name in self.model_fields_set and getattr(self, field_name) is None:
+                raise ValueError(f"{field_name} cannot be null")
+        return self
 
 
 class LocationResponse(BaseModel):

--- a/backend/app/schemas/location.py
+++ b/backend/app/schemas/location.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class LocationCreateRequest(BaseModel):
+    room: str
+    furniture: str
+    shelf: str
+
+
+class LocationUpdateRequest(BaseModel):
+    room: str | None = None
+    furniture: str | None = None
+    shelf: str | None = None
+
+
+class LocationResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    room: str
+    furniture: str
+    shelf: str
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/location.py
+++ b/backend/app/services/location.py
@@ -37,7 +37,7 @@ async def update_location(
     session: AsyncSession, location_id: uuid.UUID, payload: LocationUpdateRequest
 ) -> Location:
     location = await get_location_or_404(session, location_id)
-    update_data = payload.model_dump(exclude_unset=True)
+    update_data = payload.model_dump(exclude_unset=True, exclude_none=True)
     for field_name, value in update_data.items():
         setattr(location, field_name, value)
 
@@ -63,9 +63,13 @@ async def delete_location(session: AsyncSession, location_id: uuid.UUID) -> None
 
 async def _location_has_books(session: AsyncSession, location_id: uuid.UUID) -> bool:
     connection = await session.connection()
-    has_books_table = await connection.run_sync(lambda sync_conn: inspect(sync_conn).has_table("books"))
+    books_columns = await connection.run_sync(
+        lambda sync_conn: {column["name"] for column in inspect(sync_conn).get_columns("books")}
+        if inspect(sync_conn).has_table("books")
+        else set()
+    )
 
-    if not has_books_table:
+    if "location_id" not in books_columns:
         return False
 
     books = Table("books", MetaData(), Column("location_id", Uuid(as_uuid=True)))

--- a/backend/app/services/location.py
+++ b/backend/app/services/location.py
@@ -1,0 +1,75 @@
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import Column, MetaData, Table, Uuid, func, inspect, select
+from sqlalchemy.ext.asyncio import AsyncSession
+import structlog
+
+from app.models.location import Location
+from app.schemas.location import LocationCreateRequest, LocationUpdateRequest
+
+logger = structlog.get_logger()
+
+
+async def list_locations(session: AsyncSession) -> list[Location]:
+    result = await session.execute(select(Location).order_by(Location.room, Location.furniture, Location.shelf))
+    return list(result.scalars().all())
+
+
+async def create_location(session: AsyncSession, payload: LocationCreateRequest) -> Location:
+    location = Location(room=payload.room, furniture=payload.furniture, shelf=payload.shelf)
+    session.add(location)
+    await session.commit()
+    await session.refresh(location)
+    logger.info("location_created", location_id=str(location.id))
+    return location
+
+
+async def get_location_or_404(session: AsyncSession, location_id: uuid.UUID) -> Location:
+    result = await session.execute(select(Location).where(Location.id == location_id))
+    location = result.scalar_one_or_none()
+    if location is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Location not found")
+    return location
+
+
+async def update_location(
+    session: AsyncSession, location_id: uuid.UUID, payload: LocationUpdateRequest
+) -> Location:
+    location = await get_location_or_404(session, location_id)
+    update_data = payload.model_dump(exclude_unset=True)
+    for field_name, value in update_data.items():
+        setattr(location, field_name, value)
+
+    await session.commit()
+    await session.refresh(location)
+    logger.info("location_updated", location_id=str(location.id), fields=list(update_data.keys()))
+    return location
+
+
+async def delete_location(session: AsyncSession, location_id: uuid.UUID) -> None:
+    location = await get_location_or_404(session, location_id)
+
+    if await _location_has_books(session, location_id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Location cannot be deleted because books are assigned",
+        )
+
+    await session.delete(location)
+    await session.commit()
+    logger.info("location_deleted", location_id=str(location_id))
+
+
+async def _location_has_books(session: AsyncSession, location_id: uuid.UUID) -> bool:
+    connection = await session.connection()
+    has_books_table = await connection.run_sync(lambda sync_conn: inspect(sync_conn).has_table("books"))
+
+    if not has_books_table:
+        return False
+
+    books = Table("books", MetaData(), Column("location_id", Uuid(as_uuid=True)))
+    result = await session.execute(
+        select(func.count()).select_from(books).where(books.c.location_id == location_id)
+    )
+    return int(result.scalar_one()) > 0

--- a/backend/tests/test_locations.py
+++ b/backend/tests/test_locations.py
@@ -1,0 +1,129 @@
+from collections.abc import AsyncIterator, Iterator
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+from sqlalchemy import Column, DateTime, MetaData, String, Table, Uuid, func, insert
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.user import User
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url="sqlite+aiosqlite:///:memory:",
+        jwt_secret_key="test-secret",
+        jwt_algorithm="HS256",
+        access_token_expire_minutes=15,
+        refresh_token_expire_days=7,
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(test_session: AsyncSession, test_settings: Settings) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        yield test_session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _seed_user(session: AsyncSession) -> None:
+    session.add(User(email="admin@example.com", hashed_password=get_password_hash("secret")))
+    await session.commit()
+
+
+async def _auth_headers(client: AsyncClient, session: AsyncSession) -> dict[str, str]:
+    await _seed_user(session)
+    login_response = await client.post("/api/v1/auth/login", json={"email": "admin@example.com", "password": "secret"})
+    token = login_response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_locations_full_crud_cycle(test_session: AsyncSession) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        created = await client.post(
+            "/api/v1/locations",
+            json={"room": "office", "furniture": "bookshelf-2", "shelf": "shelf-3"},
+            headers=headers,
+        )
+        assert created.status_code == 201
+        location_id = created.json()["id"]
+
+        assert (await client.get("/api/v1/locations", headers=headers)).status_code == 200
+        assert (await client.get(f"/api/v1/locations/{location_id}", headers=headers)).status_code == 200
+
+        patched = await client.patch(
+            f"/api/v1/locations/{location_id}", json={"shelf": "shelf-4"}, headers=headers
+        )
+        assert patched.status_code == 200
+        assert patched.json()["shelf"] == "shelf-4"
+
+        deleted = await client.delete(f"/api/v1/locations/{location_id}", headers=headers)
+        assert deleted.status_code == 204
+        assert (await client.get(f"/api/v1/locations/{location_id}", headers=headers)).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_locations_require_authentication() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        assert (await client.get("/api/v1/locations")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_location_blocked_when_books_assigned(test_session: AsyncSession) -> None:
+    books_table = Table(
+        "books",
+        MetaData(),
+        Column("id", Uuid(as_uuid=True), primary_key=True),
+        Column("title", String(255), nullable=False),
+        Column("location_id", Uuid(as_uuid=True), nullable=True),
+        Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
+    )
+    async with test_session.bind.begin() as connection:
+        await connection.run_sync(books_table.create)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        created = await client.post(
+            "/api/v1/locations",
+            json={"room": "office", "furniture": "bookshelf-2", "shelf": "shelf-3"},
+            headers=headers,
+        )
+        location_id = uuid.UUID(created.json()["id"])
+
+        await test_session.execute(
+            insert(books_table).values(
+                id=uuid.uuid4(),
+                title="Domain-Driven Design",
+                location_id=location_id,
+            )
+        )
+        await test_session.commit()
+
+        blocked = await client.delete(f"/api/v1/locations/{location_id}", headers=headers)
+
+    assert blocked.status_code == 409

--- a/backend/tests/test_locations.py
+++ b/backend/tests/test_locations.py
@@ -82,6 +82,13 @@ async def test_locations_full_crud_cycle(test_session: AsyncSession) -> None:
         assert patched.status_code == 200
         assert patched.json()["shelf"] == "shelf-4"
 
+        patched_null = await client.patch(
+            f"/api/v1/locations/{location_id}",
+            json={"shelf": None},
+            headers=headers,
+        )
+        assert 400 <= patched_null.status_code < 500
+
         deleted = await client.delete(f"/api/v1/locations/{location_id}", headers=headers)
         assert deleted.status_code == 204
         assert (await client.get(f"/api/v1/locations/{location_id}", headers=headers)).status_code == 404
@@ -127,3 +134,28 @@ async def test_delete_location_blocked_when_books_assigned(test_session: AsyncSe
         blocked = await client.delete(f"/api/v1/locations/{location_id}", headers=headers)
 
     assert blocked.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_delete_location_safe_when_books_table_has_no_location_id(test_session: AsyncSession) -> None:
+    books_table = Table(
+        "books",
+        MetaData(),
+        Column("id", Uuid(as_uuid=True), primary_key=True),
+        Column("title", String(255), nullable=False),
+    )
+    async with test_session.bind.begin() as connection:
+        await connection.run_sync(books_table.create)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        created = await client.post(
+            "/api/v1/locations",
+            json={"room": "office", "furniture": "bookshelf-2", "shelf": "shelf-3"},
+            headers=headers,
+        )
+        location_id = created.json()["id"]
+
+        delete_response = await client.delete(f"/api/v1/locations/{location_id}", headers=headers)
+
+    assert delete_response.status_code == 204

--- a/docs/project-spec.md
+++ b/docs/project-spec.md
@@ -407,6 +407,7 @@ Jobs
 Locations
   GET    /api/v1/locations
   POST   /api/v1/locations
+  GET    /api/v1/locations/{id}
   PATCH  /api/v1/locations/{id}
   DELETE /api/v1/locations/{id}
 


### PR DESCRIPTION
### Motivation
- Implement Phase 3 backend deliverables: persistent `Location` resource with full CRUD and protection by existing auth dependency. 
- Ensure deleting a location is safe by blocking removal when books are assigned, while remaining compatible before the full `Book` model is added in Phase 5.

### Description
- Added `Location` SQLAlchemy model with `room`, `furniture`, `shelf`, and timestamp columns (`backend/app/models/location.py`).
- Added Pydantic schemas `LocationCreateRequest`, `LocationUpdateRequest`, and `LocationResponse` (`backend/app/schemas/location.py`).
- Introduced async service layer `app.services.location` implementing `list/create/get/update/delete` and a guarded `_location_has_books` check that first detects the presence of a `books` table then counts rows to enforce delete conflict (`409`) when appropriate (`backend/app/services/location.py`).
- Exposed protected REST endpoints `GET /api/v1/locations`, `POST /api/v1/locations`, `GET /api/v1/locations/{id}`, `PATCH /api/v1/locations/{id}`, and `DELETE /api/v1/locations/{id}` behind `get_current_user`, wired the router into the app, added an Alembic migration for the `locations` table, and updated `alembic/env.py` and `docs/project-spec.md` accordingly (`backend/app/api/locations.py`, `backend/alembic/versions/20260903_000002_create_locations_table.py`, `backend/alembic/env.py`, `backend/app/main.py`, `docs/project-spec.md`).

### Testing
- Ran code quality and static checks with `ruff check app tests` and `mypy app`, both succeeded.
- Ran unit/API test suite with `pytest --cov=app --cov-fail-under=80 tests` and achieved all tests passing (13 passed) and coverage of `80.66%`, which meets the required `80%` threshold.
- The location tests exercise full CRUD flows, authentication enforcement (unauthenticated requests return `401`), and the delete-blocking behavior when a `books` row is present (returns `409`) (`backend/tests/test_locations.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18fbae4e48325ad9dec2deccb74cc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced locations management with full CRUD API endpoints (create, list, retrieve, update, delete) behind authentication.
  * Deletion is blocked when related records exist to protect data integrity.

* **Database**
  * Added database migration to create a persistent locations table.

* **Tests**
  * Added end-to-end tests covering auth, full CRUD lifecycle, and deletion/constraint behaviors.

* **Documentation**
  * Updated spec to document per-location retrieval endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->