### PR TITLE
fix: prevent MissingGreenlet in image upload task publish

### DIFF
--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -113,6 +113,8 @@ async def upload_book_image(
     _current_user: User = Depends(get_current_user),
 ) -> UploadResponse:
     job, minio_path = await create_upload_job(session, image)
+    job_id = job.id
+    job_status = job.status
 
     try:
         await session.commit()
@@ -122,7 +124,7 @@ async def upload_book_image(
             None,
             lambda: celery_client.send_task(
                 "worker.celery_app.process_book_image",
-                args=[str(job.id)],
+                args=[str(job_id)],
             ),
         )
     except Exception as publish_exc:
@@ -133,7 +135,7 @@ async def upload_book_image(
             pass
         try:
             async with AsyncSession(session.bind) as cleanup_session:
-                orphaned_job = await cleanup_session.get(ProcessingJob, job.id)
+                orphaned_job = await cleanup_session.get(ProcessingJob, job_id)
                 if orphaned_job is not None:
                     orphaned_job.status = ProcessingJobStatus.FAILED
                     orphaned_job.error_message = "Queue unavailable"
@@ -145,4 +147,4 @@ async def upload_book_image(
             detail="Image processing queue is unavailable",
         ) from publish_exc
 
-    return UploadResponse(job_id=job.id, status=job.status)
+    return UploadResponse(job_id=job_id, status=job_status)


### PR DESCRIPTION
## Summary
Fixes issue #71 where image upload returned 503 due `MissingGreenlet` after commit.

## Root cause
`upload_book_image` accessed `job.id` from an expired ORM object inside `run_in_executor` after `await session.commit()`, which can trigger async lazy-load in non-greenlet context.

## Changes
- In `backend/app/api/books.py`:
  - capture `job_id` and `job_status` before commit
  - use captured `job_id` for Celery task publish and cleanup lookup
  - return response from captured values instead of expired ORM object attributes

## Validation
- `pytest -q tests/test_jobs.py` passed
- Manual API retest on homelab2:
  - before fix: `POST /api/v1/books/upload` -> 503
  - after fix: `POST /api/v1/books/upload` -> 202 with `job_id`

Closes #71


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency in book image upload handling with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->