### PR TITLE
feat(backend): Phase 5 books backend — Book model, APIs, search & pagination

### DIFF
--- a/backend/alembic/versions/20260910_000003_create_books_table.py
+++ b/backend/alembic/versions/20260910_000003_create_books_table.py
@@ -57,16 +57,15 @@ def upgrade() -> None:
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.ForeignKeyConstraint(["location_id"], ["locations.id"], ondelete="SET NULL"),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("isbn"),
     )
-    op.create_index("ix_books_isbn", "books", ["isbn"], unique=False)
+    op.create_index("ix_books_isbn", "books", ["isbn"], unique=True)
     op.create_index("ix_books_location_id", "books", ["location_id"], unique=False)
 
     if is_postgresql:
         op.create_index(
             "ix_books_search_vector",
             "books",
-            [sa.text("to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(author, ''))")],
+            [sa.text("to_tsvector('simple', concat_ws(' ', title, coalesce(author, '')))")],
             postgresql_using="gin",
         )
 

--- a/backend/alembic/versions/20260910_000003_create_books_table.py
+++ b/backend/alembic/versions/20260910_000003_create_books_table.py
@@ -32,6 +32,9 @@ def upgrade() -> None:
     bind = op.get_bind()
     is_postgresql = bind.dialect.name == "postgresql"
 
+    if is_postgresql:
+        book_processing_status.create(bind, checkfirst=True)
+
     op.create_table(
         "books",
         sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
@@ -80,4 +83,4 @@ def downgrade() -> None:
     op.drop_table("books")
 
     if is_postgresql:
-        book_processing_status.drop(op.get_bind(), checkfirst=True)
+        book_processing_status.drop(bind, checkfirst=True)

--- a/backend/alembic/versions/20260910_000003_create_books_table.py
+++ b/backend/alembic/versions/20260910_000003_create_books_table.py
@@ -24,15 +24,13 @@ book_processing_status = sa.Enum(
     "failed",
     "partial",
     name="book_processing_status",
+    create_type=False,
 )
 
 
 def upgrade() -> None:
     bind = op.get_bind()
     is_postgresql = bind.dialect.name == "postgresql"
-
-    if is_postgresql:
-        book_processing_status.create(bind, checkfirst=True)
 
     op.create_table(
         "books",
@@ -62,9 +60,11 @@ def upgrade() -> None:
     op.create_index("ix_books_location_id", "books", ["location_id"], unique=False)
 
     if is_postgresql:
-        op.execute(
-            "CREATE INDEX ix_books_search_vector ON books USING GIN "
-            "(to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(author, '')));"
+        op.create_index(
+            "ix_books_search_vector",
+            "books",
+            [sa.text("to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(author, ''))")],
+            postgresql_using="gin",
         )
 
 
@@ -73,11 +73,11 @@ def downgrade() -> None:
     is_postgresql = bind.dialect.name == "postgresql"
 
     if is_postgresql:
-        op.execute("DROP INDEX IF EXISTS ix_books_search_vector")
+        op.drop_index("ix_books_search_vector", table_name="books")
 
     op.drop_index("ix_books_location_id", table_name="books")
     op.drop_index("ix_books_isbn", table_name="books")
     op.drop_table("books")
 
     if is_postgresql:
-        book_processing_status.drop(bind, checkfirst=True)
+        book_processing_status.drop(op.get_bind(), checkfirst=True)

--- a/backend/alembic/versions/20260910_000003_create_books_table.py
+++ b/backend/alembic/versions/20260910_000003_create_books_table.py
@@ -1,0 +1,83 @@
+"""create books table
+
+Revision ID: 20260910_000003
+Revises: 20260903_000002
+Create Date: 2026-09-10 00:00:03
+"""
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260910_000003"
+down_revision: str | None = "20260903_000002"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+book_processing_status = sa.Enum(
+    "manual",
+    "pending",
+    "done",
+    "failed",
+    "partial",
+    name="book_processing_status",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    if is_postgresql:
+        book_processing_status.create(bind, checkfirst=True)
+
+    op.create_table(
+        "books",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("title", sa.String(length=500), nullable=False),
+        sa.Column("author", sa.String(length=500), nullable=True),
+        sa.Column("isbn", sa.String(length=20), nullable=True),
+        sa.Column("publisher", sa.String(length=300), nullable=True),
+        sa.Column("language", sa.String(length=10), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("publication_year", sa.Integer(), nullable=True),
+        sa.Column("cover_image_url", sa.String(length=500), nullable=True),
+        sa.Column("location_id", sa.Uuid(as_uuid=True), nullable=True),
+        sa.Column(
+            "processing_status",
+            book_processing_status if is_postgresql else sa.String(length=20),
+            nullable=False,
+            server_default="manual",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["location_id"], ["locations.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("isbn"),
+    )
+    op.create_index("ix_books_isbn", "books", ["isbn"], unique=False)
+    op.create_index("ix_books_location_id", "books", ["location_id"], unique=False)
+
+    if is_postgresql:
+        op.execute(
+            "CREATE INDEX ix_books_search_vector ON books USING GIN "
+            "(to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(author, '')));"
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    if is_postgresql:
+        op.execute("DROP INDEX IF EXISTS ix_books_search_vector")
+
+    op.drop_index("ix_books_location_id", table_name="books")
+    op.drop_index("ix_books_isbn", table_name="books")
+    op.drop_table("books")
+
+    if is_postgresql:
+        book_processing_status.drop(bind, checkfirst=True)

--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -1,0 +1,73 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Query, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies.auth import get_current_user
+from app.db.session import get_db_session
+from app.models.user import User
+from app.schemas.book import BookCreateRequest, BookListResponse, BookResponse, BookUpdateRequest
+from app.services.book import create_book, delete_book, get_book_or_404, list_books, update_book
+
+router = APIRouter(prefix="/api/v1/books", tags=["books"])
+
+
+@router.get("", response_model=BookListResponse)
+async def read_books(
+    search: str | None = Query(default=None, min_length=1),
+    location_id: uuid.UUID | None = None,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> BookListResponse:
+    books, total = await list_books(
+        session, search=search, location_id=location_id, page=page, page_size=page_size
+    )
+    return BookListResponse(
+        total=total,
+        page=page,
+        page_size=page_size,
+        items=[BookResponse.model_validate(book) for book in books],
+    )
+
+
+@router.post("", response_model=BookResponse, status_code=status.HTTP_201_CREATED)
+async def create_book_endpoint(
+    payload: BookCreateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> BookResponse:
+    book = await create_book(session, payload)
+    return BookResponse.model_validate(book)
+
+
+@router.get("/{book_id}", response_model=BookResponse)
+async def read_book(
+    book_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> BookResponse:
+    book = await get_book_or_404(session, book_id)
+    return BookResponse.model_validate(book)
+
+
+@router.patch("/{book_id}", response_model=BookResponse)
+async def update_book_endpoint(
+    book_id: uuid.UUID,
+    payload: BookUpdateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> BookResponse:
+    book = await update_book(session, book_id, payload)
+    return BookResponse.model_validate(book)
+
+
+@router.delete("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_book_endpoint(
+    book_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> Response:
+    await delete_book(session, book_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 import structlog
 
 from app.api.auth import router as auth_router
+from app.api.books import router as books_router
 from app.api.health import router as health_router
 from app.api.locations import router as locations_router
 from app.core.config import get_settings
@@ -33,6 +34,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router)
     app.include_router(auth_router)
     app.include_router(locations_router)
+    app.include_router(books_router)
     return app
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
+from app.models.book import Book
 from app.models.location import Location
 from app.models.user import User
 
-__all__ = ["User", "Location"]
+__all__ = ["User", "Location", "Book"]

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 import uuid
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, Uuid, func
+from sqlalchemy import DateTime, Enum as SAEnum, ForeignKey, Integer, String, Text, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -32,7 +32,13 @@ class Book(Base):
         Uuid(as_uuid=True), ForeignKey("locations.id", ondelete="SET NULL"), nullable=True, index=True
     )
     processing_status: Mapped[BookProcessingStatus] = mapped_column(
-        String(20),
+        SAEnum(
+            BookProcessingStatus,
+            values_callable=lambda e: [member.value for member in e],
+            validate_strings=True,
+            name="book_processing_status",
+            create_type=False,
+        ),
         nullable=False,
         default=BookProcessingStatus.MANUAL,
         server_default=BookProcessingStatus.MANUAL.value,

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from enum import Enum
+import uuid
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, Uuid, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class BookProcessingStatus(str, Enum):
+    MANUAL = "manual"
+    PENDING = "pending"
+    DONE = "done"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+class Book(Base):
+    __tablename__ = "books"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    author: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    isbn: Mapped[str | None] = mapped_column(String(20), nullable=True, unique=True, index=True)
+    publisher: Mapped[str | None] = mapped_column(String(300), nullable=True)
+    language: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    publication_year: Mapped[int | None] = mapped_column(Integer(), nullable=True)
+    cover_image_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    location_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("locations.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    processing_status: Mapped[BookProcessingStatus] = mapped_column(
+        String(20),
+        nullable=False,
+        default=BookProcessingStatus.MANUAL,
+        server_default=BookProcessingStatus.MANUAL.value,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/schemas/book.py
+++ b/backend/app/schemas/book.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.models.book import BookProcessingStatus
+
+
+class BookBaseRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=500)
+    author: str | None = Field(default=None, min_length=1, max_length=500)
+    isbn: str | None = Field(default=None, min_length=1, max_length=20)
+    publisher: str | None = Field(default=None, min_length=1, max_length=300)
+    language: str | None = Field(default=None, min_length=2, max_length=10)
+    description: str | None = Field(default=None, min_length=1)
+    publication_year: int | None = Field(default=None, ge=0, le=9999)
+    cover_image_url: str | None = Field(default=None, max_length=500)
+    location_id: uuid.UUID | None = None
+    processing_status: BookProcessingStatus = BookProcessingStatus.MANUAL
+
+
+class BookCreateRequest(BookBaseRequest):
+    pass
+
+
+class BookUpdateRequest(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=500)
+    author: str | None = Field(default=None, min_length=1, max_length=500)
+    isbn: str | None = Field(default=None, min_length=1, max_length=20)
+    publisher: str | None = Field(default=None, min_length=1, max_length=300)
+    language: str | None = Field(default=None, min_length=2, max_length=10)
+    description: str | None = Field(default=None, min_length=1)
+    publication_year: int | None = Field(default=None, ge=0, le=9999)
+    cover_image_url: str | None = Field(default=None, max_length=500)
+    location_id: uuid.UUID | None = None
+    processing_status: BookProcessingStatus | None = None
+
+    @model_validator(mode="after")
+    def reject_explicit_nulls(self) -> "BookUpdateRequest":
+        nullable_fields = {"author", "isbn", "publisher", "language", "description", "publication_year", "cover_image_url", "location_id"}
+        for field_name in self.model_fields_set:
+            if field_name not in nullable_fields and getattr(self, field_name) is None:
+                raise ValueError(f"{field_name} cannot be null")
+        return self
+
+
+class BookResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    title: str
+    author: str | None
+    isbn: str | None
+    publisher: str | None
+    language: str | None
+    description: str | None
+    publication_year: int | None
+    cover_image_url: str | None
+    location_id: uuid.UUID | None
+    processing_status: BookProcessingStatus
+    created_at: datetime
+    updated_at: datetime
+
+
+class BookListResponse(BaseModel):
+    total: int
+    page: int
+    page_size: int
+    items: list[BookResponse]

--- a/backend/app/services/book.py
+++ b/backend/app/services/book.py
@@ -60,7 +60,12 @@ async def create_book(session: AsyncSession, payload: BookCreateRequest) -> Book
     except IntegrityError as exc:
         await session.rollback()
         orig = str(exc.orig).lower() if exc.orig else ""
-        if "ix_books_isbn" in orig or "uq_books_isbn" in orig or "books_isbn" in orig:
+        if (
+            "ix_books_isbn" in orig
+            or "uq_books_isbn" in orig
+            or "books_isbn" in orig
+            or "books.isbn" in orig
+        ):
             raise _map_integrity_error(exc) from exc
         raise
 
@@ -92,7 +97,12 @@ async def update_book(session: AsyncSession, book_id: uuid.UUID, payload: BookUp
     except IntegrityError as exc:
         await session.rollback()
         orig = str(exc.orig).lower() if exc.orig else ""
-        if "ix_books_isbn" in orig or "uq_books_isbn" in orig or "books_isbn" in orig:
+        if (
+            "ix_books_isbn" in orig
+            or "uq_books_isbn" in orig
+            or "books_isbn" in orig
+            or "books.isbn" in orig
+        ):
             raise _map_integrity_error(exc) from exc
         raise
 

--- a/backend/app/services/book.py
+++ b/backend/app/services/book.py
@@ -1,0 +1,120 @@
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import ColumnElement
+from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+import structlog
+
+from app.models.book import Book
+from app.models.location import Location
+from app.schemas.book import BookCreateRequest, BookUpdateRequest
+
+logger = structlog.get_logger()
+
+
+async def list_books(
+    session: AsyncSession,
+    *,
+    search: str | None,
+    location_id: uuid.UUID | None,
+    page: int,
+    page_size: int,
+) -> tuple[list[Book], int]:
+    filters: list[ColumnElement[bool]] = []
+
+    if location_id is not None:
+        filters.append(Book.location_id == location_id)
+
+    normalized_search = search.strip() if search else ""
+    if normalized_search:
+        if session.bind is not None and session.bind.dialect.name == "postgresql":
+            tsvector = func.to_tsvector("simple", func.concat_ws(" ", Book.title, func.coalesce(Book.author, "")))
+            filters.append(tsvector.op("@@")(func.plainto_tsquery("simple", normalized_search)))
+        else:
+            like_pattern = f"%{normalized_search}%"
+            filters.append(or_(Book.title.ilike(like_pattern), Book.author.ilike(like_pattern)))
+
+    count_query = select(func.count()).select_from(Book)
+    if filters:
+        count_query = count_query.where(*filters)
+
+    query = select(Book).order_by(Book.created_at.desc())
+    if filters:
+        query = query.where(*filters)
+    query = query.offset((page - 1) * page_size).limit(page_size)
+
+    total = int((await session.execute(count_query)).scalar_one())
+    books = list((await session.execute(query)).scalars().all())
+    return books, total
+
+
+async def create_book(session: AsyncSession, payload: BookCreateRequest) -> Book:
+    await _validate_location_exists(session, payload.location_id)
+    book = Book(**payload.model_dump())
+    session.add(book)
+
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise _map_integrity_error(exc) from exc
+
+    await session.refresh(book)
+    logger.info("book_created", book_id=str(book.id), location_id=str(book.location_id) if book.location_id else None)
+    return book
+
+
+async def get_book_or_404(session: AsyncSession, book_id: uuid.UUID) -> Book:
+    result = await session.execute(select(Book).where(Book.id == book_id))
+    book = result.scalar_one_or_none()
+    if book is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found")
+    return book
+
+
+async def update_book(session: AsyncSession, book_id: uuid.UUID, payload: BookUpdateRequest) -> Book:
+    book = await get_book_or_404(session, book_id)
+    update_data = payload.model_dump(exclude_unset=True)
+
+    if "location_id" in update_data:
+        await _validate_location_exists(session, update_data["location_id"])
+
+    for field_name, value in update_data.items():
+        setattr(book, field_name, value)
+
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise _map_integrity_error(exc) from exc
+
+    await session.refresh(book)
+    logger.info("book_updated", book_id=str(book.id), fields=list(update_data.keys()))
+    return book
+
+
+async def delete_book(session: AsyncSession, book_id: uuid.UUID) -> None:
+    book = await get_book_or_404(session, book_id)
+    await session.delete(book)
+    await session.commit()
+    logger.info("book_deleted", book_id=str(book_id))
+
+
+async def _validate_location_exists(session: AsyncSession, location_id: uuid.UUID | None) -> None:
+    if location_id is None:
+        return
+
+    exists = (
+        await session.execute(select(Location.id).where(Location.id == location_id).limit(1))
+    ).scalar_one_or_none()
+    if exists is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Location not found")
+
+
+def _map_integrity_error(_exc: IntegrityError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="Book with this ISBN already exists",
+    )

--- a/backend/app/services/book.py
+++ b/backend/app/services/book.py
@@ -40,7 +40,7 @@ async def list_books(
     if filters:
         count_query = count_query.where(*filters)
 
-    query = select(Book).order_by(Book.created_at.desc())
+    query = select(Book).order_by(Book.created_at.desc(), Book.id.desc())
     if filters:
         query = query.where(*filters)
     query = query.offset((page - 1) * page_size).limit(page_size)
@@ -59,7 +59,10 @@ async def create_book(session: AsyncSession, payload: BookCreateRequest) -> Book
         await session.commit()
     except IntegrityError as exc:
         await session.rollback()
-        raise _map_integrity_error(exc) from exc
+        orig = str(exc.orig).lower() if exc.orig else ""
+        if "ix_books_isbn" in orig or "uq_books_isbn" in orig or "books_isbn" in orig:
+            raise _map_integrity_error(exc) from exc
+        raise
 
     await session.refresh(book)
     logger.info("book_created", book_id=str(book.id), location_id=str(book.location_id) if book.location_id else None)
@@ -88,7 +91,10 @@ async def update_book(session: AsyncSession, book_id: uuid.UUID, payload: BookUp
         await session.commit()
     except IntegrityError as exc:
         await session.rollback()
-        raise _map_integrity_error(exc) from exc
+        orig = str(exc.orig).lower() if exc.orig else ""
+        if "ix_books_isbn" in orig or "uq_books_isbn" in orig or "books_isbn" in orig:
+            raise _map_integrity_error(exc) from exc
+        raise
 
     await session.refresh(book)
     logger.info("book_updated", book_id=str(book.id), fields=list(update_data.keys()))

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -1,0 +1,190 @@
+from collections.abc import AsyncIterator, Iterator
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.book import Book
+from app.models.location import Location
+from app.models.user import User
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url="sqlite+aiosqlite:///:memory:",
+        jwt_secret_key="test-secret",
+        jwt_algorithm="HS256",
+        access_token_expire_minutes=15,
+        refresh_token_expire_days=7,
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(test_session: AsyncSession, test_settings: Settings) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        yield test_session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _seed_user(session: AsyncSession) -> None:
+    session.add(User(email="admin@example.com", hashed_password=get_password_hash("secret")))
+    await session.commit()
+
+
+async def _auth_headers(client: AsyncClient, session: AsyncSession) -> dict[str, str]:
+    await _seed_user(session)
+    login_response = await client.post("/api/v1/auth/login", json={"email": "admin@example.com", "password": "secret"})
+    token = login_response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_location(session: AsyncSession) -> uuid.UUID:
+    location = Location(room="office", furniture="bookshelf", shelf="shelf-1")
+    session.add(location)
+    await session.commit()
+    await session.refresh(location)
+    return location.id
+
+
+@pytest.mark.asyncio
+async def test_books_full_crud_cycle(test_session: AsyncSession) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        location_id = await _create_location(test_session)
+
+        created = await client.post(
+            "/api/v1/books",
+            json={
+                "title": "Clean Architecture",
+                "author": "Robert C. Martin",
+                "isbn": "9780134494166",
+                "publisher": "Prentice Hall",
+                "language": "en",
+                "description": "Software architecture and design principles.",
+                "publication_year": 2017,
+                "cover_image_url": "https://example.com/clean-architecture.jpg",
+                "location_id": str(location_id),
+            },
+            headers=headers,
+        )
+        assert created.status_code == 201
+        book_id = created.json()["id"]
+
+        listed = await client.get("/api/v1/books", headers=headers)
+        assert listed.status_code == 200
+        assert listed.json()["total"] == 1
+        assert len(listed.json()["items"]) == 1
+
+        fetched = await client.get(f"/api/v1/books/{book_id}", headers=headers)
+        assert fetched.status_code == 200
+        assert fetched.json()["isbn"] == "9780134494166"
+
+        updated = await client.patch(
+            f"/api/v1/books/{book_id}",
+            json={"title": "Clean Architecture (Updated)", "location_id": None},
+            headers=headers,
+        )
+        assert updated.status_code == 200
+        assert updated.json()["title"] == "Clean Architecture (Updated)"
+        assert updated.json()["location_id"] is None
+
+        deleted = await client.delete(f"/api/v1/books/{book_id}", headers=headers)
+        assert deleted.status_code == 204
+        assert (await client.get(f"/api/v1/books/{book_id}", headers=headers)).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_books_search_returns_expected_results(test_session: AsyncSession) -> None:
+    test_session.add_all(
+        [
+            Book(title="The Pragmatic Programmer", author="Andrew Hunt"),
+            Book(title="Domain-Driven Design", author="Eric Evans"),
+            Book(title="Refactoring", author="Martin Fowler"),
+        ]
+    )
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+
+        response = await client.get("/api/v1/books", params={"search": "Evans"}, headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["items"][0]["title"] == "Domain-Driven Design"
+
+
+@pytest.mark.asyncio
+async def test_books_filter_by_location(test_session: AsyncSession) -> None:
+    location_id = await _create_location(test_session)
+    test_session.add_all(
+        [
+            Book(title="Book A", location_id=location_id),
+            Book(title="Book B", location_id=location_id),
+            Book(title="Book C"),
+        ]
+    )
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+
+        response = await client.get(
+            "/api/v1/books", params={"location_id": str(location_id)}, headers=headers
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 2
+    assert {item["title"] for item in payload["items"]} == {"Book A", "Book B"}
+
+
+@pytest.mark.asyncio
+async def test_books_pagination_returns_total_and_page_size(test_session: AsyncSession) -> None:
+    test_session.add_all([Book(title=f"Book {index}") for index in range(1, 6)])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+
+        response = await client.get(
+            "/api/v1/books", params={"page": 2, "page_size": 2}, headers=headers
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 5
+    assert payload["page"] == 2
+    assert payload["page_size"] == 2
+    assert len(payload["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_books_require_authentication() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        assert (await client.get("/api/v1/books")).status_code == 401

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -188,3 +188,56 @@ async def test_books_pagination_returns_total_and_page_size(test_session: AsyncS
 async def test_books_require_authentication() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         assert (await client.get("/api/v1/books")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_book_with_duplicate_isbn_returns_409(test_session: AsyncSession) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+
+        first = await client.post(
+            "/api/v1/books",
+            json={"title": "Book One", "isbn": "9780134494166"},
+            headers=headers,
+        )
+        assert first.status_code == 201
+
+        duplicate = await client.post(
+            "/api/v1/books",
+            json={"title": "Book Two", "isbn": "9780134494166"},
+            headers=headers,
+        )
+
+    assert duplicate.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_invalid_location_id_returns_404_on_post_and_patch(test_session: AsyncSession) -> None:
+    invalid_location_id = uuid.uuid4()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+
+        invalid_create = await client.post(
+            "/api/v1/books",
+            json={"title": "Book with Invalid Location", "location_id": str(invalid_location_id)},
+            headers=headers,
+        )
+        assert invalid_create.status_code == 404
+
+        valid_location_id = await _create_location(test_session)
+        created = await client.post(
+            "/api/v1/books",
+            json={"title": "Valid Book", "location_id": str(valid_location_id)},
+            headers=headers,
+        )
+        assert created.status_code == 201
+        book_id = created.json()["id"]
+
+        invalid_patch = await client.patch(
+            f"/api/v1/books/{book_id}",
+            json={"location_id": str(invalid_location_id)},
+            headers=headers,
+        )
+
+    assert invalid_patch.status_code == 404

--- a/backend/tests/test_locations.py
+++ b/backend/tests/test_locations.py
@@ -3,7 +3,6 @@ import uuid
 
 from httpx import ASGITransport, AsyncClient
 import pytest
-from sqlalchemy import Column, DateTime, MetaData, String, Table, Uuid, func, insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import Settings, get_settings
@@ -11,6 +10,7 @@ from app.core.security import get_password_hash
 from app.db.base import Base
 from app.db.session import get_db_session
 from app.main import app
+from app.models.book import Book
 from app.models.user import User
 
 
@@ -102,17 +102,6 @@ async def test_locations_require_authentication() -> None:
 
 @pytest.mark.asyncio
 async def test_delete_location_blocked_when_books_assigned(test_session: AsyncSession) -> None:
-    books_table = Table(
-        "books",
-        MetaData(),
-        Column("id", Uuid(as_uuid=True), primary_key=True),
-        Column("title", String(255), nullable=False),
-        Column("location_id", Uuid(as_uuid=True), nullable=True),
-        Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
-    )
-    async with test_session.bind.begin() as connection:
-        await connection.run_sync(books_table.create)
-
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         headers = await _auth_headers(client, test_session)
         created = await client.post(
@@ -122,13 +111,7 @@ async def test_delete_location_blocked_when_books_assigned(test_session: AsyncSe
         )
         location_id = uuid.UUID(created.json()["id"])
 
-        await test_session.execute(
-            insert(books_table).values(
-                id=uuid.uuid4(),
-                title="Domain-Driven Design",
-                location_id=location_id,
-            )
-        )
+        test_session.add(Book(title="Domain-Driven Design", location_id=location_id))
         await test_session.commit()
 
         blocked = await client.delete(f"/api/v1/locations/{location_id}", headers=headers)
@@ -137,16 +120,7 @@ async def test_delete_location_blocked_when_books_assigned(test_session: AsyncSe
 
 
 @pytest.mark.asyncio
-async def test_delete_location_safe_when_books_table_has_no_location_id(test_session: AsyncSession) -> None:
-    books_table = Table(
-        "books",
-        MetaData(),
-        Column("id", Uuid(as_uuid=True), primary_key=True),
-        Column("title", String(255), nullable=False),
-    )
-    async with test_session.bind.begin() as connection:
-        await connection.run_sync(books_table.create)
-
+async def test_delete_location_succeeds_when_no_books_assigned(test_session: AsyncSession) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         headers = await _auth_headers(client, test_session)
         created = await client.post(


### PR DESCRIPTION
### Motivation
- Complete Phase 5: add the core Book catalog on the backend so books can be created, listed, searched, filtered by location, paginated, updated and deleted.
- Keep consistency with existing patterns: SQLAlchemy ORM, async services, Pydantic v2 schemas, and protected endpoints using the existing auth dependency. 
- Ensure tests and CI checks run locally (type/lint/tests) and that search works on PostgreSQL while remaining testable on SQLite.

### Description
- Added a new `Book` SQLAlchemy model with fields required by Phase 5 and `processing_status` enum (`manual/pending/done/failed/partial`) in `backend/app/models/book.py`.
- Added Pydantic schemas for create/update/response/list with validation in `backend/app/schemas/book.py`.
- Implemented async service layer `backend/app/services/book.py` with list/create/read/update/delete logic, ISBN uniqueness handling, `location_id` validation, PostgreSQL full-text search expression and a non-Postgres `ILIKE` fallback, and pagination.
- Added protected REST router `backend/app/api/books.py` exposing `GET /api/v1/books` (search/filter/pagination), `POST /api/v1/books`, `GET /api/v1/books/{id}`, `PATCH /api/v1/books/{id}`, and `DELETE /api/v1/books/{id}` and wired it into the app factory in `backend/app/main.py`.
- Created Alembic migration `backend/alembic/versions/20260910_000003_create_books_table.py` to create `books` table, indexes, and PostgreSQL GIN search expression index (created only on Postgres dialect).
- Exported `Book` in `backend/app/models/__init__.py` and updated `backend/tests/test_locations.py` to use the real `Book` model where appropriate.
- Added comprehensive API tests in `backend/tests/test_books.py` covering CRUD, search, filter-by-location, pagination and authentication; adjusted location tests to account for the new `books` table.

### Testing
- Ran linting: `ruff check app tests` — all checks passed.
- Ran static typing: `mypy app` — no issues reported.
- Ran backend tests: `pytest --cov=app --cov-fail-under=80 tests` — all tests passed (19 passed) and coverage reached the required `80%` threshold.
- Ran frontend checks: `cd frontend && npm run lint` — lint passed, and `cd frontend && npm test` — vitest tests passed (frontend tests: 1 file, 6 tests passed).
- Verified local test DB compatibility: PostgreSQL full-text search is used when the DB dialect is Postgres; SQLite fallback using `ILIKE` enabled the test-suite to run successfully in-memory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b308502e74832588e89697b7ecfdf1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full book management API (CRUD) with pagination, search (DB-accelerated when available), location filtering, and processing-status tracking; unique ISBN enforcement.
  * Books API automatically registered with the application.

* **Tests**
  * Added comprehensive async tests covering CRUD, search, filtering, pagination, auth, and duplicate-ISBN/location validation.

* **Refactor**
  * Tests updated to use ORM models for book fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->