### PR TITLE
fix: correct multi-spine upsert to avoid single-book reuse

### DIFF
--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -605,10 +605,8 @@ def _upsert_book_from_metadata(
     metadata_or_empty = metadata or {}
 
     book: Book | None = None
-    if book_image.book_id is not None:
-        book = session.get(Book, book_image.book_id)
 
-    if book is None and isbn:
+    if isbn:
         book = session.execute(select(Book).where(Book.isbn == isbn)).scalar_one_or_none()
 
     if book is None:


### PR DESCRIPTION
## Summary
Fixes #79: multi-spine processing could reuse the same `book_id` for all detected entries.

## Root cause
`_upsert_book_from_metadata` prioritized `book_image.book_id` lookup. In multi-spine flow all entries share the same image, so later entries reused the already-linked book.

## Change
- In `worker/celery_app.py`, remove `book_image.book_id` reuse as the first lookup path.
- Keep ISBN-first dedupe behavior unchanged.

## Impact
Each detected spine result now upserts independently (except intentional dedupe by ISBN).

Closes #79


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved book identification logic to prioritize ISBN-based matching, enhancing data consistency and deduplication when processing book metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->