### PR TITLE
chore: switch MinIO images to bitnami/minio

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "6379:6379"
 
   minio:
-    image: minio/minio:latest
+    image: bitnami/minio:latest
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}

--- a/infra/swarm-stack.yml
+++ b/infra/swarm-stack.yml
@@ -76,7 +76,7 @@ services:
         condition: on-failure
 
   minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1
+    image: bitnami/minio:latest
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
### Motivation
- Replace the MinIO image vendor in infra manifests per issue #63 (Phase 12) to use the Bitnami-provided image.

### Description
- Updated `infra/docker-compose.yml` and `infra/swarm-stack.yml` to use `bitnami/minio:latest` instead of `minio/minio:latest` and the pinned `minio` release tag, while keeping the existing `minio` command, environment wiring, healthchecks, and Traefik labels unchanged.

### Testing
- Ran `cd backend && ruff check app tests` and `cd backend && mypy app tests`, both succeeded. 
- Ran frontend checks `cd frontend && npm run lint` and `cd frontend && npm test -- --run`, both succeeded. 
- `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests` could not run with coverage flags in this environment (pytest reported unrecognized cov options). 
- Docker Compose/Swarm config validation could not be executed here because the `docker` CLI is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb8bede7c48325b1c75df4336c0290)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MinIO container image configuration across deployment environments to use an alternative image source for improved compatibility and ongoing maintenance support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->