### PR TITLE
fix: add configurable backend CORS middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ ENVIRONMENT=development
 # Backend service connectivity
 DATABASE_URL=postgresql+asyncpg://shelfy:shelfy@postgres:5432/shelfy
 REDIS_URL=redis://redis:6379/0
+CORS_ALLOWED_ORIGINS=["http://localhost:5173"]
 
 # Authentication
 JWT_SECRET_KEY=change-me

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Set these environment variables in `.env` before starting the backend:
 - `ADMIN_EMAIL`
 - `ADMIN_PASSWORD`
 - `SEED_ADMIN_ON_STARTUP=true` (optional auto-seed)
+- `CORS_ALLOWED_ORIGINS=["http://localhost:5173"]` (JSON array for allowed frontend origins)
 
 Manual admin seed command:
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     environment: str = "development"
     database_url: str = "postgresql+asyncpg://shelfy:shelfy@localhost:5432/shelfy"
     redis_url: str = "redis://localhost:6379/0"
+    cors_allowed_origins: list[str] = ["http://localhost:5173"]
 
     jwt_secret_key: str = "change-me"
     jwt_algorithm: str = "HS256"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 import structlog
 
 from app.api.auth import router as auth_router
@@ -31,6 +32,13 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 def create_app() -> FastAPI:
     settings = get_settings()
     app = FastAPI(title=settings.app_name, lifespan=lifespan)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_allowed_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
     app.include_router(health_router)
     app.include_router(auth_router)
     app.include_router(locations_router)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -18,6 +18,22 @@ async def test_health_returns_ok() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cors_preflight_allows_configured_origin() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5173"
+
+
+
+@pytest.mark.asyncio
 async def test_readiness_returns_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _ok(_: object) -> None:
         return None
@@ -30,6 +46,7 @@ async def test_readiness_returns_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- The backend did not register CORS middleware which caused browser requests from non-local origins to be blocked (issue #17).  
- The change provides a configurable, safe default to allow the frontend to interact with the API from common local origins.

### Description
- Add `cors_allowed_origins: list[str]` to backend settings with a default of `['http://localhost:5173']` in `app.core.config`.  
- Register `CORSMiddleware` in the FastAPI app creation and wire it to `settings.cors_allowed_origins`, enabling credentials and allowing all methods/headers.  
- Document `CORS_ALLOWED_ORIGINS` in `.env.example` and the README backend setup section.  
- Add an API test that validates CORS preflight behavior for the configured origin on the `/health` endpoint.

### Testing
- Ran `ruff check app tests` and it passed with no findings.  
- Ran `mypy app` and it reported no issues.  
- Ran `pytest -q tests/test_health.py tests/test_auth.py` and all tests passed (`11 passed`).  
- Note: the full backend test suite (`pytest -q`) includes integration tests that require `TEST_DATABASE_URL` to be set for Postgres-backed tests (`tests/test_books.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4630c4f5883259f8b4d7b7b87f9d6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORS support to enable secure communication between frontend and backend services

* **Tests**
  * Added test coverage for CORS preflight request handling

* **Chores**
  * Updated configuration documentation with new environment variable for allowed origins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->