### PR TITLE
Add image upload & processing: MinIO storage, processing jobs, Celery worker, API and frontend support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ POSTGRES_PASSWORD=shelfy
 # MinIO local bootstrap credentials
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
+MINIO_ACCESS_KEY=minioadmin
+MINIO_BUCKET=shelfy-images
+MINIO_ENDPOINT=http://minio:9000
+MINIO_REGION=us-east-1
+MINIO_SECRET_KEY=minioadmin
 
 # Worker service connectivity
 CELERY_BROKER_URL=redis://redis:6379/0

--- a/backend/alembic/versions/20260912_000004_create_book_images_and_processing_jobs.py
+++ b/backend/alembic/versions/20260912_000004_create_book_images_and_processing_jobs.py
@@ -1,0 +1,87 @@
+"""create book_images and processing_jobs tables
+
+Revision ID: 20260912_000004
+Revises: 20260910_000003
+Create Date: 2026-09-12 00:00:04
+"""
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260912_000004"
+down_revision: str | None = "20260910_000003"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+processing_job_status = sa.Enum(
+    "pending",
+    "processing",
+    "done",
+    "failed",
+    name="processing_job_status",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    if is_postgresql:
+        processing_job_status.create(bind, checkfirst=True)
+
+    op.create_table(
+        "book_images",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("book_id", sa.Uuid(as_uuid=True), nullable=True),
+        sa.Column("minio_path", sa.String(length=1024), nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["book_id"], ["books.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_book_images_book_id", "book_images", ["book_id"], unique=False)
+
+    op.create_table(
+        "processing_jobs",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column(
+            "status",
+            processing_job_status if is_postgresql else sa.String(length=20),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("book_image_id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column(
+            "result_json",
+            postgresql.JSONB(astext_type=sa.Text()) if is_postgresql else sa.JSON(),
+            nullable=True,
+        ),
+        sa.Column("error_message", sa.String(length=1000), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["book_image_id"], ["book_images.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_processing_jobs_book_image_id", "processing_jobs", ["book_image_id"], unique=False)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    op.drop_index("ix_processing_jobs_book_image_id", table_name="processing_jobs")
+    op.drop_table("processing_jobs")
+
+    op.drop_index("ix_book_images_book_id", table_name="book_images")
+    op.drop_table("book_images")
+
+    if is_postgresql:
+        processing_job_status.drop(bind, checkfirst=True)

--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -1,13 +1,18 @@
+import asyncio
 import uuid
 
-from fastapi import APIRouter, Depends, Query, Response, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Response, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db_session
 from app.models.user import User
 from app.schemas.book import BookCreateRequest, BookListResponse, BookResponse, BookUpdateRequest
+from app.schemas.job import UploadResponse
 from app.services.book import create_book, delete_book, get_book_or_404, list_books, update_book
+from app.services.job import create_upload_job
+from app.services.job_queue import get_celery_client
+from app.services.storage import delete_image_bytes
 
 router = APIRouter(prefix="/api/v1/books", tags=["books"])
 
@@ -71,3 +76,30 @@ async def delete_book_endpoint(
 ) -> Response:
     await delete_book(session, book_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/upload", response_model=UploadResponse, status_code=status.HTTP_202_ACCEPTED)
+async def upload_book_image(
+    image: UploadFile = File(...),
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> UploadResponse:
+    job, minio_path = await create_upload_job(session, image)
+
+    try:
+        celery_client = get_celery_client()
+        celery_client.send_task("worker.celery_app.process_book_image", args=[str(job.id)])
+        await session.commit()
+    except Exception as exc:
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.run_in_executor(None, lambda: delete_image_bytes(minio_path))
+        except Exception:
+            pass
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Image processing queue is unavailable",
+        ) from exc
+
+    return UploadResponse(job_id=job.id, status=job.status)

--- a/backend/app/api/jobs.py
+++ b/backend/app/api/jobs.py
@@ -1,0 +1,31 @@
+import uuid
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies.auth import get_current_user
+from app.db.session import get_db_session
+from app.models.user import User
+from app.schemas.job import JobStatusResponse
+from app.services.job import get_job_book_id, get_job_or_404
+
+router = APIRouter(prefix="/api/v1/jobs", tags=["jobs"])
+
+
+@router.get("/{job_id}", response_model=JobStatusResponse)
+async def read_job_status(
+    job_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> JobStatusResponse:
+    job = await get_job_or_404(session, job_id)
+    return JobStatusResponse(
+        id=job.id,
+        status=job.status,
+        book_id=await get_job_book_id(session, job),
+        result_json=job.result_json,
+        error_message=job.error_message,
+        attempts=job.attempts,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,6 +11,16 @@ class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379/0"
     cors_allowed_origins: list[str] = ["http://localhost:5173"]
 
+    celery_broker_url: str = "redis://localhost:6379/0"
+    celery_result_backend: str = "redis://localhost:6379/1"
+
+    minio_endpoint: str = "http://localhost:9000"
+    minio_access_key: str = "minioadmin"
+    minio_secret_key: str = "minioadmin"
+    minio_bucket: str = "shelfy-images"
+    minio_region: str = "us-east-1"
+
+
     jwt_secret_key: str = "change-me"
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 15
@@ -28,6 +38,15 @@ class Settings(BaseSettings):
         env_value = getattr(info, "data", {}).get("environment")
         if value == "change-me" and env_value != "development":
             raise ValueError("JWT_SECRET_KEY must not use default value outside development")
+        return value
+
+
+    @field_validator("minio_access_key", "minio_secret_key")
+    @classmethod
+    def validate_minio_defaults(cls, value: str, info: object) -> str:
+        env_value = getattr(info, "data", {}).get("environment")
+        if value == "minioadmin" and env_value != "development":
+            raise ValueError("MinIO credentials must not use default values outside development")
         return value
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+from anyio import to_thread
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import structlog
@@ -8,9 +9,11 @@ import structlog
 from app.api.auth import router as auth_router
 from app.api.books import router as books_router
 from app.api.health import router as health_router
+from app.api.jobs import router as jobs_router
 from app.api.locations import router as locations_router
 from app.core.config import get_settings
 from app.db.session import SessionLocal
+from app.services.storage import ensure_bucket_exists
 from app.services.user_seed import seed_admin_user
 
 logger = structlog.get_logger()
@@ -19,6 +22,12 @@ logger = structlog.get_logger()
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     settings = get_settings()
+    try:
+        await to_thread.run_sync(ensure_bucket_exists)
+    except Exception as exc:
+        logger.exception("minio_bucket_setup_failed", error=str(exc), bucket=settings.minio_bucket)
+        raise
+
     if settings.seed_admin_on_startup and settings.admin_email and settings.admin_password:
         try:
             async with SessionLocal() as session:
@@ -43,6 +52,7 @@ def create_app() -> FastAPI:
     app.include_router(auth_router)
     app.include_router(locations_router)
     app.include_router(books_router)
+    app.include_router(jobs_router)
     return app
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,7 @@
 from app.models.book import Book
+from app.models.book_image import BookImage
 from app.models.location import Location
+from app.models.processing_job import ProcessingJob
 from app.models.user import User
 
-__all__ = ["User", "Location", "Book"]
+__all__ = ["User", "Location", "Book", "BookImage", "ProcessingJob"]

--- a/backend/app/models/book_image.py
+++ b/backend/app/models/book_image.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+import uuid
+
+from sqlalchemy import DateTime, ForeignKey, String, Uuid, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class BookImage(Base):
+    __tablename__ = "book_images"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    book_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("books.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    minio_path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    uploaded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/models/processing_job.py
+++ b/backend/app/models/processing_job.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from enum import Enum
+import uuid
+
+from sqlalchemy import JSON, DateTime, Enum as SAEnum, ForeignKey, Integer, String, Uuid, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ProcessingJobStatus(str, Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    DONE = "done"
+    FAILED = "failed"
+
+
+class ProcessingJob(Base):
+    __tablename__ = "processing_jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    status: Mapped[ProcessingJobStatus] = mapped_column(
+        SAEnum(
+            ProcessingJobStatus,
+            values_callable=lambda e: [member.value for member in e],
+            validate_strings=True,
+            name="processing_job_status",
+            create_type=False,
+        ),
+        nullable=False,
+        default=ProcessingJobStatus.PENDING,
+        server_default=ProcessingJobStatus.PENDING.value,
+    )
+    book_image_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("book_images.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    result_json: Mapped[dict[str, object] | None] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"), nullable=True  # type: ignore[no-untyped-call]
+    )
+    error_message: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+from app.models.processing_job import ProcessingJobStatus
+
+
+class UploadResponse(BaseModel):
+    job_id: uuid.UUID
+    status: ProcessingJobStatus
+
+
+class JobStatusResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    status: ProcessingJobStatus
+    book_id: uuid.UUID | None
+    result_json: dict[str, object] | None
+    error_message: str | None
+    attempts: int
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/job.py
+++ b/backend/app/services/job.py
@@ -1,0 +1,81 @@
+import asyncio
+import uuid
+
+from fastapi import HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.book_image import BookImage
+from app.models.processing_job import ProcessingJob, ProcessingJobStatus
+from app.services.storage import delete_image_bytes, upload_image_bytes
+
+ALLOWED_CONTENT_TYPES = {"image/jpeg", "image/png"}
+MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024
+
+
+async def create_upload_job(session: AsyncSession, upload_file: UploadFile) -> tuple[ProcessingJob, str]:
+    content_type = upload_file.content_type
+    if content_type is None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Missing content type")
+
+    if content_type not in ALLOWED_CONTENT_TYPES:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Only jpeg/png files are supported")
+
+    chunks: list[bytes] = []
+    total_bytes = 0
+    chunk_size = 1024 * 1024
+    while True:
+        chunk = await upload_file.read(chunk_size)
+        if not chunk:
+            break
+
+        total_bytes += len(chunk)
+        if total_bytes > MAX_UPLOAD_SIZE_BYTES:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="File size exceeds 10MB")
+
+        chunks.append(chunk)
+
+    payload = b"".join(chunks)
+
+    extension = "jpg" if content_type == "image/jpeg" else "png"
+    object_name = f"uploads/{uuid.uuid4()}.{extension}"
+    loop = asyncio.get_running_loop()
+    try:
+        minio_path = await loop.run_in_executor(
+            None,
+            lambda: upload_image_bytes(object_name=object_name, payload=payload, content_type=content_type),
+        )
+    except Exception as storage_exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Image storage is temporarily unavailable",
+        ) from storage_exc
+
+    try:
+        book_image = BookImage(minio_path=minio_path)
+        session.add(book_image)
+        await session.flush()
+
+        job = ProcessingJob(book_image_id=book_image.id, status=ProcessingJobStatus.PENDING)
+        session.add(job)
+        await session.flush()
+
+        return job, minio_path
+    except Exception:
+        await loop.run_in_executor(None, lambda: delete_image_bytes(object_name))
+        raise
+
+
+async def get_job_or_404(session: AsyncSession, job_id: uuid.UUID) -> ProcessingJob:
+    result = await session.execute(select(ProcessingJob).where(ProcessingJob.id == job_id))
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job
+
+
+async def get_job_book_id(session: AsyncSession, job: ProcessingJob) -> uuid.UUID | None:
+    image = await session.get(BookImage, job.book_image_id)
+    if image is None:
+        return None
+    return image.book_id

--- a/backend/app/services/job_queue.py
+++ b/backend/app/services/job_queue.py
@@ -1,0 +1,15 @@
+from functools import lru_cache
+
+from celery import Celery
+
+from app.core.config import get_settings
+
+
+@lru_cache
+def get_celery_client() -> Celery:
+    settings = get_settings()
+    return Celery(
+        "shelfy_backend",
+        broker=settings.celery_broker_url,
+        backend=settings.celery_result_backend,
+    )

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,0 +1,61 @@
+from io import BytesIO
+
+import boto3
+from botocore.client import BaseClient
+from botocore.exceptions import ClientError
+import structlog
+
+from app.core.config import get_settings
+
+logger = structlog.get_logger()
+
+
+def _get_s3_client() -> BaseClient:
+    settings = get_settings()
+    return boto3.client(
+        "s3",
+        endpoint_url=settings.minio_endpoint,
+        aws_access_key_id=settings.minio_access_key,
+        aws_secret_access_key=settings.minio_secret_key,
+        region_name=settings.minio_region,
+    )
+
+
+def ensure_bucket_exists() -> None:
+    settings = get_settings()
+    client = _get_s3_client()
+    try:
+        client.head_bucket(Bucket=settings.minio_bucket)
+    except ClientError as exc:
+        error_code = exc.response.get("Error", {}).get("Code")
+        if error_code not in {"404", "NoSuchBucket", "BucketAlreadyOwnedByYou", "BucketAlreadyExists"}:
+            raise
+
+        create_kwargs: dict[str, object] = {"Bucket": settings.minio_bucket}
+        if settings.minio_region != "us-east-1":
+            create_kwargs["CreateBucketConfiguration"] = {"LocationConstraint": settings.minio_region}
+        try:
+            client.create_bucket(**create_kwargs)
+            logger.info("minio_bucket_created", bucket=settings.minio_bucket)
+        except ClientError as create_exc:
+            create_error_code = create_exc.response.get("Error", {}).get("Code")
+            if create_error_code not in {"BucketAlreadyOwnedByYou", "BucketAlreadyExists"}:
+                raise
+
+
+def upload_image_bytes(*, object_name: str, payload: bytes, content_type: str) -> str:
+    settings = get_settings()
+    client = _get_s3_client()
+    client.upload_fileobj(
+        Fileobj=BytesIO(payload),
+        Bucket=settings.minio_bucket,
+        Key=object_name,
+        ExtraArgs={"ContentType": content_type},
+    )
+    return object_name
+
+
+def delete_image_bytes(object_name: str) -> None:
+    settings = get_settings()
+    client = _get_s3_client()
+    client.delete_object(Bucket=settings.minio_bucket, Key=object_name)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,6 @@ passlib[bcrypt]==1.7.4
 bcrypt>=3.2.0,<4.0
 email-validator==2.3.0
 structlog==24.4.0
+celery==5.6.0
+boto3==1.35.36
+python-multipart==0.0.22

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1,0 +1,197 @@
+from collections.abc import AsyncIterator, Iterator
+import io
+import os
+from unittest.mock import patch
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.book_image import BookImage
+from app.models.processing_job import ProcessingJob, ProcessingJobStatus
+from app.models.user import User
+
+
+def _require_test_database_url() -> str:
+    url = os.environ.get("TEST_DATABASE_URL")
+    if not url:
+        pytest.fail("TEST_DATABASE_URL must be set for integration tests")
+    return url
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(_require_test_database_url())
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "manual",
+                "pending",
+                "done",
+                "failed",
+                "partial",
+                name="book_processing_status",
+            ).create(sync_conn, checkfirst=True)
+        )
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "pending",
+                "processing",
+                "done",
+                "failed",
+                name="processing_job_status",
+            ).create(sync_conn, checkfirst=True)
+        )
+        await connection.run_sync(Base.metadata.drop_all)
+        await connection.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    yield session_factory
+
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url=_require_test_database_url(),
+        jwt_secret_key="test-secret",
+        jwt_algorithm="HS256",
+        access_token_expire_minutes=15,
+        refresh_token_expire_days=7,
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(
+    test_session: async_sessionmaker[AsyncSession], test_settings: Settings
+) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        async with test_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _seed_user(session: AsyncSession) -> None:
+    session.add(User(email="admin@example.com", hashed_password=get_password_hash("secret")))
+    await session.commit()
+
+
+async def _auth_headers(client: AsyncClient, session: AsyncSession) -> dict[str, str]:
+    await _seed_user(session)
+    login_response = await client.post("/api/v1/auth/login", json={"email": "admin@example.com", "password": "secret"})
+    assert login_response.status_code == 200
+    token = login_response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_upload_endpoint_returns_202_with_job_id(test_session: async_sessionmaker[AsyncSession]) -> None:
+    with (
+        patch("app.services.job.upload_image_bytes", return_value="uploads/file.jpg"),
+        patch("app.api.books.get_celery_client") as celery_client,
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            async with test_session() as session:
+                headers = await _auth_headers(client, session)
+
+            response = await client.post(
+                "/api/v1/books/upload",
+                files={"image": ("cover.jpg", io.BytesIO(b"image"), "image/jpeg")},
+                headers=headers,
+            )
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["status"] == "pending"
+    assert uuid.UUID(payload["job_id"])
+    celery_client.return_value.send_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_invalid_file_type_returns_422(test_session: async_sessionmaker[AsyncSession]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        response = await client.post(
+            "/api/v1/books/upload",
+            files={"image": ("notes.txt", io.BytesIO(b"text"), "text/plain")},
+            headers=headers,
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_upload_exceeds_10mb_returns_422(test_session: async_sessionmaker[AsyncSession]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        response = await client.post(
+            "/api/v1/books/upload",
+            files={"image": ("large.png", io.BytesIO(b"A" * (10 * 1024 * 1024 + 1)), "image/png")},
+            headers=headers,
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_upload_returns_503_when_celery_unavailable(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    with (
+        patch("app.services.job.upload_image_bytes", return_value="uploads/file.jpg"),
+        patch("app.api.books.get_celery_client") as mock_celery,
+    ):
+        mock_celery.return_value.send_task.side_effect = Exception("Celery unavailable")
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            async with test_session() as session:
+                headers = await _auth_headers(client, session)
+
+            response = await client.post(
+                "/api/v1/books/upload",
+                files={"image": ("cover.jpg", io.BytesIO(b"image"), "image/jpeg")},
+                headers=headers,
+            )
+
+        assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_job_status_endpoint_returns_correct_status(test_session: async_sessionmaker[AsyncSession]) -> None:
+    async with test_session() as session:
+        image = BookImage(minio_path="uploads/file.jpg")
+        session.add(image)
+        await session.flush()
+        job = ProcessingJob(book_image_id=image.id, status=ProcessingJobStatus.DONE, attempts=1)
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        job_id = job.id
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        response = await client.get(f"/api/v1/jobs/{job_id}", headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == str(job_id)
+    assert payload["status"] == "done"
+    assert payload["attempts"] == 1

--- a/frontend/src/hooks/useBooks.ts
+++ b/frontend/src/hooks/useBooks.ts
@@ -1,6 +1,15 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { createBook, deleteBook, formatApiError, getBook, listBooks, updateBook } from '../lib/api'
+import {
+  createBook,
+  deleteBook,
+  formatApiError,
+  getBook,
+  getJobStatus,
+  listBooks,
+  updateBook,
+  uploadBookImage,
+} from '../lib/api'
 import { useToastStore } from '../lib/toast-store'
 import type { BookCreateRequest, BookListParams, BookUpdateRequest } from '../lib/types'
 
@@ -64,5 +73,32 @@ export function useDeleteBook() {
     onError: (error: unknown) => {
       showError(formatApiError(error))
     },
+  })
+}
+
+export function useUploadBookImage() {
+  const showError = useToastStore((state) => state.showError)
+
+  return useMutation({
+    mutationFn: (file: File) => uploadBookImage(file),
+    onError: (error: unknown) => {
+      showError(formatApiError(error))
+    },
+  })
+}
+
+export function useJobStatus(jobId: string | null) {
+  return useQuery({
+    queryKey: ['job-status', jobId],
+    queryFn: () => getJobStatus(jobId as string),
+    enabled: Boolean(jobId),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      if (status === 'done' || status === 'failed' || query.state.status === 'error') {
+        return false
+      }
+      return 2000
+    },
+    retry: false,
   })
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7,11 +7,13 @@ import type {
   BookListParams,
   BookListResponse,
   BookUpdateRequest,
+  JobStatusResponse,
   Location,
   LocationCreateRequest,
   LocationUpdateRequest,
   LoginRequest,
   TokenResponse,
+  UploadJobResponse,
 } from './types'
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
@@ -106,4 +108,17 @@ export async function updateBook(id: string, payload: BookUpdateRequest): Promis
 
 export async function deleteBook(id: string): Promise<void> {
   await apiClient.delete(`/api/v1/books/${id}`)
+}
+
+
+export async function uploadBookImage(file: File): Promise<UploadJobResponse> {
+  const formData = new FormData()
+  formData.append('image', file)
+  const response = await apiClient.post<UploadJobResponse>('/api/v1/books/upload', formData)
+  return response.data
+}
+
+export async function getJobStatus(id: string): Promise<JobStatusResponse> {
+  const response = await apiClient.get<JobStatusResponse>(`/api/v1/jobs/${id}`)
+  return response.data
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -85,3 +85,22 @@ export interface TokenResponse {
   refresh_token: string
   token_type: string
 }
+
+
+export type JobStatus = 'pending' | 'processing' | 'done' | 'failed'
+
+export interface UploadJobResponse {
+  job_id: string
+  status: JobStatus
+}
+
+export interface JobStatusResponse {
+  id: string
+  status: JobStatus
+  book_id: string | null
+  result_json: Record<string, unknown> | null
+  error_message: string | null
+  attempts: number
+  created_at: string
+  updated_at: string
+}

--- a/frontend/src/pages/BooksPage.test.tsx
+++ b/frontend/src/pages/BooksPage.test.tsx
@@ -1,11 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { type ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BooksPage } from './BooksPage'
+import { useToastStore } from '../lib/toast-store'
 import type { Book, BookListResponse, Location } from '../lib/types'
 
 vi.mock('../lib/api', () => ({
@@ -14,10 +15,20 @@ vi.mock('../lib/api', () => ({
   updateBook: vi.fn(),
   deleteBook: vi.fn(),
   listLocations: vi.fn(),
+  uploadBookImage: vi.fn(),
+  getJobStatus: vi.fn(),
   formatApiError: vi.fn(() => 'API error'),
 }))
 
-import { createBook, deleteBook, listBooks, listLocations, updateBook } from '../lib/api'
+import {
+  createBook,
+  deleteBook,
+  getJobStatus,
+  listBooks,
+  listLocations,
+  updateBook,
+  uploadBookImage,
+} from '../lib/api'
 
 function renderWithProviders(ui: ReactNode) {
   const queryClient = new QueryClient({
@@ -69,7 +80,9 @@ const locations: Location[] = [
 
 describe('BooksPage', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     vi.clearAllMocks()
+    useToastStore.setState({ message: null })
     vi.mocked(listBooks).mockResolvedValue(booksResponse)
     vi.mocked(listLocations).mockResolvedValue(locations)
     vi.mocked(deleteBook).mockResolvedValue()
@@ -89,6 +102,65 @@ describe('BooksPage', () => {
 
     await waitFor(() => {
       expect(listBooks).toHaveBeenLastCalledWith(expect.objectContaining({ search: 'Martin' }))
+    })
+  })
+
+  it('polls job status and refreshes books on done', async () => {
+    vi.mocked(uploadBookImage).mockResolvedValue({ job_id: 'job-1', status: 'pending' })
+    vi.mocked(getJobStatus)
+      .mockResolvedValueOnce({ id: 'job-1', status: 'pending', book_id: null })
+      .mockResolvedValueOnce({ id: 'job-1', status: 'done', book_id: null })
+
+    renderWithProviders(<BooksPage />)
+    await screen.findByText('Clean Code')
+
+    const file = new File(['img'], 'cover.png', { type: 'image/png' })
+    await userEvent.upload(screen.getByLabelText('Upload cover image'), file)
+    fireEvent.submit(screen.getByLabelText('upload-book-image-form'))
+
+    await waitFor(() => expect(uploadBookImage).toHaveBeenCalled(), { timeout: 7000 })
+    await waitFor(() => expect(screen.getByText(/Processing job job-1:/)).toBeInTheDocument(), { timeout: 7000 })
+    await waitFor(() => expect(getJobStatus).toHaveBeenCalled(), { timeout: 7000 })
+    await waitFor(() => expect(listBooks).toHaveBeenCalledTimes(2), { timeout: 7000 })
+  }, 10000)
+
+  it('shows error toast when job fails', async () => {
+    const showErrorSpy = vi.spyOn(useToastStore.getState(), 'showError')
+    vi.mocked(uploadBookImage).mockResolvedValue({ job_id: 'job-2', status: 'pending' })
+    vi.mocked(getJobStatus).mockResolvedValue({ id: 'job-2', status: 'failed', book_id: null })
+
+    renderWithProviders(<BooksPage />)
+    await screen.findByText('Clean Code')
+
+    const file = new File(['img'], 'cover.png', { type: 'image/png' })
+    await userEvent.upload(screen.getByLabelText('Upload cover image'), file)
+    fireEvent.submit(screen.getByLabelText('upload-book-image-form'))
+
+    await waitFor(() => expect(uploadBookImage).toHaveBeenCalled(), { timeout: 7000 })
+    await waitFor(() => expect(screen.getByText(/Processing job job-2:/)).toBeInTheDocument(), { timeout: 7000 })
+    await waitFor(() => expect(showErrorSpy).toHaveBeenCalled(), { timeout: 7000 })
+  }, 10000)
+
+  it('aggregates failed-book toast messages into one toast', async () => {
+    const showErrorSpy = vi.spyOn(useToastStore.getState(), 'showError')
+    vi.mocked(listBooks).mockResolvedValue({
+      ...booksResponse,
+      total: 2,
+      items: [
+        { ...booksResponse.items[0], id: 'book-f1', title: 'Book Failed 1', processing_status: 'failed' },
+        { ...booksResponse.items[0], id: 'book-f2', title: 'Book Failed 2', processing_status: 'failed' },
+      ],
+    })
+
+    renderWithProviders(<BooksPage />)
+
+    await screen.findByText('Book Failed 1')
+
+    await waitFor(() => {
+      expect(showErrorSpy).toHaveBeenCalledTimes(1)
+      expect(showErrorSpy).toHaveBeenCalledWith(
+        'Metadata extraction failed for 2 book(s): "Book Failed 1", "Book Failed 2"',
+      )
     })
   })
 
@@ -151,4 +223,6 @@ describe('BooksPage', () => {
       expect(deleteBook).toHaveBeenCalledWith('book-1')
     })
   })
+
+
 })

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -1,9 +1,17 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import { useBooks, useCreateBook, useDeleteBook, useUpdateBook } from '../hooks/useBooks'
+import {
+  useBooks,
+  useCreateBook,
+  useDeleteBook,
+  useJobStatus,
+  useUpdateBook,
+  useUploadBookImage,
+} from '../hooks/useBooks'
 import { useLocations } from '../hooks/useLocations'
 import { getBookDetailRoute } from '../lib/routes'
+import { useToastStore } from '../lib/toast-store'
 import type { BookCreateRequest } from '../lib/types'
 
 const PAGE_SIZE = 10
@@ -29,6 +37,8 @@ export function BooksPage() {
   const [editingBookId, setEditingBookId] = useState<string | null>(null)
   const [editForm, setEditForm] = useState<BookCreateRequest>(EMPTY_FORM)
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
+  const [uploadJobId, setUploadJobId] = useState<string | null>(null)
+  const toastedFailedIdsRef = useRef<Set<string>>(new Set())
 
   const queryParams = useMemo(
     () => ({ page, pageSize: PAGE_SIZE, search: search || undefined, locationId: selectedLocationId || undefined }),
@@ -36,10 +46,14 @@ export function BooksPage() {
   )
 
   const booksQuery = useBooks(queryParams)
+  const refetchBooks = booksQuery.refetch
   const locationsQuery = useLocations()
   const createMutation = useCreateBook()
   const updateMutation = useUpdateBook()
   const deleteMutation = useDeleteBook()
+  const uploadMutation = useUploadBookImage()
+  const uploadJobStatusQuery = useJobStatus(uploadJobId)
+  const showError = useToastStore((state) => state.showError)
 
   const locationLabelById = useMemo(() => {
     const map = new Map<string, string>()
@@ -49,6 +63,19 @@ export function BooksPage() {
     return map
   }, [locationsQuery.data])
 
+  useEffect(() => {
+    const failedBooks = (booksQuery.data?.items ?? []).filter(
+      (book) => book.processing_status === 'failed' && !toastedFailedIdsRef.current.has(book.id)
+    )
+    if (failedBooks.length === 0) {
+      return
+    }
+    for (const book of failedBooks) {
+      toastedFailedIdsRef.current.add(book.id)
+    }
+    const titles = failedBooks.map((book) => `"${book.title}"`).join(', ')
+    showError(`Metadata extraction failed for ${failedBooks.length} book(s): ${titles}`)
+  }, [booksQuery.data?.items, showError])
 
   useEffect(() => {
     if (!booksQuery.data) {
@@ -65,6 +92,29 @@ export function BooksPage() {
       setPage(lastValidPage)
     }
   }, [booksQuery.data])
+
+  useEffect(() => {
+    const status = uploadJobStatusQuery.data?.status
+    if (status === 'done' || status === 'failed') {
+      if (status === 'failed') {
+        showError(uploadJobStatusQuery.data?.error_message ?? 'Image processing failed.')
+      }
+      setUploadJobId(null)
+      void refetchBooks()
+      return
+    }
+
+    if (uploadJobStatusQuery.isError) {
+      showError('Failed to check upload status.')
+      setUploadJobId(null)
+    }
+  }, [
+    refetchBooks,
+    showError,
+    uploadJobStatusQuery.data?.error_message,
+    uploadJobStatusQuery.data?.status,
+    uploadJobStatusQuery.isError,
+  ])
 
   return (
     <section style={{ marginTop: '1.5rem' }}>
@@ -102,6 +152,36 @@ export function BooksPage() {
         </select>
         <button type="submit">Apply search</button>
       </form>
+
+      <form
+        aria-label="upload-book-image-form"
+        onSubmit={(event) => {
+          event.preventDefault()
+          const formData = new FormData(event.currentTarget)
+          const file = formData.get('book-image')
+          if (!(file instanceof File)) {
+            return
+          }
+          uploadMutation.mutate(file, {
+            onSuccess: (response) => {
+              setUploadJobId(response.job_id)
+            },
+          })
+        }}
+        style={{ marginBottom: '1rem' }}
+      >
+        <label htmlFor="book-image">Upload cover image</label>
+        <input id="book-image" name="book-image" type="file" accept="image/jpeg,image/png" required />
+        <button type="submit" disabled={uploadMutation.isPending || Boolean(uploadJobId)}>
+          {uploadMutation.isPending ? 'Uploading…' : 'Upload image'}
+        </button>
+      </form>
+
+      {uploadJobId && (
+        <p>
+          Processing job {uploadJobId}: {uploadJobStatusQuery.data?.status ?? 'pending'}
+        </p>
+      )}
 
       <form
         aria-label="create-book-form"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -29,6 +29,11 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -42,10 +47,19 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://shelfy:shelfy@postgres:5432/shelfy}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      CELERY_BROKER_URL: ${CELERY_BROKER_URL:-redis://redis:6379/0}
+      CELERY_RESULT_BACKEND: ${CELERY_RESULT_BACKEND:-redis://redis:6379/1}
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_BUCKET: ${MINIO_BUCKET:-shelfy-images}
+      MINIO_REGION: ${MINIO_REGION:-us-east-1}
     depends_on:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      minio:
         condition: service_healthy
     ports:
       - "8000:8000"
@@ -59,7 +73,10 @@ services:
     environment:
       CELERY_BROKER_URL: ${CELERY_BROKER_URL:-redis://redis:6379/0}
       CELERY_RESULT_BACKEND: ${CELERY_RESULT_BACKEND:-redis://redis:6379/1}
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://shelfy:shelfy@postgres:5432/shelfy}
     depends_on:
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
 

--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -1,6 +1,52 @@
+from datetime import datetime
 import os
+import time
+import uuid
+from enum import Enum
 
 from celery import Celery
+from sqlalchemy import DateTime, Enum as SAEnum, ForeignKey, Integer, String, Uuid, create_engine, exc, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class ProcessingJobStatus(str, Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    DONE = "done"
+    FAILED = "failed"
+
+
+class ProcessingJob(Base):
+    __tablename__ = "processing_jobs"
+    # Keep this schema aligned with backend/app/models/processing_job.py.
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
+    status: Mapped[ProcessingJobStatus] = mapped_column(
+        SAEnum(
+            ProcessingJobStatus,
+            values_callable=lambda e: [member.value for member in e],
+            validate_strings=True,
+            name="processing_job_status",
+            create_type=False,
+        ),
+        nullable=False,
+        default=ProcessingJobStatus.PENDING,
+    )
+    book_image_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("book_images.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    result_json: Mapped[dict[str, object] | None] = mapped_column(JSONB, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
 
 def get_celery_app() -> Celery:
@@ -13,3 +59,63 @@ def get_celery_app() -> Celery:
 
 
 celery_app = get_celery_app()
+
+
+def _get_engine():
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL environment variable is not set")
+    sync_database_url = database_url.replace("+asyncpg", "+psycopg2")
+    return create_engine(sync_database_url)
+
+
+@celery_app.task(
+    name="worker.celery_app.process_book_image",
+    bind=True,
+    autoretry_for=(exc.OperationalError, exc.InterfaceError),
+    retry_backoff=True,
+    retry_backoff_max=60,
+    max_retries=3,
+)
+def process_book_image(self, job_id: str) -> None:
+    engine = _get_engine()
+    try:
+        with Session(engine) as session:
+            job = session.get(ProcessingJob, uuid.UUID(job_id))
+            if job is None:
+                return
+
+            job.status = ProcessingJobStatus.PROCESSING
+            job.attempts += 1
+            session.commit()
+    except (exc.OperationalError, exc.InterfaceError):
+        raise
+    except Exception as error:
+        with Session(engine) as session:
+            job = session.get(ProcessingJob, uuid.UUID(job_id))
+            if job is not None:
+                job.status = ProcessingJobStatus.FAILED
+                job.error_message = str(error)[:1000]
+                session.commit()
+        raise
+
+    try:
+        time.sleep(2)
+
+        with Session(engine) as session:
+            job = session.get(ProcessingJob, uuid.UUID(job_id))
+            if job is None:
+                return
+            job.status = ProcessingJobStatus.DONE
+            job.error_message = None
+            session.commit()
+    except (exc.OperationalError, exc.InterfaceError):
+        raise
+    except Exception as error:
+        with Session(engine) as session:
+            job = session.get(ProcessingJob, uuid.UUID(job_id))
+            if job is not None:
+                job.status = ProcessingJobStatus.FAILED
+                job.error_message = str(error)[:1000]
+                session.commit()
+        raise

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -1,2 +1,4 @@
 celery==5.5.3
 redis==6.4.0
+sqlalchemy==2.0.36
+psycopg2==2.9.9


### PR DESCRIPTION
### Motivation
- Add end-to-end support for uploading book cover images, storing them in MinIO (S3-compatible), and processing them asynchronously via a Celery worker tracked as processing jobs. 
- Provide persistence and API endpoints for upload jobs and job status so the frontend can poll and update UI based on processing progress. 
- Ensure local dev infra and configuration expose MinIO and Celery settings so the feature works in Docker compose environments.

### Description
- Introduces new DB entities and migration: adds `book_images` and `processing_jobs` models, SQLAlchemy models (`app/models/book_image.py`, `app/models/processing_job.py`) and the Alembic migration `20260912_000004_create_book_images_and_processing_jobs.py` with Postgres-aware enum/JSON handling. 
- Adds image storage service `app/services/storage.py` using `boto3` for MinIO, plus `ensure_bucket_exists`, `upload_image_bytes`, and `delete_image_bytes`, and wires MinIO config into `app/core/config.py` with validation for default creds. 
- Adds job creation and lookup logic in `app/services/job.py` and a cached Celery client in `app/services/job_queue.py`, plus API endpoints: upload at `POST /api/v1/books/upload` (books router) and job status at `GET /api/v1/jobs/{job_id}` (new `app/api/jobs.py`). 
- Updates application startup to ensure MinIO bucket exists by invoking `ensure_bucket_exists` in `app/main.py`, and exposes job router. 
- Worker changes: adds a Celery worker implementation (`worker/celery_app.py`) that fetches and updates `processing_jobs` and marks jobs `processing`/`done`/`failed`, and adds worker deps in `worker/requirements.txt`. 
- Frontend updates: adds upload and job status types and API calls (`frontend/src/lib/types.ts`, `frontend/src/lib/api.ts`), client hooks and UI for uploading images and polling job status (`hooks/useBooks.ts`, `pages/BooksPage.tsx`), and updates tests to cover polling and error toast aggregation (`frontend/src/pages/BooksPage.test.tsx`). 
- Development infra and config: updates `.env.example` and `infra/docker-compose.yml` to include MinIO and Celery environment variables and healthchecks, and updates backend and worker `requirements.txt` to include `celery`, `boto3`, and multipart support.

### Testing
- Added backend integration tests in `backend/tests/test_jobs.py` exercising the upload endpoint, validation, Celery failure handling, and job status endpoint, and they were included with the change. 
- Updated frontend unit tests `BooksPage.test.tsx` to cover upload flow, job polling, failure handling, and aggregated toasts in the UI. 
- Ran automated test suites for the modified components locally (`pytest` for backend tests and `vitest` for frontend tests) and confirmed the new tests and existing suites pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9543cee148325a35262fe127de2c4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Book image upload capability with asynchronous processing support
  * Real-time job status tracking for image uploads
  * File validation (type and size limits enforced)
  * Error notifications for failed image processing

* **Infrastructure**
  * Added distributed task queue and object storage services
  * Enhanced service dependencies for reliable startup sequence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->