### PR TITLE
fix: resolve deploy blockers, migration failures, and admin seed CLI issues

### DIFF
--- a/backend/alembic/versions/20260910_000003_create_books_table.py
+++ b/backend/alembic/versions/20260910_000003_create_books_table.py
@@ -9,6 +9,7 @@ from typing import Sequence
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "20260910_000003"
@@ -17,7 +18,7 @@ branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 
 
-book_processing_status = sa.Enum(
+book_processing_status = postgresql.ENUM(
     "manual",
     "pending",
     "done",
@@ -65,7 +66,7 @@ def upgrade() -> None:
         op.create_index(
             "ix_books_search_vector",
             "books",
-            [sa.text("to_tsvector('simple', concat_ws(' ', title, coalesce(author, '')))")],
+            [sa.text("to_tsvector('simple'::regconfig, (coalesce(title, '') || ' ' || coalesce(author, ''))::text)")],
             postgresql_using="gin",
         )
 

--- a/backend/alembic/versions/20260910_000003_create_books_table.py
+++ b/backend/alembic/versions/20260910_000003_create_books_table.py
@@ -9,6 +9,7 @@ from typing import Sequence
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import cast, column, func, literal, literal_column
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
@@ -66,7 +67,17 @@ def upgrade() -> None:
         op.create_index(
             "ix_books_search_vector",
             "books",
-            [sa.text("to_tsvector('simple'::regconfig, (coalesce(title, '') || ' ' || coalesce(author, ''))::text)")],
+            [
+                func.to_tsvector(
+                    literal_column("'simple'::regconfig"),
+                    cast(
+                        func.coalesce(column("title"), "")
+                        + literal(" ")
+                        + func.coalesce(column("author"), ""),
+                        sa.Text(),
+                    ),
+                )
+            ],
             postgresql_using="gin",
         )
 

--- a/backend/app/cli/seed_admin.py
+++ b/backend/app/cli/seed_admin.py
@@ -14,8 +14,11 @@ logger = structlog.get_logger()
 async def main() -> None:
     settings = get_settings()
     if settings.admin_email is None or settings.admin_password is None:
-        print("Error: ADMIN_EMAIL and ADMIN_PASSWORD environment variables must be set.")
-        print("Example: ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=secret python -m app.cli.seed_admin")
+        logger.error(
+            "admin_seed_cli_missing_env",
+            message="ADMIN_EMAIL and ADMIN_PASSWORD environment variables must be set.",
+            example="ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=secret python -m app.cli.seed_admin",
+        )
         raise SystemExit(1)
 
     async with SessionLocal() as session:

--- a/backend/app/cli/seed_admin.py
+++ b/backend/app/cli/seed_admin.py
@@ -14,7 +14,9 @@ logger = structlog.get_logger()
 async def main() -> None:
     settings = get_settings()
     if settings.admin_email is None or settings.admin_password is None:
-        raise RuntimeError("ADMIN_EMAIL and ADMIN_PASSWORD must be set")
+        print("Error: ADMIN_EMAIL and ADMIN_PASSWORD environment variables must be set.")
+        print("Example: ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=secret python -m app.cli.seed_admin")
+        raise SystemExit(1)
 
     async with SessionLocal() as session:
         created = await seed_admin_user(session, settings.admin_email, settings.admin_password)

--- a/backend/app/services/user_seed.py
+++ b/backend/app/services/user_seed.py
@@ -11,11 +11,12 @@ logger = structlog.get_logger()
 async def seed_admin_user(session: AsyncSession, email: str, password: str) -> bool:
     existing_user = await get_user_by_email(session, email)
     if existing_user is not None:
-        logger.info("admin_user_exists", email=email, user_id=str(existing_user.id))
+        logger.info("admin_user_exists", user_id=str(existing_user.id))
         return False
 
     user = User(email=email, hashed_password=get_password_hash(password))
     session.add(user)
     await session.commit()
-    logger.info("admin_user_created", email=email, user_id=str(user.id))
+    await session.refresh(user)
+    logger.info("admin_user_created", user_id=str(user.id))
     return True

--- a/backend/tests/test_seed_admin_cli.py
+++ b/backend/tests/test_seed_admin_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
+from typing import Any
 
 import pytest
 
@@ -25,7 +26,12 @@ async def test_seed_admin_cli_calls_seed_and_logs(monkeypatch: pytest.MonkeyPatc
         async def __aenter__(self) -> "DummySession":
             return self
 
-        async def __aexit__(self, exc_type, exc, tb) -> None:
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
             return None
 
     monkeypatch.setattr(
@@ -37,7 +43,7 @@ async def test_seed_admin_cli_calls_seed_and_logs(monkeypatch: pytest.MonkeyPatc
 
     called: dict[str, object] = {}
 
-    async def fake_seed(session, email: str, password: str) -> bool:
+    async def fake_seed(session: Any, email: str, password: str) -> bool:
         called["email"] = email
         called["password"] = password
         return True

--- a/backend/tests/test_seed_admin_cli.py
+++ b/backend/tests/test_seed_admin_cli.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.cli import seed_admin
+
+
+@pytest.mark.asyncio
+async def test_seed_admin_cli_exits_with_help_when_env_missing(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(seed_admin, "get_settings", lambda: SimpleNamespace(admin_email=None, admin_password=None))
+
+    with pytest.raises(SystemExit) as exc:
+        await seed_admin.main()
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "ADMIN_EMAIL and ADMIN_PASSWORD" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_seed_admin_cli_calls_seed_and_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummySession:
+        async def __aenter__(self) -> "DummySession":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr(
+        seed_admin,
+        "get_settings",
+        lambda: SimpleNamespace(admin_email="admin@example.com", admin_password="secret"),
+    )
+    monkeypatch.setattr(seed_admin, "SessionLocal", lambda: DummySession())
+
+    called: dict[str, object] = {}
+
+    async def fake_seed(session, email: str, password: str) -> bool:
+        called["email"] = email
+        called["password"] = password
+        return True
+
+    monkeypatch.setattr(seed_admin, "seed_admin_user", fake_seed)
+
+    await seed_admin.main()
+
+    assert called == {"email": "admin@example.com", "password": "secret"}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "6379:6379"
 
   minio:
-    image: bitnami/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}

--- a/infra/swarm-stack.yml
+++ b/infra/swarm-stack.yml
@@ -76,7 +76,7 @@ services:
         condition: on-failure
 
   minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     command:
       - /bin/sh
       - -ec

--- a/infra/swarm-stack.yml
+++ b/infra/swarm-stack.yml
@@ -76,7 +76,7 @@ services:
         condition: on-failure
 
   minio:
-    image: bitnami/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
## Summary
This PR fixes issues #65, #66, #67, and #68 in one pass:

- replaces invalid MinIO image reference in infra manifests with a valid pinned image tag
- fixes Alembic migration `20260910_000003` ENUM handling to avoid duplicate type creation
- fixes Alembic GIN index expression to use an IMMUTABLE-safe expression
- hardens admin seed CLI UX and fixes MissingGreenlet in seed service logging
- adds CLI tests for missing env handling and happy path seed invocation

## Changes
### Infra
- `infra/docker-compose.yml`
  - `bitnami/minio:latest` -> `minio/minio:RELEASE.2025-09-07T16-13-09Z`
- `infra/swarm-stack.yml`
  - `bitnami/minio:latest` -> `minio/minio:RELEASE.2025-09-07T16-13-09Z`

### Migration
- `backend/alembic/versions/20260910_000003_create_books_table.py`
  - use `postgresql.ENUM(..., create_type=False)`
  - keep explicit `book_processing_status.create(bind, checkfirst=True)`
  - use IMMUTABLE-safe FTS expression:
    - `to_tsvector('simple'::regconfig, (coalesce(title, '') || ' ' || coalesce(author, ''))::text)`

### Admin seed
- `backend/app/cli/seed_admin.py`
  - replace RuntimeError with clear CLI guidance + `SystemExit(1)` for missing env vars
- `backend/app/services/user_seed.py`
  - avoid logging admin email (PII)
  - add `await session.refresh(user)` after commit before logging `user_id`

### Tests
- `backend/tests/test_seed_admin_cli.py` (new)
  - missing env -> exits with code 1 + helpful message
  - configured env -> seed function is called with expected credentials

## Validation
- `docker compose down -v && docker compose up -d postgres redis minio`
- `alembic downgrade base && alembic upgrade head` (passes)
- `pytest -q tests/test_infra_services.py tests/test_seed_admin_cli.py` (passes)

## Issues
Closes #65
Closes #66
Closes #67
Closes #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin setup now reports missing credentials clearly and exits gracefully.
  * Reduced exposure of admin email in logs.

* **Chores**
  * Updated database migration behavior affecting enum and full-text search setup.
  * Pinned MinIO container images for more stable deployments.

* **Tests**
  * Added tests covering the admin seed CLI flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->