### PR TITLE
feat: implement issue #20 Phase 6 — Books frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Link, Route, Routes } from 'react-router-dom'
 
 import { ErrorToast } from './components/ErrorToast'
 import { ProtectedRoute } from './components/ProtectedRoute'
+import { BookDetailPage } from './pages/BookDetailPage'
 import { BooksPage } from './pages/BooksPage'
 import { HomePage } from './pages/HomePage'
 import { LocationsPage } from './pages/LocationsPage'
@@ -23,6 +24,7 @@ export function App() {
         <Route element={<ProtectedRoute />}>
           <Route path="/" element={<HomePage />} />
           <Route path="/books" element={<BooksPage />} />
+          <Route path="/books/:bookId" element={<BookDetailPage />} />
           <Route path="/locations" element={<LocationsPage />} />
         </Route>
       </Routes>

--- a/frontend/src/hooks/useBooks.ts
+++ b/frontend/src/hooks/useBooks.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { createBook, deleteBook, formatApiError, getBook, listBooks, updateBook } from '../lib/api'
+import { useToastStore } from '../lib/toast-store'
+import type {
+  Book,
+  BookCreateRequest,
+  BookListParams,
+  BookListResponse,
+  BookUpdateRequest,
+} from '../lib/types'
+
+const BOOKS_QUERY_KEY = ['books']
+
+export function useBooks(params: BookListParams) {
+  return useQuery({
+    queryKey: [...BOOKS_QUERY_KEY, params],
+    queryFn: () => listBooks(params),
+    retry: false,
+  })
+}
+
+export function useBook(bookId: string) {
+  return useQuery({
+    queryKey: [...BOOKS_QUERY_KEY, 'detail', bookId],
+    queryFn: () => getBook(bookId),
+    retry: false,
+  })
+}
+
+export function useCreateBook(paramsForListUpdate: BookListParams) {
+  const queryClient = useQueryClient()
+  const showError = useToastStore((state) => state.showError)
+
+  return useMutation({
+    mutationFn: (payload: BookCreateRequest) => createBook(payload),
+    onSuccess: (createdBook) => {
+      queryClient.setQueryData<BookListResponse>([...BOOKS_QUERY_KEY, paramsForListUpdate], (current) => {
+        if (!current) {
+          return current
+        }
+
+        return {
+          ...current,
+          total: current.total + 1,
+          items: [createdBook, ...current.items],
+        }
+      })
+    },
+    onError: (error: unknown) => {
+      showError(formatApiError(error))
+    },
+  })
+}
+
+export function useUpdateBook(paramsForListUpdate: BookListParams) {
+  const queryClient = useQueryClient()
+  const showError = useToastStore((state) => state.showError)
+
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: BookUpdateRequest }) => updateBook(id, payload),
+    onSuccess: (updatedBook) => {
+      queryClient.setQueryData<BookListResponse>([...BOOKS_QUERY_KEY, paramsForListUpdate], (current) => {
+        if (!current) {
+          return current
+        }
+
+        return {
+          ...current,
+          items: current.items.map((book) => (book.id === updatedBook.id ? updatedBook : book)),
+        }
+      })
+
+      queryClient.setQueryData<Book>([...BOOKS_QUERY_KEY, 'detail', updatedBook.id], updatedBook)
+    },
+    onError: (error: unknown) => {
+      showError(formatApiError(error))
+    },
+  })
+}
+
+export function useDeleteBook(paramsForListUpdate: BookListParams) {
+  const queryClient = useQueryClient()
+  const showError = useToastStore((state) => state.showError)
+
+  return useMutation({
+    mutationFn: (id: string) => deleteBook(id),
+    onSuccess: (_, deletedId) => {
+      queryClient.setQueryData<BookListResponse>([...BOOKS_QUERY_KEY, paramsForListUpdate], (current) => {
+        if (!current) {
+          return current
+        }
+
+        return {
+          ...current,
+          total: Math.max(0, current.total - 1),
+          items: current.items.filter((book) => book.id !== deletedId),
+        }
+      })
+
+      queryClient.removeQueries({ queryKey: [...BOOKS_QUERY_KEY, 'detail', deletedId] })
+    },
+    onError: (error: unknown) => {
+      showError(formatApiError(error))
+    },
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,11 @@ import axios, { type AxiosError } from 'axios'
 
 import { clearTokens, getAccessToken } from './auth'
 import type {
+  Book,
+  BookCreateRequest,
+  BookListParams,
+  BookListResponse,
+  BookUpdateRequest,
   Location,
   LocationCreateRequest,
   LocationUpdateRequest,
@@ -69,4 +74,36 @@ export async function updateLocation(id: string, payload: LocationUpdateRequest)
 
 export async function deleteLocation(id: string): Promise<void> {
   await apiClient.delete(`/api/v1/locations/${id}`)
+}
+
+export async function listBooks(params: BookListParams = {}): Promise<BookListResponse> {
+  const response = await apiClient.get<BookListResponse>('/api/v1/books', {
+    params: {
+      search: params.search,
+      location_id: params.locationId,
+      page: params.page ?? 1,
+      page_size: params.pageSize ?? 20,
+    },
+  })
+
+  return response.data
+}
+
+export async function getBook(id: string): Promise<Book> {
+  const response = await apiClient.get<Book>(`/api/v1/books/${id}`)
+  return response.data
+}
+
+export async function createBook(payload: BookCreateRequest): Promise<Book> {
+  const response = await apiClient.post<Book>('/api/v1/books', payload)
+  return response.data
+}
+
+export async function updateBook(id: string, payload: BookUpdateRequest): Promise<Book> {
+  const response = await apiClient.patch<Book>(`/api/v1/books/${id}`, payload)
+  return response.data
+}
+
+export async function deleteBook(id: string): Promise<void> {
+  await apiClient.delete(`/api/v1/books/${id}`)
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -19,6 +19,62 @@ export interface LocationUpdateRequest {
   shelf?: string
 }
 
+export type BookProcessingStatus = 'manual' | 'pending' | 'done' | 'failed' | 'partial'
+
+export interface Book {
+  id: string
+  title: string
+  author: string | null
+  isbn: string | null
+  publisher: string | null
+  language: string | null
+  description: string | null
+  publication_year: number | null
+  cover_image_url: string | null
+  location_id: string | null
+  processing_status: BookProcessingStatus
+  created_at: string
+  updated_at: string
+}
+
+export interface BookListResponse {
+  total: number
+  page: number
+  page_size: number
+  items: Book[]
+}
+
+export interface BookListParams {
+  search?: string
+  locationId?: string
+  page?: number
+  pageSize?: number
+}
+
+export interface BookCreateRequest {
+  title: string
+  author?: string | null
+  isbn?: string | null
+  publisher?: string | null
+  language?: string | null
+  description?: string | null
+  publication_year?: number | null
+  cover_image_url?: string | null
+  location_id?: string | null
+}
+
+export interface BookUpdateRequest {
+  title?: string
+  author?: string | null
+  isbn?: string | null
+  publisher?: string | null
+  language?: string | null
+  description?: string | null
+  publication_year?: number | null
+  cover_image_url?: string | null
+  location_id?: string | null
+}
+
 export interface LoginRequest {
   email: string
   password: string

--- a/frontend/src/pages/BookDetailPage.test.tsx
+++ b/frontend/src/pages/BookDetailPage.test.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BookDetailPage } from './BookDetailPage'
+import type { Book, Location } from '../lib/types'
+
+vi.mock('../lib/api', () => ({
+  getBook: vi.fn(),
+  updateBook: vi.fn(),
+  listLocations: vi.fn(),
+  formatApiError: vi.fn(() => 'API error'),
+}))
+
+import { getBook, listLocations } from '../lib/api'
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/books/book-1']}>
+        <Routes>
+          <Route path="/books/:bookId" element={ui} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const book: Book = {
+  id: 'book-1',
+  title: 'Clean Architecture',
+  author: 'Robert C. Martin',
+  isbn: '9780134494166',
+  publisher: 'Prentice Hall',
+  language: 'en',
+  description: 'Software architecture and design principles.',
+  publication_year: 2017,
+  cover_image_url: 'https://example.com/clean-architecture.jpg',
+  location_id: 'loc-1',
+  processing_status: 'manual',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+const locations: Location[] = [
+  {
+    id: 'loc-1',
+    room: 'Office',
+    furniture: 'Bookshelf',
+    shelf: 'Shelf 1',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+]
+
+describe('BookDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getBook).mockResolvedValue(book)
+    vi.mocked(listLocations).mockResolvedValue(locations)
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders all book metadata fields', async () => {
+    renderWithProviders(<BookDetailPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Clean Architecture' })).toBeInTheDocument()
+    expect(screen.getByText('Robert C. Martin')).toBeInTheDocument()
+    expect(screen.getByText('9780134494166')).toBeInTheDocument()
+    expect(screen.getByText('Prentice Hall')).toBeInTheDocument()
+    expect(screen.getByText('en')).toBeInTheDocument()
+    expect(screen.getByText('Software architecture and design principles.')).toBeInTheDocument()
+    expect(screen.getByText('2017')).toBeInTheDocument()
+    expect(screen.getByText('https://example.com/clean-architecture.jpg')).toBeInTheDocument()
+    expect(screen.getByText('manual')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useBook, useUpdateBook } from '../hooks/useBooks'
+import { useLocations } from '../hooks/useLocations'
+
+export function BookDetailPage() {
+  const { bookId = '' } = useParams()
+  const bookQuery = useBook(bookId)
+  const locationsQuery = useLocations()
+  const updateMutation = useUpdateBook({ page: 1, pageSize: 10 })
+  const [locationSelection, setLocationSelection] = useState('')
+
+  if (bookQuery.isLoading) {
+    return <p>Loading book…</p>
+  }
+
+  if (bookQuery.isError || !bookQuery.data) {
+    return <p>Failed to load book.</p>
+  }
+
+  const book = bookQuery.data
+
+  return (
+    <section style={{ marginTop: '1.5rem' }}>
+      <h2>{book.title}</h2>
+      <dl>
+        <dt>Author</dt>
+        <dd>{book.author ?? '—'}</dd>
+        <dt>ISBN</dt>
+        <dd>{book.isbn ?? '—'}</dd>
+        <dt>Publisher</dt>
+        <dd>{book.publisher ?? '—'}</dd>
+        <dt>Language</dt>
+        <dd>{book.language ?? '—'}</dd>
+        <dt>Description</dt>
+        <dd>{book.description ?? '—'}</dd>
+        <dt>Publication year</dt>
+        <dd>{book.publication_year ?? '—'}</dd>
+        <dt>Cover URL</dt>
+        <dd>{book.cover_image_url ?? '—'}</dd>
+        <dt>Processing status</dt>
+        <dd>{book.processing_status}</dd>
+      </dl>
+
+      <form
+        aria-label="assign-location-form"
+        onSubmit={(event) => {
+          event.preventDefault()
+          updateMutation.mutate({
+            id: book.id,
+            payload: { location_id: locationSelection || null },
+          })
+        }}
+      >
+        <label>
+          Location
+          <select
+            aria-label="Assign location"
+            value={locationSelection || book.location_id || ''}
+            onChange={(event) => setLocationSelection(event.target.value)}
+          >
+            <option value="">Unassigned</option>
+            {(locationsQuery.data ?? []).map((location) => (
+              <option key={location.id} value={location.id}>
+                {location.room} / {location.furniture} / {location.shelf}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button type="submit" disabled={updateMutation.isPending}>
+          {updateMutation.isPending ? 'Saving…' : 'Save location'}
+        </button>
+      </form>
+    </section>
+  )
+}

--- a/frontend/src/pages/BooksPage.test.tsx
+++ b/frontend/src/pages/BooksPage.test.tsx
@@ -1,0 +1,140 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { type ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BooksPage } from './BooksPage'
+import type { Book, BookListResponse, Location } from '../lib/types'
+
+vi.mock('../lib/api', () => ({
+  listBooks: vi.fn(),
+  createBook: vi.fn(),
+  updateBook: vi.fn(),
+  deleteBook: vi.fn(),
+  listLocations: vi.fn(),
+  formatApiError: vi.fn(() => 'API error'),
+}))
+
+import { createBook, listBooks, listLocations, updateBook } from '../lib/api'
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const booksResponse: BookListResponse = {
+  total: 1,
+  page: 1,
+  page_size: 10,
+  items: [
+    {
+      id: 'book-1',
+      title: 'Clean Code',
+      author: 'Robert C. Martin',
+      isbn: '9780132350884',
+      publisher: 'Prentice Hall',
+      language: 'en',
+      description: 'A handbook of agile software craftsmanship.',
+      publication_year: 2008,
+      cover_image_url: 'https://example.com/clean-code.jpg',
+      location_id: 'loc-1',
+      processing_status: 'manual',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+  ],
+}
+
+const locations: Location[] = [
+  {
+    id: 'loc-1',
+    room: 'Office',
+    furniture: 'Bookshelf',
+    shelf: 'Shelf 1',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+]
+
+describe('BooksPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(listBooks).mockResolvedValue(booksResponse)
+    vi.mocked(listLocations).mockResolvedValue(locations)
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders book list and submits search input', async () => {
+    renderWithProviders(<BooksPage />)
+
+    expect(await screen.findByText('Clean Code')).toBeInTheDocument()
+
+    await userEvent.type(screen.getByLabelText('Search books'), 'Martin')
+    await userEvent.click(screen.getByRole('button', { name: 'Apply search' }))
+
+    await waitFor(() => {
+      expect(listBooks).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: 'Martin' }),
+      )
+    })
+  })
+
+  it('submits create and edit forms', async () => {
+    vi.mocked(createBook).mockImplementation(async (payload) => ({
+      ...(booksResponse.items[0] as Book),
+      id: 'book-2',
+      title: payload.title,
+      author: payload.author ?? null,
+    }))
+    vi.mocked(updateBook).mockImplementation(async (_id, payload) => ({
+      ...(booksResponse.items[0] as Book),
+      ...payload,
+      author: payload.author ?? booksResponse.items[0].author,
+    }))
+
+    renderWithProviders(<BooksPage />)
+
+    await screen.findByText('Clean Code')
+
+    await userEvent.type(screen.getByLabelText('Title'), 'Refactoring')
+    await userEvent.type(screen.getByLabelText('Author'), 'Martin Fowler')
+    await userEvent.click(screen.getByRole('button', { name: 'Create book' }))
+
+    await waitFor(() => {
+      expect(createBook).toHaveBeenCalledWith(expect.objectContaining({ title: 'Refactoring' }))
+    })
+
+    const cleanCodeCell = await screen.findByRole('link', { name: 'Clean Code' })
+    const cleanCodeRow = cleanCodeCell.closest('tr')
+    if (!cleanCodeRow) {
+      throw new Error('Expected book row to exist')
+    }
+
+    await userEvent.click(within(cleanCodeRow).getByRole('button', { name: 'Edit' }))
+    const editTitleInput = screen.getByLabelText('Edit title')
+    await userEvent.clear(editTitleInput)
+    await userEvent.type(editTitleInput, 'Clean Code 2nd Edition')
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(updateBook).toHaveBeenCalledWith(
+        'book-1',
+        expect.objectContaining({ title: 'Clean Code 2nd Edition' }),
+      )
+    })
+  })
+})

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -1,3 +1,255 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import { useBooks, useCreateBook, useDeleteBook, useUpdateBook } from '../hooks/useBooks'
+import { useLocations } from '../hooks/useLocations'
+import type { BookCreateRequest } from '../lib/types'
+
+const PAGE_SIZE = 10
+
+const EMPTY_FORM: BookCreateRequest = {
+  title: '',
+  author: '',
+  isbn: '',
+  publisher: '',
+  language: '',
+  description: '',
+  publication_year: null,
+  cover_image_url: '',
+  location_id: null,
+}
+
 export function BooksPage() {
-  return <p>Books page placeholder</p>
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [selectedLocationId, setSelectedLocationId] = useState('')
+  const [page, setPage] = useState(1)
+  const [createForm, setCreateForm] = useState<BookCreateRequest>(EMPTY_FORM)
+  const [editingBookId, setEditingBookId] = useState<string | null>(null)
+  const [editForm, setEditForm] = useState<BookCreateRequest>(EMPTY_FORM)
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
+
+  const queryParams = useMemo(
+    () => ({ page, pageSize: PAGE_SIZE, search: search || undefined, locationId: selectedLocationId || undefined }),
+    [page, search, selectedLocationId],
+  )
+
+  const booksQuery = useBooks(queryParams)
+  const locationsQuery = useLocations()
+  const createMutation = useCreateBook(queryParams)
+  const updateMutation = useUpdateBook(queryParams)
+  const deleteMutation = useDeleteBook(queryParams)
+
+  const locationLabelById = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const location of locationsQuery.data ?? []) {
+      map.set(location.id, `${location.room} / ${location.furniture} / ${location.shelf}`)
+    }
+    return map
+  }, [locationsQuery.data])
+
+  return (
+    <section style={{ marginTop: '1.5rem' }}>
+      <h2>Books</h2>
+
+      <form
+        aria-label="book-search-form"
+        onSubmit={(event) => {
+          event.preventDefault()
+          setPage(1)
+          setSearch(searchInput.trim())
+        }}
+        style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', flexWrap: 'wrap' }}
+      >
+        <input
+          aria-label="Search books"
+          placeholder="Search by title, author, ISBN..."
+          value={searchInput}
+          onChange={(event) => setSearchInput(event.target.value)}
+        />
+        <select
+          aria-label="Filter by location"
+          value={selectedLocationId}
+          onChange={(event) => {
+            setSelectedLocationId(event.target.value)
+            setPage(1)
+          }}
+        >
+          <option value="">All locations</option>
+          {(locationsQuery.data ?? []).map((location) => (
+            <option key={location.id} value={location.id}>
+              {location.room} / {location.furniture} / {location.shelf}
+            </option>
+          ))}
+        </select>
+        <button type="submit">Apply search</button>
+      </form>
+
+      <form
+        aria-label="create-book-form"
+        onSubmit={(event) => {
+          event.preventDefault()
+          createMutation.mutate(createForm, {
+            onSuccess: () => setCreateForm(EMPTY_FORM),
+          })
+        }}
+        style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(240px, 1fr))', gap: '0.5rem', marginBottom: '1rem' }}
+      >
+        <input aria-label="Title" required placeholder="Title" value={createForm.title ?? ''} onChange={(event) => setCreateForm((prev) => ({ ...prev, title: event.target.value }))} />
+        <input aria-label="Author" placeholder="Author" value={createForm.author ?? ''} onChange={(event) => setCreateForm((prev) => ({ ...prev, author: event.target.value }))} />
+        <input aria-label="ISBN" placeholder="ISBN" value={createForm.isbn ?? ''} onChange={(event) => setCreateForm((prev) => ({ ...prev, isbn: event.target.value }))} />
+        <input aria-label="Publisher" placeholder="Publisher" value={createForm.publisher ?? ''} onChange={(event) => setCreateForm((prev) => ({ ...prev, publisher: event.target.value }))} />
+        <input aria-label="Language" placeholder="Language" value={createForm.language ?? ''} onChange={(event) => setCreateForm((prev) => ({ ...prev, language: event.target.value }))} />
+        <input aria-label="Publication year" type="number" placeholder="Publication year" value={createForm.publication_year ?? ''} onChange={(event) => setCreateForm((prev) => ({ ...prev, publication_year: event.target.value ? Number(event.target.value) : null }))} />
+        <input aria-label="Cover URL" placeholder="Cover URL" value={createForm.cover_image_url ?? ''} onChange={(event) => setCreateForm((prev) => ({ ...prev, cover_image_url: event.target.value }))} />
+        <select
+          aria-label="Location"
+          value={createForm.location_id ?? ''}
+          onChange={(event) => setCreateForm((prev) => ({ ...prev, location_id: event.target.value || null }))}
+        >
+          <option value="">Unassigned</option>
+          {(locationsQuery.data ?? []).map((location) => (
+            <option key={location.id} value={location.id}>
+              {location.room} / {location.furniture} / {location.shelf}
+            </option>
+          ))}
+        </select>
+        <textarea aria-label="Description" placeholder="Description" value={createForm.description ?? ''} onChange={(event) => setCreateForm((prev) => ({ ...prev, description: event.target.value }))} />
+        <button type="submit" disabled={createMutation.isPending}>{createMutation.isPending ? 'Creating…' : 'Create book'}</button>
+      </form>
+
+      {booksQuery.isLoading && <p>Loading books…</p>}
+
+      {booksQuery.data && booksQuery.data.items.length === 0 && <p>No books found.</p>}
+
+      {booksQuery.data && booksQuery.data.items.length > 0 && (
+        <>
+          <table width="100%" cellPadding={8} style={{ borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th align="left">Title</th>
+                <th align="left">Author</th>
+                <th align="left">Location</th>
+                <th align="left">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {booksQuery.data.items.map((book) => {
+                const isEditing = editingBookId === book.id
+
+                return (
+                  <tr key={book.id} style={{ borderTop: '1px solid #ddd' }}>
+                    <td>{isEditing ? <input aria-label="Edit title" value={editForm.title ?? ''} onChange={(event) => setEditForm((prev) => ({ ...prev, title: event.target.value }))} /> : <Link to={`/books/${book.id}`}>{book.title}</Link>}</td>
+                    <td>{isEditing ? <input aria-label="Edit author" value={editForm.author ?? ''} onChange={(event) => setEditForm((prev) => ({ ...prev, author: event.target.value }))} /> : (book.author || '—')}</td>
+                    <td>
+                      {isEditing ? (
+                        <select
+                          aria-label="Edit location"
+                          value={editForm.location_id ?? ''}
+                          onChange={(event) => setEditForm((prev) => ({ ...prev, location_id: event.target.value || null }))}
+                        >
+                          <option value="">Unassigned</option>
+                          {(locationsQuery.data ?? []).map((location) => (
+                            <option key={location.id} value={location.id}>
+                              {location.room} / {location.furniture} / {location.shelf}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        (book.location_id ? locationLabelById.get(book.location_id) : null) ?? 'Unassigned'
+                      )}
+                    </td>
+                    <td style={{ display: 'flex', gap: '0.5rem' }}>
+                      {isEditing ? (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              updateMutation.mutate(
+                                { id: book.id, payload: editForm },
+                                { onSuccess: () => setEditingBookId(null) },
+                              )
+                            }}
+                          >
+                            Save
+                          </button>
+                          <button type="button" onClick={() => setEditingBookId(null)}>
+                            Cancel
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingBookId(book.id)
+                              setEditForm({
+                                title: book.title,
+                                author: book.author,
+                                isbn: book.isbn,
+                                publisher: book.publisher,
+                                language: book.language,
+                                description: book.description,
+                                publication_year: book.publication_year,
+                                cover_image_url: book.cover_image_url,
+                                location_id: book.location_id,
+                              })
+                            }}
+                          >
+                            Edit
+                          </button>
+                          <button type="button" onClick={() => setDeleteTargetId(book.id)}>
+                            Delete
+                          </button>
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.75rem' }}>
+            <button type="button" disabled={page <= 1} onClick={() => setPage((current) => current - 1)}>
+              Previous
+            </button>
+            <span>
+              Page {booksQuery.data.page} of {Math.max(1, Math.ceil(booksQuery.data.total / booksQuery.data.page_size))}
+            </span>
+            <button
+              type="button"
+              disabled={page >= Math.ceil(booksQuery.data.total / booksQuery.data.page_size)}
+              onClick={() => setPage((current) => current + 1)}
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
+
+      {deleteTargetId && (
+        <div
+          role="dialog"
+          aria-label="delete-book-dialog"
+          style={{ border: '1px solid #ddd', padding: '1rem', marginTop: '1rem' }}
+        >
+          <p>Are you sure you want to delete this book?</p>
+          <button
+            type="button"
+            onClick={() => {
+              deleteMutation.mutate(deleteTargetId, {
+                onSuccess: () => setDeleteTargetId(null),
+              })
+            }}
+          >
+            Confirm delete
+          </button>
+          <button type="button" onClick={() => setDeleteTargetId(null)}>
+            Cancel
+          </button>
+        </div>
+      )}
+    </section>
+  )
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,3 +1,53 @@
+import { useMemo } from 'react'
+
+import { useBooks } from '../hooks/useBooks'
+import { useLocations } from '../hooks/useLocations'
+
 export function HomePage() {
-  return <p>Dashboard placeholder</p>
+  const booksQuery = useBooks({ page: 1, pageSize: 20 })
+  const locationsQuery = useLocations()
+
+  const booksPerLocation = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const location of locationsQuery.data ?? []) {
+      counts.set(location.id, 0)
+    }
+
+    for (const book of booksQuery.data?.items ?? []) {
+      if (book.location_id) {
+        counts.set(book.location_id, (counts.get(book.location_id) ?? 0) + 1)
+      }
+    }
+
+    return counts
+  }, [booksQuery.data?.items, locationsQuery.data])
+
+  return (
+    <section style={{ marginTop: '1.5rem' }}>
+      <h2>Dashboard</h2>
+      <p>Total books: {booksQuery.data?.total ?? 0}</p>
+
+      <h3>Books per location</h3>
+      <ul>
+        {(locationsQuery.data ?? []).map((location) => (
+          <li key={location.id}>
+            {location.room} / {location.furniture} / {location.shelf}: {booksPerLocation.get(location.id) ?? 0}
+          </li>
+        ))}
+      </ul>
+
+      <h3>Recent additions</h3>
+      <ul>
+        {(booksQuery.data?.items ?? [])
+          .slice()
+          .sort((left, right) => right.created_at.localeCompare(left.created_at))
+          .slice(0, 5)
+          .map((book) => (
+            <li key={book.id}>
+              {book.title} ({new Date(book.created_at).toLocaleDateString()})
+            </li>
+          ))}
+      </ul>
+    </section>
+  )
 }


### PR DESCRIPTION
### Motivation
- Complete Phase 6 frontend deliverables so the app supports full browser-based book catalog management (list, search, filter, create, edit, delete, and detail view) as defined in `docs/implementation-phases.md`.
- Reuse existing UI patterns and React Query cache patterns to keep the change focused and consistent with the rest of the frontend.

### Description
- Added the Books list page implementation at `frontend/src/pages/BooksPage.tsx` with search, location filter, pagination, manual create form, inline edit, and delete confirmation.  
- Added the Book detail page at `frontend/src/pages/BookDetailPage.tsx` with full metadata rendering and assign/change location form.  
- Implemented React Query hooks for books in `frontend/src/hooks/useBooks.ts` and wired API calls in `frontend/src/lib/api.ts` with corresponding type additions in `frontend/src/lib/types.ts`.  
- Updated `frontend/src/App.tsx` and `frontend/src/pages/HomePage.tsx` to register routes and show dashboard summaries, and added unit tests `BooksPage.test.tsx` and `BookDetailPage.test.tsx` to cover the new UI flows.

### Testing
- Ran frontend lint with `cd frontend && npm run lint`, which completed successfully.  
- Ran frontend unit tests with `cd frontend && npm test`, and all frontend tests passed (3 test files, 9 tests).  
- Ran backend static checks `cd backend && ruff check app/` and `cd backend && mypy app/`, both of which passed.  
- Attempted backend test coverage run `cd backend && pytest --cov=app --cov-fail-under=80 tests/`, which failed in this environment because `pytest-cov` is not available; running `cd backend && pytest tests/` produced multiple failures/errors due to missing async pytest plugin/config (these backend failures are environmental and not caused by the frontend changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b52448a7448325905294c0a8257376)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a book detail page for viewing book metadata and managing location assignments
  * Implemented full books management with search, location filtering, pagination, and create/edit/delete operations
  * Enhanced dashboard with total book count, books-per-location statistics, and recent additions list

* **Tests**
  * Added comprehensive test coverage for book detail and books management pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->