### PR TITLE
feat: phase 10 observability — structured logging and Prometheus metrics

### DIFF
--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,6 +12,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
 
 
 async def get_current_user(
+    request: Request,
     token: str = Depends(oauth2_scheme),
     session: AsyncSession = Depends(get_db_session),
 ) -> User:
@@ -36,4 +37,5 @@ async def get_current_user(
     if user is None:
         raise credentials_exception
 
+    request.state.user_id = str(user.id)
     return user

--- a/backend/app/api/metrics.py
+++ b/backend/app/api/metrics.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.metrics import BOOK_PROCESSING_JOBS_TOTAL, render_metrics
+from app.db.session import get_db_session
+from app.models.book import Book, BookProcessingStatus
+
+router = APIRouter(tags=["metrics"])
+
+
+@router.get("/metrics", include_in_schema=False)
+async def metrics(session: AsyncSession = Depends(get_db_session)) -> Response:
+    statuses = [
+        BookProcessingStatus.DONE.value,
+        BookProcessingStatus.FAILED.value,
+        BookProcessingStatus.PARTIAL.value,
+    ]
+
+    for status in statuses:
+        result = await session.execute(select(func.count()).select_from(Book).where(Book.processing_status == status))
+        count = int(result.scalar_one())
+        BOOK_PROCESSING_JOBS_TOTAL.labels(status=status).set(count)
+
+    payload, content_type = render_metrics()
+    return Response(content=payload, media_type=content_type)

--- a/backend/app/cli/seed_admin.py
+++ b/backend/app/cli/seed_admin.py
@@ -1,8 +1,14 @@
 import asyncio
 
+import structlog
+
 from app.core.config import get_settings
+from app.core.logging import configure_structlog
 from app.db.session import SessionLocal
 from app.services.user_seed import seed_admin_user
+
+configure_structlog(service="backend")
+logger = structlog.get_logger()
 
 
 async def main() -> None:
@@ -13,7 +19,7 @@ async def main() -> None:
     async with SessionLocal() as session:
         created = await seed_admin_user(session, settings.admin_email, settings.admin_password)
 
-    print("Admin user created." if created else "Admin user already exists.")
+    logger.info("admin_seed_cli_result", created=created, email=settings.admin_email)
 
 
 if __name__ == "__main__":

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+import sys
+
+import structlog
+
+
+def configure_structlog(service: str) -> None:
+    timestamper = structlog.processors.TimeStamper(fmt="iso", key="timestamp")
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.add_log_level,
+            timestamper,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stdout),
+        cache_logger_on_first_use=True,
+    )
+    structlog.contextvars.bind_contextvars(service=service)

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from time import perf_counter
+
+from fastapi import Request
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
+
+HTTP_REQUESTS_TOTAL = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    labelnames=("method", "endpoint", "status"),
+)
+BOOK_PROCESSING_JOBS_TOTAL = Gauge(
+    "book_processing_jobs_total",
+    "Book processing jobs by status",
+    labelnames=("status",),
+)
+EXTERNAL_API_CALLS_TOTAL = Counter(
+    "external_api_calls_total",
+    "External metadata API calls by provider",
+    labelnames=("provider",),
+)
+EXTERNAL_API_LATENCY_SECONDS = Histogram(
+    "external_api_latency_seconds",
+    "External metadata API latency",
+    labelnames=("provider",),
+)
+
+
+def endpoint_label(request: Request) -> str:
+    route = request.scope.get("route")
+    if route is not None and hasattr(route, "path"):
+        return str(route.path)
+    return request.url.path
+
+
+def record_http_request(request: Request, status_code: int) -> None:
+    HTTP_REQUESTS_TOTAL.labels(
+        method=request.method,
+        endpoint=endpoint_label(request),
+        status=str(status_code),
+    ).inc()
+
+
+def observe_external_api_latency(provider: str, start_time: float) -> None:
+    EXTERNAL_API_LATENCY_SECONDS.labels(provider=provider).observe(perf_counter() - start_time)
+
+
+def render_metrics() -> tuple[bytes, str]:
+    return generate_latest(), CONTENT_TYPE_LATEST

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from anyio import to_thread
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.responses import Response
 import structlog
 
 from app.api.auth import router as auth_router
@@ -11,11 +15,15 @@ from app.api.books import router as books_router
 from app.api.health import router as health_router
 from app.api.jobs import router as jobs_router
 from app.api.locations import router as locations_router
+from app.api.metrics import router as metrics_router
 from app.core.config import get_settings
+from app.core.logging import configure_structlog
+from app.core.metrics import record_http_request
 from app.db.session import SessionLocal
 from app.services.storage import ensure_bucket_exists
 from app.services.user_seed import seed_admin_user
 
+configure_structlog(service="backend")
 logger = structlog.get_logger()
 
 
@@ -41,6 +49,33 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 def create_app() -> FastAPI:
     settings = get_settings()
     app = FastAPI(title=settings.app_name, lifespan=lifespan)
+
+    @app.middleware("http")
+    async def observability_middleware(request: Request, call_next) -> Response:  # type: ignore[no-untyped-def]
+        request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
+
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(request_id=request_id, user_id=None, service="backend")
+
+        response: Response | None = None
+        try:
+            response = await call_next(request)
+            user_id = getattr(request.state, "user_id", None)
+            structlog.contextvars.bind_contextvars(user_id=user_id)
+            return response
+        finally:
+            status_code = response.status_code if response is not None else 500
+            if response is not None:
+                response.headers["x-request-id"] = request_id
+            record_http_request(request, status_code=status_code)
+            logger.info(
+                "http_request",
+                method=request.method,
+                endpoint=request.url.path,
+                status=status_code,
+            )
+            structlog.contextvars.clear_contextvars()
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.cors_allowed_origins,
@@ -49,6 +84,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     app.include_router(health_router)
+    app.include_router(metrics_router)
     app.include_router(auth_router)
     app.include_router(locations_router)
     app.include_router(books_router)

--- a/backend/app/services/metadata/service.py
+++ b/backend/app/services/metadata/service.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import json
+from time import perf_counter
 
 import httpx
 from redis import asyncio as redis_async
+import structlog
 
 from app.core.config import get_settings
+from app.core.metrics import EXTERNAL_API_CALLS_TOTAL, observe_external_api_latency
 from app.services.metadata.google_books import fetch_google_books_metadata
 from app.services.metadata.open_library import fetch_open_library_metadata
 
 CACHE_TTL_SECONDS = 24 * 60 * 60
+logger = structlog.get_logger()
 
 
 async def enrich_metadata_with_fallback(isbn: str) -> dict[str, object] | None:
@@ -23,16 +27,28 @@ async def enrich_metadata_with_fallback(isbn: str) -> dict[str, object] | None:
             result: dict[str, object] = json.loads(cached)
             return result
 
+        metadata: dict[str, object] | None = None
         async with httpx.AsyncClient() as client:
+            google_start = perf_counter()
             try:
+                EXTERNAL_API_CALLS_TOTAL.labels(provider="google_books").inc()
                 metadata = await fetch_google_books_metadata(client, isbn)
-            except Exception:
+            except Exception as exc:
+                logger.warning("google_books_lookup_failed", isbn=isbn, error=str(exc))
                 metadata = None
+            finally:
+                observe_external_api_latency("google_books", google_start)
+
             if metadata is None:
+                open_library_start = perf_counter()
                 try:
+                    EXTERNAL_API_CALLS_TOTAL.labels(provider="open_library").inc()
                     metadata = await fetch_open_library_metadata(client, isbn)
-                except Exception:
+                except Exception as exc:
+                    logger.warning("open_library_lookup_failed", isbn=isbn, error=str(exc))
                     metadata = None
+                finally:
+                    observe_external_api_latency("open_library", open_library_start)
 
         if metadata is None:
             return None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ structlog==24.4.0
 celery==5.6.0
 boto3==1.35.36
 python-multipart==0.0.22
+prometheus-client==0.22.1

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -5,6 +5,7 @@ from httpx import ASGITransport, AsyncClient
 import pytest
 
 from app.api.health import check_database, check_redis
+from app.db.session import get_db_session
 from app.main import app
 
 
@@ -120,3 +121,41 @@ async def test_check_redis_pings_and_closes_client(monkeypatch: pytest.MonkeyPat
 
     assert pinged is True
     assert closed is True
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_returns_prometheus_payload() -> None:
+    class _FakeResult:
+        def scalar_one(self) -> int:
+            return 0
+
+    class _FakeSession:
+        async def execute(self, _statement: object) -> _FakeResult:
+            return _FakeResult()
+
+    async def _override_session():
+        yield _FakeSession()
+
+    app.dependency_overrides[get_db_session] = _override_session
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/metrics")
+    finally:
+        app.dependency_overrides.pop(get_db_session, None)
+
+    assert response.status_code == 200
+    assert "http_requests_total" in response.text
+    assert "book_processing_jobs_total" in response.text
+    assert "external_api_calls_total" in response.text
+    assert "external_api_latency_seconds" in response.text
+
+
+@pytest.mark.asyncio
+async def test_request_logging_contains_request_id(capsys: pytest.CaptureFixture[str]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/health", headers={"x-request-id": "req-123"})
+
+    assert response.status_code == 200
+    captured = capsys.readouterr().out
+    assert "\"event\": \"http_request\"" in captured
+    assert "\"request_id\": \"req-123\"" in captured

--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -8,11 +8,13 @@ import json
 import os
 import re
 import uuid
+from time import perf_counter
+
+import structlog
 
 import boto3
 from celery import Celery
 from celery.exceptions import Retry
-from celery.utils.log import get_task_logger
 import cv2
 import httpx
 import numpy as np
@@ -27,7 +29,24 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 
 CACHE_TTL_SECONDS = 24 * 60 * 60
-logger = get_task_logger(__name__)
+
+
+def _configure_structlog() -> None:
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", key="timestamp"),
+            structlog.processors.JSONRenderer(),
+        ],
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+    structlog.contextvars.bind_contextvars(service="worker")
+
+
+_configure_structlog()
+logger = structlog.get_logger()
 
 
 class Base(DeclarativeBase):
@@ -297,14 +316,18 @@ def _cache_key(isbn: str) -> str:
 
 
 async def _fetch_google_books_metadata(isbn: str) -> dict[str, object] | None:
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            "https://www.googleapis.com/books/v1/volumes",
-            params={"q": f"isbn:{isbn}", "maxResults": 1},
-            timeout=10.0,
-        )
-        response.raise_for_status()
-        payload = response.json()
+    start = perf_counter()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "https://www.googleapis.com/books/v1/volumes",
+                params={"q": f"isbn:{isbn}", "maxResults": 1},
+                timeout=10.0,
+            )
+            response.raise_for_status()
+            payload = response.json()
+    finally:
+        logger.info("external_api_call", provider="google_books", isbn=isbn, processing_step="metadata_lookup", latency_seconds=perf_counter() - start)
 
     items = payload.get("items")
     if not items:
@@ -330,14 +353,18 @@ async def _fetch_google_books_metadata(isbn: str) -> dict[str, object] | None:
 
 async def _fetch_open_library_metadata(isbn: str) -> dict[str, object] | None:
     bib_key = f"ISBN:{isbn}"
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            "https://openlibrary.org/api/books",
-            params={"bibkeys": bib_key, "format": "json", "jscmd": "data"},
-            timeout=10.0,
-        )
-        response.raise_for_status()
-        payload = response.json()
+    start = perf_counter()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "https://openlibrary.org/api/books",
+                params={"bibkeys": bib_key, "format": "json", "jscmd": "data"},
+                timeout=10.0,
+            )
+            response.raise_for_status()
+            payload = response.json()
+    finally:
+        logger.info("external_api_call", provider="open_library", isbn=isbn, processing_step="metadata_lookup", latency_seconds=perf_counter() - start)
 
     book_data = payload.get(bib_key)
     if not book_data:
@@ -464,7 +491,10 @@ def _mark_book_partial(book_id: str, message: str) -> None:
     max_retries=3,
 )
 def process_book_image(self, job_id: str) -> None:
+    structlog.contextvars.clear_contextvars()
+    structlog.contextvars.bind_contextvars(service="worker", job_id=job_id, isbn=None, processing_step="job_processing")
     try:
+        logger.info("process_book_image_started")
         with Session(_get_engine()) as session:
             job = session.get(ProcessingJob, uuid.UUID(job_id))
             if job is None:
@@ -491,10 +521,11 @@ def process_book_image(self, job_id: str) -> None:
             isbn = local_result.get("isbn")
             metadata: dict[str, object] | None = None
             if isinstance(isbn, str):
+                structlog.contextvars.bind_contextvars(isbn=isbn, processing_step="metadata_enrichment")
                 metadata = asyncio.run(_enrich_metadata_with_fallback(isbn))
 
             if isinstance(isbn, str) and metadata is None:
-                logger.warning("metadata_enrichment_partial job_id=%s isbn=%s", job_id, isbn)
+                logger.warning("metadata_enrichment_partial", job_id=job_id, isbn=isbn, processing_step="metadata_enrichment")
 
             book = _upsert_book_from_metadata(session, image, local_result, metadata)
 
@@ -507,11 +538,14 @@ def process_book_image(self, job_id: str) -> None:
             job.result_json = result_json
             job.error_message = None
             session.commit()
+            processing_result = "partial" if metadata is None else "success"
+            logger.info("process_book_image_completed", job_id=job_id, isbn=isbn, processing_step="job_complete", status=processing_result)
     except Retry:
         raise
     except (exc.OperationalError, exc.InterfaceError):
         raise
     except Exception as error:
+        logger.exception("process_book_image_failed", job_id=job_id, processing_step="job_processing", error=str(error))
         _mark_failed(job_id, str(error))
         raise
 
@@ -526,7 +560,10 @@ def process_book_image(self, job_id: str) -> None:
     max_retries=3,
 )
 def retry_book_enrichment(self, book_id: str) -> None:
+    structlog.contextvars.clear_contextvars()
+    structlog.contextvars.bind_contextvars(service="worker", job_id=book_id, isbn=None, processing_step="retry_enrichment")
     try:
+        logger.info("retry_book_enrichment_started")
         with Session(_get_engine()) as session:
             book = session.get(Book, uuid.UUID(book_id))
             if book is None:
@@ -538,6 +575,7 @@ def retry_book_enrichment(self, book_id: str) -> None:
             metadata = asyncio.run(_enrich_metadata_with_fallback(book.isbn))
             if metadata is None:
                 _mark_book_partial(book_id, "Retry enrichment failed for all providers")
+                logger.warning("retry_book_enrichment_partial", job_id=book_id, processing_step="retry_enrichment")
                 return
 
             book.title = metadata.get("title") if isinstance(metadata.get("title"), str) else book.title
@@ -549,10 +587,12 @@ def retry_book_enrichment(self, book_id: str) -> None:
             book.cover_image_url = metadata.get("cover_image_url") if isinstance(metadata.get("cover_image_url"), str) else book.cover_image_url
             book.processing_status = BookProcessingStatus.DONE
             session.commit()
+            logger.info("retry_book_enrichment_completed", job_id=book_id, isbn=book.isbn, processing_step="retry_enrichment")
     except Retry:
         raise
     except (exc.OperationalError, exc.InterfaceError):
         raise
-    except Exception:
+    except Exception as error:
+        logger.exception("retry_enrichment_failed", job_id=book_id, processing_step="retry_enrichment", error=str(error))
         _mark_book_partial(book_id, "Retry enrichment failed")
         raise

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -8,3 +8,4 @@ pyzbar==0.1.9
 pytesseract==0.3.13
 numpy==2.2.3
 httpx==0.28.1
+structlog==24.4.0

--- a/worker/tests/test_celery_app.py
+++ b/worker/tests/test_celery_app.py
@@ -229,3 +229,78 @@ def test_both_providers_failing_sets_partial_and_creates_book(monkeypatch) -> No
     assert fake_book_image.book_id == fake_book.id
     assert len(added_books) == 1
     assert added_books[0].processing_status == celery_app.BookProcessingStatus.PARTIAL
+
+
+def test_worker_logs_include_job_id(monkeypatch, capsys) -> None:
+    job_id = uuid.uuid4()
+    book_image_id = uuid.uuid4()
+
+    class FakeJob:
+        def __init__(self) -> None:
+            self.id = job_id
+            self.book_image_id = book_image_id
+            self.status = celery_app.ProcessingJobStatus.PENDING
+            self.result_json = None
+            self.error_message = None
+            self.attempts = 0
+
+    class FakeBookImage:
+        def __init__(self) -> None:
+            self.id = book_image_id
+            self.minio_path = "uploads/test.jpg"
+            self.book_id = None
+
+    class FakeResult:
+        def scalar_one_or_none(self):
+            return None
+
+    class FakeSession:
+        def __init__(self, _engine) -> None:
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def get(self, model, identifier):
+            if model is celery_app.ProcessingJob and identifier == job_id:
+                return FakeJob()
+            if model is celery_app.BookImage and identifier == book_image_id:
+                return FakeBookImage()
+            return None
+
+        def execute(self, _query):
+            return FakeResult()
+
+        def add(self, _obj) -> None:
+            return None
+
+        def flush(self) -> None:
+            return None
+
+        def commit(self) -> None:
+            return None
+
+    monkeypatch.setattr(celery_app, "Session", FakeSession)
+    monkeypatch.setattr(celery_app, "_get_engine", lambda: object())
+    monkeypatch.setattr(celery_app, "_download_image_bytes", lambda _path: b"image")
+    monkeypatch.setattr(
+        celery_app,
+        "_extract_metadata",
+        lambda _bytes: (
+            {"isbn": "9780306406157", "title": "Fallback title", "author": "Fallback author", "source": "ocr"},
+            celery_app.ProcessingJobStatus.DONE,
+            None,
+        ),
+    )
+    async def _metadata(_isbn):
+        return None
+
+    monkeypatch.setattr(celery_app, "_enrich_metadata_with_fallback", _metadata)
+
+    celery_app.process_book_image.run(job_id=str(job_id))
+
+    output = capsys.readouterr().out
+    assert "\"job_id\": \"" + str(job_id) + "\"" in output


### PR DESCRIPTION
### Motivation
- Implement Phase 10 observability deliverables: structured JSON logging with request/task context and a Prometheus `/metrics` scrape endpoint to allow scraping and alerting.
- Ensure logs include required context (`timestamp`, `service`, `request_id`/`job_id`, `user_id` when available) and record key metrics for HTTP requests and external metadata calls.

### Description
- Added structured logging configuration and initialization via `backend/app/core/logging.py` and enabled it in the API (`backend/app/main.py`) and CLI (`backend/app/cli/seed_admin.py`).
- Introduced Prometheus metrics and helpers in `backend/app/core/metrics.py` and exposed a scrape endpoint at `GET /metrics` (`backend/app/api/metrics.py`) which exports `http_requests_total`, `book_processing_jobs_total`, `external_api_calls_total`, and `external_api_latency_seconds`.
- Wired an observability HTTP middleware in `backend/app/main.py` to bind `request_id` and `user_id` into structlog context, emit a structured `http_request` log per request, and increment `http_requests_total` with method/endpoint/status labels.
- Instrumented metadata enrichment to count external API calls and observe latency in `backend/app/services/metadata/service.py`, and updated worker task code (`worker/celery_app.py`) to use structlog with per-task context (`job_id`, `isbn`, `processing_step`) plus task start/complete/error logs and external-call latency logs.
- Updated auth dependency to propagate `user_id` into request state for logging in `backend/app/api/dependencies/auth.py`, replaced CLI `print()` with structured log in `backend/app/cli/seed_admin.py`, added tests exercising `/metrics` and request/task logging (`backend/tests/test_health.py`, `worker/tests/test_celery_app.py`), and added runtime deps (`prometheus-client` in backend requirements and `structlog` in worker requirements).

### Testing
- Ran static checks: `cd backend && ruff check app tests` — passed.
- Ran type checks: `cd backend && mypy app` — passed.
- Ran backend tests: `cd backend && pytest tests/test_health.py -q` — failed during collection due to missing runtime `prometheus_client` in the test environment (ModuleNotFoundError); the dependency was added to `backend/requirements.txt` to address this.
- Ran worker tests: `cd worker && pytest tests/test_celery_app.py -q` — failed during collection due to missing runtime `numpy` in the test environment; worker requirements already list `numpy` / heavy runtime deps (worker tests require installing `worker/requirements.txt`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9296d36083258eca0c1a0c9fd26c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/metrics` endpoint for Prometheus monitoring (HTTP requests, book processing jobs, external API calls).
  * Implemented structured logging with service context and request ID tracking.
  * Added optional admin account auto-seeding on startup.
  * Enhanced request observability with automatic logging and metrics recording.

* **Tests**
  * Added metrics endpoint integration tests.
  * Added request logging verification tests.

* **Chores**
  * Added prometheus-client and structlog dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->