### PR TITLE
feat: Phase 9 — external metadata enrichment (Google Books + OpenLibrary, cache, worker upsert, retry)

### DIFF
--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -8,7 +8,7 @@ from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db_session
 from app.models.processing_job import ProcessingJob, ProcessingJobStatus
 from app.models.user import User
-from app.schemas.book import BookCreateRequest, BookListResponse, BookResponse, BookUpdateRequest
+from app.schemas.book import BookCreateRequest, BookListResponse, BookResponse, BookUpdateRequest, RetryEnrichmentResponse
 from app.schemas.job import UploadResponse
 from app.services.book import create_book, delete_book, get_book_or_404, list_books, update_book
 from app.services.job import create_upload_job
@@ -78,6 +78,27 @@ async def delete_book_endpoint(
     await delete_book(session, book_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
+
+
+@router.patch("/{book_id}/retry-enrichment", response_model=RetryEnrichmentResponse, status_code=status.HTTP_202_ACCEPTED)
+async def retry_book_enrichment(
+    book_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _current_user: User = Depends(get_current_user),
+) -> RetryEnrichmentResponse:
+    await get_book_or_404(session, book_id)
+
+    celery_client = get_celery_client()
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(
+        None,
+        lambda: celery_client.send_task(
+            "worker.celery_app.retry_book_enrichment",
+            args=[str(book_id)],
+        ),
+    )
+
+    return RetryEnrichmentResponse(book_id=book_id, status="queued")
 
 @router.post("/upload", response_model=UploadResponse, status_code=status.HTTP_202_ACCEPTED)
 async def upload_book_image(

--- a/backend/app/schemas/book.py
+++ b/backend/app/schemas/book.py
@@ -67,3 +67,8 @@ class BookListResponse(BaseModel):
     page: int
     page_size: int
     items: list[BookResponse]
+
+
+class RetryEnrichmentResponse(BaseModel):
+    book_id: uuid.UUID
+    status: str

--- a/backend/app/services/metadata/__init__.py
+++ b/backend/app/services/metadata/__init__.py
@@ -1,0 +1,3 @@
+from app.services.metadata.service import enrich_metadata_with_fallback
+
+__all__ = ["enrich_metadata_with_fallback"]

--- a/backend/app/services/metadata/google_books.py
+++ b/backend/app/services/metadata/google_books.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+async def fetch_google_books_metadata(client: httpx.AsyncClient, isbn: str) -> dict[str, Any] | None:
+    response = await client.get(
+        "https://www.googleapis.com/books/v1/volumes",
+        params={"q": f"isbn:{isbn}", "maxResults": 1},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    payload = response.json()
+
+    items = payload.get("items")
+    if not items:
+        return None
+
+    volume_info = items[0].get("volumeInfo", {})
+    published_date = str(volume_info.get("publishedDate", ""))
+    year: int | None = None
+    if len(published_date) >= 4 and published_date[:4].isdigit():
+        year = int(published_date[:4])
+
+    image_links = volume_info.get("imageLinks") or {}
+
+    return {
+        "title": volume_info.get("title"),
+        "author": (volume_info.get("authors") or [None])[0],
+        "isbn": isbn,
+        "publisher": volume_info.get("publisher"),
+        "language": volume_info.get("language"),
+        "description": volume_info.get("description"),
+        "publication_year": year,
+        "cover_image_url": image_links.get("thumbnail") or image_links.get("smallThumbnail"),
+        "provider": "google_books",
+    }

--- a/backend/app/services/metadata/open_library.py
+++ b/backend/app/services/metadata/open_library.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+async def fetch_open_library_metadata(client: httpx.AsyncClient, isbn: str) -> dict[str, Any] | None:
+    bib_key = f"ISBN:{isbn}"
+    response = await client.get(
+        "https://openlibrary.org/api/books",
+        params={"bibkeys": bib_key, "format": "json", "jscmd": "data"},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    entry = payload.get(bib_key)
+    if not entry:
+        return None
+
+    publish_date = str(entry.get("publish_date", ""))
+    year: int | None = None
+    for token in publish_date.split():
+        if len(token) == 4 and token.isdigit():
+            year = int(token)
+            break
+
+    cover = entry.get("cover") or {}
+
+    return {
+        "title": entry.get("title"),
+        "author": (entry.get("authors") or [{}])[0].get("name"),
+        "isbn": isbn,
+        "publisher": (entry.get("publishers") or [{}])[0].get("name"),
+        "language": ((entry.get("languages") or [{}])[0].get("key") or "").split("/")[-1] or None,
+        "description": (entry.get("description") or {}).get("value") if isinstance(entry.get("description"), dict) else entry.get("description"),
+        "publication_year": year,
+        "cover_image_url": cover.get("large") or cover.get("medium") or cover.get("small"),
+        "provider": "open_library",
+    }

--- a/backend/app/services/metadata/service.py
+++ b/backend/app/services/metadata/service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+from redis import asyncio as redis_async
+
+from app.core.config import get_settings
+from app.services.metadata.google_books import fetch_google_books_metadata
+from app.services.metadata.open_library import fetch_open_library_metadata
+
+CACHE_TTL_SECONDS = 24 * 60 * 60
+
+
+async def enrich_metadata_with_fallback(isbn: str) -> dict[str, object] | None:
+    settings = get_settings()
+    cache_key = f"book-metadata:{isbn}"
+    redis_client = redis_async.from_url(settings.redis_url, decode_responses=True)
+
+    try:
+        cached = await redis_client.get(cache_key)
+        if cached:
+            return json.loads(cached)
+
+        async with httpx.AsyncClient() as client:
+            metadata = await fetch_google_books_metadata(client, isbn)
+            if metadata is None:
+                metadata = await fetch_open_library_metadata(client, isbn)
+
+        if metadata is None:
+            return None
+
+        await redis_client.set(cache_key, json.dumps(metadata), ex=CACHE_TTL_SECONDS)
+        return metadata
+    finally:
+        await redis_client.aclose()

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -313,3 +313,41 @@ async def test_update_book_with_duplicate_isbn_returns_409(
         )
 
     assert conflict.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_retry_enrichment_enqueues_worker_task(test_session: async_sessionmaker[AsyncSession]) -> None:
+    async with test_session() as session:
+        book = Book(title="Book pending", isbn="9780134494166")
+        session.add(book)
+        await session.commit()
+        await session.refresh(book)
+        book_id = book.id
+
+    from unittest.mock import patch
+
+    with patch("app.api.books.get_celery_client") as celery_client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            async with test_session() as session:
+                headers = await _auth_headers(client, session)
+
+            response = await client.patch(f"/api/v1/books/{book_id}/retry-enrichment", headers=headers)
+
+    assert response.status_code == 202
+    assert response.json()["book_id"] == str(book_id)
+    assert response.json()["status"] == "queued"
+    celery_client.return_value.send_task.assert_called_once_with(
+        "worker.celery_app.retry_book_enrichment",
+        args=[str(book_id)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_enrichment_missing_book_returns_404(test_session: async_sessionmaker[AsyncSession]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        response = await client.patch(f"/api/v1/books/{uuid.uuid4()}/retry-enrichment", headers=headers)
+
+    assert response.status_code == 404

--- a/backend/tests/test_metadata_services.py
+++ b/backend/tests/test_metadata_services.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from app.services.metadata.google_books import fetch_google_books_metadata
+from app.services.metadata.open_library import fetch_open_library_metadata
+from app.services.metadata.service import enrich_metadata_with_fallback
+
+
+def test_google_books_client_returns_normalized_metadata() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/books/v1/volumes"
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "volumeInfo": {
+                            "title": "Clean Code",
+                            "authors": ["Robert C. Martin"],
+                            "publisher": "Prentice Hall",
+                            "publishedDate": "2008-08-01",
+                            "language": "en",
+                            "description": "A handbook of agile software craftsmanship.",
+                            "imageLinks": {"thumbnail": "https://example.com/cover.jpg"},
+                        }
+                    }
+                ]
+            },
+        )
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await fetch_google_books_metadata(client, "9780132350884")
+
+    metadata = asyncio.run(_run())
+
+    assert metadata is not None
+    assert metadata["isbn"] == "9780132350884"
+    assert metadata["title"] == "Clean Code"
+    assert metadata["publication_year"] == 2008
+    assert metadata["provider"] == "google_books"
+
+
+def test_open_library_fallback_called_when_google_books_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _google(_client: httpx.AsyncClient, _isbn: str):
+        return None
+
+    async def _open_library(_client: httpx.AsyncClient, isbn: str):
+        return {
+            "title": "Refactoring",
+            "author": "Martin Fowler",
+            "isbn": isbn,
+            "publisher": "Addison-Wesley",
+            "language": "eng",
+            "description": "Improving existing code.",
+            "publication_year": 1999,
+            "cover_image_url": "https://example.com/refactoring.jpg",
+            "provider": "open_library",
+        }
+
+    class FakeRedis:
+        def __init__(self) -> None:
+            self.storage: dict[str, str] = {}
+
+        async def get(self, key: str) -> str | None:
+            return self.storage.get(key)
+
+        async def set(self, key: str, value: str, ex: int) -> None:
+            assert ex == 24 * 60 * 60
+            self.storage[key] = value
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_redis = FakeRedis()
+
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _google)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library)
+    monkeypatch.setattr("app.services.metadata.service.redis_async.from_url", lambda *_args, **_kwargs: fake_redis)
+
+    metadata = asyncio.run(enrich_metadata_with_fallback("9780201485677"))
+
+    assert metadata is not None
+    assert metadata["provider"] == "open_library"
+    assert json.loads(fake_redis.storage["book-metadata:9780201485677"])["title"] == "Refactoring"
+
+
+def test_cache_hit_skips_external_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    cached_payload = {"title": "Cached Book", "provider": "google_books", "isbn": "9780134494166"}
+
+    class FakeRedis:
+        async def get(self, key: str) -> str | None:
+            if key == "book-metadata:9780134494166":
+                return json.dumps(cached_payload)
+            return None
+
+        async def set(self, _key: str, _value: str, ex: int) -> None:
+            raise AssertionError(f"cache set should not be called, got TTL {ex}")
+
+        async def aclose(self) -> None:
+            return None
+
+    async def _raise_if_called(*_args, **_kwargs):
+        raise AssertionError("external client should not be called on cache hit")
+
+    monkeypatch.setattr("app.services.metadata.service.redis_async.from_url", lambda *_args, **_kwargs: FakeRedis())
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _raise_if_called)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _raise_if_called)
+
+    metadata = asyncio.run(enrich_metadata_with_fallback("9780134494166"))
+
+    assert metadata == cached_payload
+
+
+def test_open_library_client_normalizes_response() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "ISBN:9780134494166": {
+                    "title": "Clean Architecture",
+                    "authors": [{"name": "Robert C. Martin"}],
+                    "publishers": [{"name": "Prentice Hall"}],
+                    "publish_date": "2017",
+                    "languages": [{"key": "/languages/eng"}],
+                    "description": {"value": "Software architecture patterns."},
+                    "cover": {"large": "https://example.com/clean-architecture.jpg"},
+                }
+            },
+        )
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await fetch_open_library_metadata(client, "9780134494166")
+
+    metadata = asyncio.run(_run())
+
+    assert metadata is not None
+    assert metadata["provider"] == "open_library"
+    assert metadata["publication_year"] == 2017

--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -1,25 +1,33 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 from enum import Enum
 from functools import lru_cache
+import json
 import os
 import re
 import uuid
 
 import boto3
+from celery import Celery
+from celery.exceptions import Retry
+from celery.utils.log import get_task_logger
 import cv2
+import httpx
 import numpy as np
 import pytesseract
 try:
     from pyzbar.pyzbar import decode as decode_barcodes
 except ImportError:
     decode_barcodes = None
-from celery import Celery
-from celery.exceptions import Retry
-from sqlalchemy import DateTime, Enum as SAEnum, ForeignKey, Integer, String, Uuid, create_engine, exc, func
+from redis import Redis
+from sqlalchemy import DateTime, Enum as SAEnum, ForeignKey, Integer, String, Text, Uuid, create_engine, exc, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+CACHE_TTL_SECONDS = 24 * 60 * 60
+logger = get_task_logger(__name__)
 
 
 class Base(DeclarativeBase):
@@ -33,16 +41,49 @@ class ProcessingJobStatus(str, Enum):
     FAILED = "failed"
 
 
+class BookProcessingStatus(str, Enum):
+    MANUAL = "manual"
+    PENDING = "pending"
+    DONE = "done"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+class Book(Base):
+    __tablename__ = "books"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    author: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    isbn: Mapped[str | None] = mapped_column(String(20), nullable=True, unique=True, index=True)
+    publisher: Mapped[str | None] = mapped_column(String(300), nullable=True)
+    language: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    publication_year: Mapped[int | None] = mapped_column(Integer(), nullable=True)
+    cover_image_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    processing_status: Mapped[BookProcessingStatus] = mapped_column(
+        SAEnum(
+            BookProcessingStatus,
+            values_callable=lambda e: [member.value for member in e],
+            validate_strings=True,
+            name="book_processing_status",
+            create_type=False,
+        ),
+        nullable=False,
+        default=BookProcessingStatus.MANUAL,
+    )
+
+
 class BookImage(Base):
     __tablename__ = "book_images"
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
+    book_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(as_uuid=True), ForeignKey("books.id", ondelete="SET NULL"), nullable=True, index=True)
     minio_path: Mapped[str] = mapped_column(String(1024), nullable=False)
 
 
 class ProcessingJob(Base):
     __tablename__ = "processing_jobs"
-    # Keep this schema aligned with backend/app/models/processing_job.py.
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
     status: Mapped[ProcessingJobStatus] = mapped_column(
@@ -85,6 +126,12 @@ def _get_engine():
     database_url = os.getenv("DATABASE_URL", "postgresql+asyncpg://shelfy:shelfy@postgres:5432/shelfy")
     sync_database_url = database_url.replace("+asyncpg", "+psycopg2")
     return create_engine(sync_database_url, pool_pre_ping=True)
+
+
+@lru_cache(maxsize=1)
+def _get_redis_client() -> Redis:
+    redis_url = os.getenv("REDIS_URL", "redis://redis:6379/0")
+    return Redis.from_url(redis_url, decode_responses=True)
 
 
 def _get_minio_client():
@@ -245,6 +292,146 @@ def _extract_metadata(image_bytes: bytes) -> tuple[dict[str, object], Processing
     )
 
 
+def _cache_key(isbn: str) -> str:
+    return f"book-metadata:{isbn}"
+
+
+async def _fetch_google_books_metadata(isbn: str) -> dict[str, object] | None:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            "https://www.googleapis.com/books/v1/volumes",
+            params={"q": f"isbn:{isbn}", "maxResults": 1},
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    items = payload.get("items")
+    if not items:
+        return None
+
+    volume = items[0].get("volumeInfo", {})
+    published_date = str(volume.get("publishedDate", ""))
+    publication_year = int(published_date[:4]) if len(published_date) >= 4 and published_date[:4].isdigit() else None
+    image_links = volume.get("imageLinks") or {}
+
+    return {
+        "title": volume.get("title"),
+        "author": (volume.get("authors") or [None])[0],
+        "isbn": isbn,
+        "publisher": volume.get("publisher"),
+        "language": volume.get("language"),
+        "description": volume.get("description"),
+        "publication_year": publication_year,
+        "cover_image_url": image_links.get("thumbnail") or image_links.get("smallThumbnail"),
+        "provider": "google_books",
+    }
+
+
+async def _fetch_open_library_metadata(isbn: str) -> dict[str, object] | None:
+    bib_key = f"ISBN:{isbn}"
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            "https://openlibrary.org/api/books",
+            params={"bibkeys": bib_key, "format": "json", "jscmd": "data"},
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    book_data = payload.get(bib_key)
+    if not book_data:
+        return None
+
+    publish_date = str(book_data.get("publish_date", ""))
+    publication_year: int | None = None
+    for token in publish_date.replace(",", " ").split():
+        if len(token) == 4 and token.isdigit():
+            publication_year = int(token)
+            break
+
+    cover_data = book_data.get("cover") or {}
+    language_key = ((book_data.get("languages") or [{}])[0].get("key") or "").split("/")[-1] or None
+    description = book_data.get("description")
+    if isinstance(description, dict):
+        description = description.get("value")
+
+    return {
+        "title": book_data.get("title"),
+        "author": (book_data.get("authors") or [{}])[0].get("name"),
+        "isbn": isbn,
+        "publisher": (book_data.get("publishers") or [{}])[0].get("name"),
+        "language": language_key,
+        "description": description,
+        "publication_year": publication_year,
+        "cover_image_url": cover_data.get("large") or cover_data.get("medium") or cover_data.get("small"),
+        "provider": "open_library",
+    }
+
+
+async def _enrich_metadata_with_fallback(isbn: str) -> dict[str, object] | None:
+    cache = _get_redis_client()
+    cached = cache.get(_cache_key(isbn))
+    if cached:
+        return json.loads(cached)
+
+    metadata: dict[str, object] | None = None
+
+    try:
+        metadata = await _fetch_google_books_metadata(isbn)
+    except Exception:
+        metadata = None
+
+    if metadata is None:
+        try:
+            metadata = await _fetch_open_library_metadata(isbn)
+        except Exception:
+            metadata = None
+
+    if metadata is not None:
+        cache.setex(_cache_key(isbn), CACHE_TTL_SECONDS, json.dumps(metadata))
+    return metadata
+
+
+def _upsert_book_from_metadata(
+    session: Session,
+    book_image: BookImage,
+    local_result: dict[str, object],
+    metadata: dict[str, object] | None,
+) -> Book:
+    isbn = local_result.get("isbn") if isinstance(local_result.get("isbn"), str) else None
+    metadata_or_empty = metadata or {}
+
+    book: Book | None = None
+    if book_image.book_id is not None:
+        book = session.get(Book, book_image.book_id)
+
+    if book is None and isbn:
+        book = session.execute(select(Book).where(Book.isbn == isbn)).scalar_one_or_none()
+
+    if book is None:
+        book = Book(id=uuid.uuid4(), title="Unknown title")
+        session.add(book)
+
+    book.title = (metadata_or_empty.get("title") if isinstance(metadata_or_empty.get("title"), str) else None) or (
+        local_result.get("title") if isinstance(local_result.get("title"), str) else None
+    ) or "Unknown title"
+    book.author = (metadata_or_empty.get("author") if isinstance(metadata_or_empty.get("author"), str) else None) or (
+        local_result.get("author") if isinstance(local_result.get("author"), str) else None
+    )
+    book.isbn = isbn
+    book.publisher = metadata_or_empty.get("publisher") if isinstance(metadata_or_empty.get("publisher"), str) else None
+    book.language = metadata_or_empty.get("language") if isinstance(metadata_or_empty.get("language"), str) else None
+    book.description = metadata_or_empty.get("description") if isinstance(metadata_or_empty.get("description"), str) else None
+    book.publication_year = metadata_or_empty.get("publication_year") if isinstance(metadata_or_empty.get("publication_year"), int) else None
+    book.cover_image_url = metadata_or_empty.get("cover_image_url") if isinstance(metadata_or_empty.get("cover_image_url"), str) else None
+    book.processing_status = BookProcessingStatus.DONE if metadata is not None else BookProcessingStatus.PARTIAL
+
+    session.flush()
+    book_image.book_id = book.id
+    return book
+
+
 def _mark_failed(job_id: str, message: str) -> None:
     with Session(_get_engine()) as session:
         job = session.get(ProcessingJob, uuid.UUID(job_id))
@@ -253,6 +440,18 @@ def _mark_failed(job_id: str, message: str) -> None:
             job.result_json = None
             job.error_message = message[:1000]
             session.commit()
+
+
+def _mark_book_partial(book_id: str, message: str) -> None:
+    with Session(_get_engine()) as session:
+        book = session.get(Book, uuid.UUID(book_id))
+        if book is None:
+            return
+
+        book.processing_status = BookProcessingStatus.PARTIAL
+        if not book.description:
+            book.description = message[:1000]
+        session.commit()
 
 
 @celery_app.task(
@@ -280,11 +479,33 @@ def process_book_image(self, job_id: str) -> None:
             session.commit()
 
             image_bytes = _download_image_bytes(image.minio_path)
-            result_json, final_status, error_message = _extract_metadata(image_bytes)
+            local_result, local_status, error_message = _extract_metadata(image_bytes)
 
-            job.status = final_status
+            if local_status == ProcessingJobStatus.FAILED:
+                job.status = local_status
+                job.result_json = local_result
+                job.error_message = error_message
+                session.commit()
+                return
+
+            isbn = local_result.get("isbn")
+            metadata: dict[str, object] | None = None
+            if isinstance(isbn, str):
+                metadata = asyncio.run(_enrich_metadata_with_fallback(isbn))
+
+            if isinstance(isbn, str) and metadata is None:
+                logger.warning("metadata_enrichment_partial", job_id=job_id, isbn=isbn)
+
+            book = _upsert_book_from_metadata(session, image, local_result, metadata)
+
+            result_json = {**local_result}
+            if metadata is not None:
+                result_json["metadata"] = metadata
+            result_json["book_id"] = str(book.id)
+
+            job.status = ProcessingJobStatus.DONE
             job.result_json = result_json
-            job.error_message = error_message
+            job.error_message = None
             session.commit()
     except Retry:
         raise
@@ -292,4 +513,46 @@ def process_book_image(self, job_id: str) -> None:
         raise
     except Exception as error:
         _mark_failed(job_id, str(error))
+        raise
+
+
+@celery_app.task(
+    name="worker.celery_app.retry_book_enrichment",
+    bind=True,
+    acks_late=True,
+    autoretry_for=(exc.OperationalError, exc.InterfaceError),
+    retry_backoff=True,
+    retry_backoff_max=60,
+    max_retries=3,
+)
+def retry_book_enrichment(self, book_id: str) -> None:
+    try:
+        with Session(_get_engine()) as session:
+            book = session.get(Book, uuid.UUID(book_id))
+            if book is None:
+                raise self.retry(exc=RuntimeError(f"Book {book_id} not found"), countdown=2)
+            if not book.isbn:
+                _mark_book_partial(book_id, "Retry skipped: book ISBN is missing")
+                return
+
+            metadata = asyncio.run(_enrich_metadata_with_fallback(book.isbn))
+            if metadata is None:
+                _mark_book_partial(book_id, "Retry enrichment failed for all providers")
+                return
+
+            book.title = metadata.get("title") if isinstance(metadata.get("title"), str) else book.title
+            book.author = metadata.get("author") if isinstance(metadata.get("author"), str) else book.author
+            book.publisher = metadata.get("publisher") if isinstance(metadata.get("publisher"), str) else book.publisher
+            book.language = metadata.get("language") if isinstance(metadata.get("language"), str) else book.language
+            book.description = metadata.get("description") if isinstance(metadata.get("description"), str) else book.description
+            book.publication_year = metadata.get("publication_year") if isinstance(metadata.get("publication_year"), int) else book.publication_year
+            book.cover_image_url = metadata.get("cover_image_url") if isinstance(metadata.get("cover_image_url"), str) else book.cover_image_url
+            book.processing_status = BookProcessingStatus.DONE
+            session.commit()
+    except Retry:
+        raise
+    except (exc.OperationalError, exc.InterfaceError):
+        raise
+    except Exception:
+        _mark_book_partial(book_id, "Retry enrichment failed")
         raise

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -7,3 +7,4 @@ opencv-python-headless==4.11.0.86
 pyzbar==0.1.9
 pytesseract==0.3.13
 numpy==2.2.3
+httpx==0.28.1

--- a/worker/tests/test_celery_app.py
+++ b/worker/tests/test_celery_app.py
@@ -104,3 +104,128 @@ def test_normalize_and_validate_isbn() -> None:
     assert celery_app.normalize_isbn("978-0-306-40615-7") == "9780306406157"
     assert celery_app.normalize_isbn("0-306-40615-2") == "0306406152"
     assert celery_app.normalize_isbn("1234567890") is None
+
+
+def test_enrichment_cache_hit_skips_external_calls(monkeypatch) -> None:
+    class FakeRedis:
+        def get(self, _key):
+            return '{"title":"Cached","provider":"google_books"}'
+
+        def setex(self, _key, _ttl, _payload):
+            raise AssertionError("setex should not be called on cache hit")
+
+    monkeypatch.setattr(celery_app, "_get_redis_client", lambda: FakeRedis())
+
+    async def _raise(*_args, **_kwargs):
+        raise AssertionError("external call should not happen")
+
+    monkeypatch.setattr(celery_app, "_fetch_google_books_metadata", _raise)
+    monkeypatch.setattr(celery_app, "_fetch_open_library_metadata", _raise)
+
+    result = celery_app.asyncio.run(celery_app._enrich_metadata_with_fallback("9780134494166"))
+
+    assert result == {"title": "Cached", "provider": "google_books"}
+
+
+def test_both_providers_failing_sets_partial_and_creates_book(monkeypatch) -> None:
+    job_id = uuid.uuid4()
+    book_image_id = uuid.uuid4()
+
+    class FakeJob:
+        def __init__(self) -> None:
+            self.id = job_id
+            self.book_image_id = book_image_id
+            self.status = celery_app.ProcessingJobStatus.PENDING
+            self.result_json = None
+            self.error_message = None
+            self.attempts = 0
+
+    class FakeBookImage:
+        def __init__(self) -> None:
+            self.id = book_image_id
+            self.minio_path = "uploads/test.jpg"
+            self.book_id = None
+
+    class FakeBook:
+        def __init__(self) -> None:
+            self.id = uuid.uuid4()
+            self.title = ""
+            self.author = None
+            self.isbn = None
+            self.publisher = None
+            self.language = None
+            self.description = None
+            self.publication_year = None
+            self.cover_image_url = None
+            self.processing_status = celery_app.BookProcessingStatus.MANUAL
+
+    fake_job = FakeJob()
+    fake_book_image = FakeBookImage()
+    fake_book = FakeBook()
+
+    class FakeResult:
+        def scalar_one_or_none(self):
+            return None
+
+    added_books = []
+
+    class FakeSession:
+        def __init__(self, _engine) -> None:
+            self.added = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def get(self, model, identifier):
+            if model is celery_app.ProcessingJob and identifier == job_id:
+                return fake_job
+            if model is celery_app.BookImage and identifier == book_image_id:
+                return fake_book_image
+            if model is celery_app.Book and identifier == fake_book_image.book_id:
+                return fake_book
+            return None
+
+        def execute(self, _query):
+            return FakeResult()
+
+        def add(self, obj) -> None:
+            self.added.append(obj)
+            if isinstance(obj, celery_app.Book):
+                obj.id = fake_book.id
+                added_books.append(obj)
+
+        def flush(self) -> None:
+            return None
+
+        def commit(self) -> None:
+            return None
+
+    monkeypatch.setattr(celery_app, "Session", FakeSession)
+    monkeypatch.setattr(celery_app, "_get_engine", lambda: object())
+    monkeypatch.setattr(celery_app, "_download_image_bytes", lambda _path: b"image")
+    monkeypatch.setattr(
+        celery_app,
+        "_extract_metadata",
+        lambda _bytes: (
+            {"isbn": "9780306406157", "title": "Fallback title", "author": "Fallback author", "source": "ocr"},
+            celery_app.ProcessingJobStatus.DONE,
+            None,
+        ),
+    )
+
+    async def _no_metadata(_isbn):
+        return None
+
+    monkeypatch.setattr(celery_app, "_enrich_metadata_with_fallback", _no_metadata)
+    monkeypatch.setattr(celery_app.uuid, "uuid4", lambda: fake_book.id)
+
+    celery_app.process_book_image.run(job_id=str(job_id))
+
+    assert fake_job.status == celery_app.ProcessingJobStatus.DONE
+    assert fake_job.error_message is None
+    assert fake_book_image.book_id == fake_book.id
+    assert len(added_books) == 1
+    assert added_books[0].processing_status == celery_app.BookProcessingStatus.PARTIAL


### PR DESCRIPTION
### Motivation
- Add Phase 9 deliverables to enrich OCR/barcode results with external metadata and persist enriched Book records. 
- Provide a resilient fallback and caching strategy so enrichment is fast and tolerant of provider failures.

### Description
- Added async provider clients `app/services/metadata/google_books.py` and `app/services/metadata/open_library.py` that normalize provider responses into a shared schema. 
- Implemented `app/services/metadata/service.py` with Redis cache (`book-metadata:{isbn}`, 24h TTL) and Google→OpenLibrary fallback logic. 
- Extended the worker (`worker/celery_app.py`) to call enrichment during `process_book_image`, create/update `Book` records from metadata, attach `BookImage.book_id`, and mark `Book.processing_status = partial` if enrichment fails; added `retry_book_enrichment` worker task. 
- Exposed a manual retry API `PATCH /api/v1/books/{book_id}/retry-enrichment` which enqueues `worker.celery_app.retry_book_enrichment`, and added `RetryEnrichmentResponse` schema. 
- Updated `worker/requirements.txt` to include `httpx` and added unit tests for metadata clients, cache and worker enrichment behaviors (`backend/tests/test_metadata_services.py`, adjusted `worker/tests/test_celery_app.py`, and added API tests for the retry endpoint in `backend/tests/test_books.py`).

### Testing
- Static checks and byte-compile: ran `ruff check` and `python -m py_compile` over modified files and they passed. 
- Backend metadata unit tests: ran `cd backend && pytest tests/test_metadata_services.py -q` and all tests passed (4 passed, 1 warning). 
- Attempted combined worker + backend test run triggered test collection error in the current local environment due to missing native `numpy` in the root test environment; this is an environment issue (worker tests expect worker deps) and not a code failure. 
- Note: CI should run the full suite (backend + worker) in the appropriate environments where `worker/requirements.txt` is installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba739cee2c8325ace239becd7f40a8)