### PR TITLE
fix: require frontend API base URL (remove localhost fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,6 @@ MINIO_ROOT_PASSWORD=minioadmin
 # Worker service connectivity
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
+# Frontend app configuration
+VITE_API_BASE_URL=http://localhost:8000
+

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,8 +9,14 @@ import type {
   TokenResponse,
 } from './types'
 
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
+
+if (!apiBaseUrl) {
+  throw new Error('VITE_API_BASE_URL is not set. Check your .env file.')
+}
+
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000',
+  baseURL: apiBaseUrl,
 })
 
 apiClient.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
Removed the silent `http://localhost:8000` fallback from the frontend API client and made `VITE_API_BASE_URL` a required configuration value so misconfiguration fails fast with a clear error message.

## Files changed
- `frontend/src/lib/api.ts` — look up `VITE_API_BASE_URL` explicitly, throw a startup error when it's missing, and use the validated value as Axios `baseURL`.
- `.env.example` — added `VITE_API_BASE_URL=http://localhost:8000` to document the required frontend environment variable for local development.

## Assumptions
- Making the API base URL mandatory and failing fast is preferable to silently falling back to localhost in non-local deployments.

## Deferred
- No runtime UI error boundaries or additional frontend UX changes were added; this PR is limited to configuration validation.

## How to verify
- Run frontend unit tests and linter: `cd frontend && npm run lint && npm test`.
- Manual check: unset `VITE_API_BASE_URL` and start the dev server with `cd frontend && npm run dev` and observe the startup error `VITE_API_BASE_URL is not set. Check your .env file.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b46888f21c8325bac102fd0df392e1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added required environment configuration variable for API endpoint connectivity.
  * API module now enforces strict configuration validation at startup, throwing an error if the required configuration is missing instead of silently using a default fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->