### PR TITLE
fix: secure Traefik dashboard and harden swarm stack config

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,7 +47,7 @@ docker push "$REGISTRY/shelfy-worker:$TAG"
 
 ## 3) Create Docker secrets
 
-Create local files in a temporary directory (avoid writing secrets in the repo checkout):
+Create local files in a temporary directory (avoid writing secrets in the repo checkout). Ensure `htpasswd` is installed (`apache2-utils` on Debian/Ubuntu or `httpd-tools` on RHEL/Fedora):
 
 ```bash
 SECRETS_DIR="$(mktemp -d)"
@@ -57,6 +57,7 @@ openssl rand -base64 32 > "$SECRETS_DIR/postgres_password.txt"
 openssl rand -base64 32 > "$SECRETS_DIR/redis_password.txt"
 openssl rand -base64 32 > "$SECRETS_DIR/minio_root_password.txt"
 openssl rand -base64 64 > "$SECRETS_DIR/jwt_secret_key.txt"
+htpasswd -nB admin > "$SECRETS_DIR/traefik_dashboard_auth.txt"
 printf 'admin@example.com' > "$SECRETS_DIR/admin_email.txt"
 printf 'change-this-admin-password' > "$SECRETS_DIR/admin_password.txt"
 ```
@@ -68,6 +69,7 @@ docker secret create postgres_password "$SECRETS_DIR/postgres_password.txt"
 docker secret create redis_password "$SECRETS_DIR/redis_password.txt"
 docker secret create minio_root_password "$SECRETS_DIR/minio_root_password.txt"
 docker secret create jwt_secret_key "$SECRETS_DIR/jwt_secret_key.txt"
+docker secret create traefik_dashboard_auth "$SECRETS_DIR/traefik_dashboard_auth.txt"
 docker secret create admin_email "$SECRETS_DIR/admin_email.txt"
 docker secret create admin_password "$SECRETS_DIR/admin_password.txt"
 ```
@@ -99,8 +101,10 @@ export POSTGRES_USER=shelfy
 export MINIO_ROOT_USER=minioadmin
 export MINIO_BUCKET=shelfy-images
 export MINIO_REGION=us-east-1
-# export CORS_ALLOWED_ORIGINS='["https://library.example.com"]'
 ```
+
+**Optional:** To override allowed CORS origins:
+`CORS_ALLOWED_ORIGINS='["https://library.example.com"]'`
 
 ## 5) Deploy the stack
 

--- a/infra/swarm-stack.yml
+++ b/infra/swarm-stack.yml
@@ -8,6 +8,8 @@ services:
       - --providers.swarm.exposedbydefault=false
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
       - --certificatesresolvers.letsencrypt.acme.tlschallenge=true
       - --certificatesresolvers.letsencrypt.acme.email=${TRAEFIK_ACME_EMAIL:?TRAEFIK_ACME_EMAIL is required}
       - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
@@ -24,6 +26,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik_letsencrypt:/letsencrypt
+    secrets:
+      - traefik_dashboard_auth
     networks:
       - public
     deploy:
@@ -35,6 +39,8 @@ services:
         - traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DASHBOARD_HOST}`)
         - traefik.http.routers.traefik.entrypoints=websecure
         - traefik.http.routers.traefik.tls.certresolver=letsencrypt
+        - traefik.http.middlewares.dashboard-auth.basicauth.usersfile=/run/secrets/traefik_dashboard_auth
+        - traefik.http.routers.traefik.middlewares=dashboard-auth
         - traefik.http.routers.traefik.service=api@internal
 
   postgres:
@@ -70,7 +76,7 @@ services:
         condition: on-failure
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1
     command:
       - /bin/sh
       - -ec
@@ -209,4 +215,6 @@ secrets:
   admin_email:
     external: true
   admin_password:
+    external: true
+  traefik_dashboard_auth:
     external: true


### PR DESCRIPTION
### Motivation
- Address remaining review findings from the Phase 12 deployment PR by removing an unprotected Traefik dashboard, hardening ingress behavior, and reducing deployment drift for MinIO.
- Update the deployment runbook so operators can create the required secrets (including dashboard auth) and understand optional CORS overrides.

### Description
- Added a new external Swarm secret `traefik_dashboard_auth` to `infra/swarm-stack.yml` and mounted it into the `traefik` service so credentials are read from `/run/secrets/traefik_dashboard_auth`.
- Configured a Traefik Basic Auth middleware (`traefik.http.middlewares.dashboard-auth.basicauth.usersfile`) and attached it to the dashboard router via labels in `infra/swarm-stack.yml`.
- Enabled HTTP→HTTPS redirect on the Traefik `web` entrypoint by adding `--entrypoints.web.http.redirections.entrypoint.to=websecure` and `--entrypoints.web.http.redirections.entrypoint.scheme=https` to the Traefik command flags in `infra/swarm-stack.yml`.
- Replaced the floating `minio/minio:latest` image with a pinned release tag in `infra/swarm-stack.yml` to avoid unexpected breaking changes.
- Updated `docs/deployment.md` to document the `htpasswd` prerequisite, add the `htpasswd` generation step and `docker secret create traefik_dashboard_auth ...` command, and replace the commented CORS example with an explicit optional CORS example.

### Testing
- Ran backend static checks: `cd backend && ruff check app tests` succeeded.
- Ran backend type checks: `cd backend && mypy app tests` succeeded.
- Attempted backend tests with coverage (`TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`) but the `--cov` options were unrecognized in this environment, so coverage-run failed due to test runner configuration rather than code changes.
- Ran frontend checks: `cd frontend && npm run lint` succeeded and `cd frontend && npm test -- --run` (Vitest) passed all tests.
- Attempted to validate stack render with `docker compose -f infra/swarm-stack.yml config` but the Docker CLI was not available in the execution environment (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bafa3f1c8c83258918922d57a63c0c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Infrastructure**
  * Enabled Traefik dashboard authentication for enhanced security
  * Added automatic HTTP to HTTPS redirection
  * Updated MinIO to a specific production-ready release version

* **Documentation**
  * Improved deployment guide with clearer CORS configuration examples
  * Enhanced secret setup instructions with htpasswd requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->