### PR TITLE
feat: ship redesigned frontend UI with delete action

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,38 +1,49 @@
-import { Link, Route, Routes } from 'react-router-dom'
-
+import { Route, Routes, useLocation } from 'react-router-dom'
 import { ErrorToast } from './components/ErrorToast'
 import { ProtectedRoute } from './components/ProtectedRoute'
+import { BottomNav } from './components/BottomNav'
 import { ROUTES } from './lib/routes'
 import { BookDetailPage } from './pages/BookDetailPage'
 import { BooksPage } from './pages/BooksPage'
 import { HomePage } from './pages/HomePage'
 import { LocationsPage } from './pages/LocationsPage'
 import { LoginPage } from './pages/LoginPage'
+import { AddBookPage } from './pages/AddBookPage'
 
 export { ROUTES }
 
-export function App() {
+function AppShell() {
+  const location = useLocation()
+  const hideNav = location.pathname === ROUTES.login
+
   return (
-    <main style={{ fontFamily: 'sans-serif', margin: '2rem auto', maxWidth: 860 }}>
-      <h1>Shelfy</h1>
-      <nav style={{ display: 'flex', gap: '1rem' }}>
-        <Link to={ROUTES.home}>Home</Link>
-        <Link to={ROUTES.books}>Books</Link>
-        <Link to={ROUTES.locations}>Locations</Link>
-        <Link to={ROUTES.login}>Login</Link>
-      </nav>
-
-      <Routes>
-        <Route path={ROUTES.login} element={<LoginPage />} />
-        <Route element={<ProtectedRoute />}>
-          <Route path={ROUTES.home} element={<HomePage />} />
-          <Route path={ROUTES.books} element={<BooksPage />} />
-          <Route path={ROUTES.bookDetail} element={<BookDetailPage />} />
-          <Route path={ROUTES.locations} element={<LocationsPage />} />
-        </Route>
-      </Routes>
-
+    <div style={{
+      maxWidth: 480,
+      margin: '0 auto',
+      minHeight: '100dvh',
+      background: 'white',
+      position: 'relative',
+      display: 'flex',
+      flexDirection: 'column',
+    }}>
+      <div style={{ flex: 1, overflowY: 'auto', paddingBottom: hideNav ? 0 : 80 }}>
+        <Routes>
+          <Route path={ROUTES.login} element={<LoginPage />} />
+          <Route element={<ProtectedRoute />}>
+            <Route path={ROUTES.home}       element={<HomePage />} />
+            <Route path={ROUTES.books}      element={<BooksPage />} />
+            <Route path={ROUTES.addBook}    element={<AddBookPage />} />
+            <Route path={ROUTES.bookDetail} element={<BookDetailPage />} />
+            <Route path={ROUTES.locations}  element={<LocationsPage />} />
+          </Route>
+        </Routes>
+      </div>
+      {!hideNav && <BottomNav />}
       <ErrorToast />
-    </main>
+    </div>
   )
+}
+
+export function App() {
+  return <AppShell />
 }

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -1,0 +1,108 @@
+import { Link } from 'react-router-dom'
+import type { Book } from '../lib/types'
+import { ReadingStatusBadge } from './ReadingStatusBadge'
+import { getBookDetailRoute } from '../lib/routes'
+
+const GRADIENTS: [string, string][] = [
+  ['#1D9E75', '#085041'],
+  ['#BA7517', '#633806'],
+  ['#534AB7', '#26215C'],
+  ['#185FA5', '#042C53'],
+  ['#639922', '#173404'],
+  ['#993556', '#4B1528'],
+]
+
+function hashTitle(title: string): number {
+  let h = 0
+  for (const ch of title) h = ((h << 5) - h + ch.charCodeAt(0)) | 0
+  return Math.abs(h)
+}
+
+interface Props {
+  book: Book
+  onDelete?: (bookId: string) => void
+}
+
+export function BookCard({ book, onDelete }: Props) {
+  const [from, to] = GRADIENTS[hashTitle(book.title) % GRADIENTS.length]
+
+  return (
+    <div style={{ position: "relative" }}>
+      {onDelete && (
+        <button
+          aria-label={`delete-${book.id}`}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onDelete(book.id)
+          }}
+          style={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            zIndex: 2,
+            border: "none",
+            borderRadius: 999,
+            width: 24,
+            height: 24,
+            cursor: "pointer",
+            background: "rgba(0,0,0,0.55)",
+            color: "white",
+            fontSize: 14,
+            lineHeight: "24px",
+            padding: 0,
+          }}
+          title="Smazat knihu"
+        >
+          ×
+        </button>
+      )}
+      <Link
+      to={getBookDetailRoute(book.id)}
+      style={{
+        background: 'white',
+        borderRadius: 14,
+        border: '0.5px solid rgba(0,0,0,0.10)',
+        overflow: 'hidden',
+        display: 'block',
+        transition: 'border-color 0.15s',
+      }}
+    >
+      {/* Cover */}
+      <div style={{
+        height: 130,
+        background: `linear-gradient(135deg, ${from}, ${to})`,
+        display: 'flex',
+        alignItems: 'flex-end',
+        padding: 10,
+      }}>
+        <span style={{
+          fontSize: 11,
+          fontWeight: 500,
+          color: 'white',
+          lineHeight: 1.3,
+          textShadow: '0 1px 3px rgba(0,0,0,0.4)',
+        }}>
+          {book.title}
+        </span>
+      </div>
+
+      {/* Info */}
+      <div style={{ padding: 10 }}>
+        {book.author && (
+          <p style={{ fontSize: 11, color: '#888', marginBottom: 3 }}>{book.author}</p>
+        )}
+        <p style={{ fontSize: 13, fontWeight: 500, lineHeight: 1.3, marginBottom: 6 }}>
+          {book.title}
+        </p>
+        <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+          <ReadingStatusBadge
+            status={book.reading_status ?? 'unread'}
+            lentTo={book.lent_to}
+          />
+        </div>
+      </div>
+    </Link>
+    </div>
+  )
+}

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,0 +1,60 @@
+import { useLocation, useNavigate } from 'react-router-dom'
+import { ROUTES } from '../lib/routes'
+
+const TABS = [
+  { label: 'Knihovna', icon: '⊞', path: ROUTES.books },
+  { label: 'Přidat',   icon: '⊕', path: ROUTES.addBook },
+  { label: 'Domů',     icon: '⌂', path: ROUTES.home },
+] as const
+
+export function BottomNav() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const active = '#1D9E75'
+  const inactive = '#888'
+
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: 0,
+      left: '50%',
+      transform: 'translateX(-50%)',
+      width: '100%',
+      maxWidth: 480,
+      display: 'flex',
+      background: 'white',
+      borderTop: '0.5px solid rgba(0,0,0,0.10)',
+      paddingBottom: 'env(safe-area-inset-bottom, 8px)',
+      zIndex: 100,
+    }}>
+      {TABS.map(tab => {
+        const isActive = location.pathname === tab.path ||
+          (tab.path === ROUTES.books && location.pathname.startsWith('/books') && location.pathname !== ROUTES.addBook)
+
+        return (
+          <button
+            key={tab.path}
+            onClick={() => navigate(tab.path)}
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 3,
+              padding: '10px 0 6px',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: isActive ? active : inactive,
+              fontSize: 11,
+              transition: 'color 0.15s',
+            }}
+          >
+            <span style={{ fontSize: 20, lineHeight: 1 }}>{tab.icon}</span>
+            <span>{tab.label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/ReadingStatusBadge.tsx
+++ b/frontend/src/components/ReadingStatusBadge.tsx
@@ -1,0 +1,32 @@
+import type { ReadingStatus } from '../lib/types'
+
+interface Props {
+  status: ReadingStatus
+  lentTo?: string | null
+}
+
+const CONFIG: Record<ReadingStatus, { label: string; bg: string; color: string }> = {
+  read:    { label: 'Přečteno',  bg: '#E1F5EE', color: '#085041' },
+  reading: { label: 'Čtu',       bg: '#FAEEDA', color: '#633806' },
+  lent:    { label: 'Půjčeno',   bg: '#E6F1FB', color: '#042C53' },
+  unread:  { label: 'Nepřečteno',bg: '#F1EFE8', color: '#5F5E5A' },
+}
+
+export function ReadingStatusBadge({ status, lentTo }: Props) {
+  const { bg, color, label } = CONFIG[status]
+  const text = status === 'lent' && lentTo ? `Půjčeno · ${lentTo}` : label
+
+  return (
+    <span style={{
+      fontSize: 10,
+      padding: '2px 8px',
+      borderRadius: 4,
+      background: bg,
+      color,
+      fontWeight: 500,
+      whiteSpace: 'nowrap',
+    }}>
+      {text}
+    </span>
+  )
+}

--- a/frontend/src/components/ShelfBreadcrumb.tsx
+++ b/frontend/src/components/ShelfBreadcrumb.tsx
@@ -1,0 +1,26 @@
+import type { Location } from '../lib/types'
+
+interface Props {
+  location: Location
+}
+
+export function ShelfBreadcrumb({ location }: Props) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginBottom: 10 }}>
+      <span style={{ fontSize: 11, color: '#888' }}>{location.room}</span>
+      <span style={{ fontSize: 11, color: '#ccc' }}>›</span>
+      <span style={{ fontSize: 11, color: '#888' }}>{location.furniture}</span>
+      <span style={{ fontSize: 11, color: '#ccc' }}>›</span>
+      <span style={{
+        fontSize: 11,
+        fontWeight: 500,
+        color: '#0F6E56',
+        background: '#E1F5EE',
+        padding: '2px 8px',
+        borderRadius: 4,
+      }}>
+        {location.shelf}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/StatBar.tsx
+++ b/frontend/src/components/StatBar.tsx
@@ -1,0 +1,35 @@
+import type { Book } from '../lib/types'
+
+interface Props {
+  books: Book[]
+  total: number
+}
+
+export function StatBar({ books, total }: Props) {
+  const read    = books.filter(b => b.reading_status === 'read').length
+  const reading = books.filter(b => b.reading_status === 'reading').length
+  const lent    = books.filter(b => b.reading_status === 'lent').length
+
+  const stats = [
+    { label: 'Celkem', value: total, accent: '#111' },
+    { label: 'Přečteno', value: read, accent: '#1D9E75' },
+    { label: 'Čtu', value: reading, accent: '#BA7517' },
+    { label: 'Půjčeno', value: lent, accent: '#185FA5' },
+  ]
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8, margin: '14px 16px 0' }}>
+      {stats.map(s => (
+        <div key={s.label} style={{
+          background: '#F7F7F5',
+          borderRadius: 10,
+          padding: '10px 8px',
+          textAlign: 'center',
+        }}>
+          <div style={{ fontSize: 20, fontWeight: 500, color: s.accent, lineHeight: 1 }}>{s.value}</div>
+          <div style={{ fontSize: 10, color: '#888', marginTop: 3 }}>{s.label}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -3,9 +3,10 @@ export const ROUTES = {
   login: '/login',
   books: '/books',
   bookDetail: '/books/:bookId',
+  addBook: '/books/new',
   locations: '/locations',
 } as const
 
 export function getBookDetailRoute(bookId: string): string {
-  return ROUTES.bookDetail.replace(':bookId', bookId)
+  return `/books/${bookId}`
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -19,6 +19,8 @@ export interface LocationUpdateRequest {
   shelf?: string
 }
 
+export type ReadingStatus = 'unread' | 'reading' | 'read' | 'lent'
+
 export type BookProcessingStatus = 'manual' | 'pending' | 'done' | 'failed' | 'partial'
 
 export interface Book {
@@ -33,6 +35,8 @@ export interface Book {
   cover_image_url: string | null
   location_id: string | null
   processing_status: BookProcessingStatus
+  reading_status?: ReadingStatus   // optional until backend migration applied
+  lent_to?: string | null
   created_at: string
   updated_at: string
 }
@@ -61,6 +65,8 @@ export interface BookCreateRequest {
   publication_year?: number | null
   cover_image_url?: string | null
   location_id?: string | null
+  reading_status?: ReadingStatus
+  lent_to?: string | null
 }
 
 export interface BookUpdateRequest {
@@ -73,6 +79,8 @@ export interface BookUpdateRequest {
   publication_year?: number | null
   cover_image_url?: string | null
   location_id?: string | null
+  reading_status?: ReadingStatus
+  lent_to?: string | null
 }
 
 export interface LoginRequest {
@@ -85,7 +93,6 @@ export interface TokenResponse {
   refresh_token: string
   token_type: string
 }
-
 
 export type JobStatus = 'pending' | 'processing' | 'done' | 'failed'
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,9 @@
+import './styles/shelfy.css'   // ADD THIS LINE before other imports
+
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
-
 import { App } from './App'
 
 const queryClient = new QueryClient()

--- a/frontend/src/pages/AddBookPage.tsx
+++ b/frontend/src/pages/AddBookPage.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useCreateBook, useUploadBookImage, useJobStatus } from '../hooks/useBooks'
+import { useLocations } from '../hooks/useLocations'
+import { useToastStore } from '../lib/toast-store'
+import { ROUTES } from '../lib/routes'
+import type { BookCreateRequest, ReadingStatus } from '../lib/types'
+
+const inputStyle = {
+  width: '100%',
+  padding: '9px 12px',
+  border: '0.5px solid rgba(0,0,0,0.18)',
+  borderRadius: 10,
+  fontSize: 14,
+  background: 'white',
+  outline: 'none',
+} as const
+
+export function AddBookPage() {
+  const navigate      = useNavigate()
+  const showError     = useToastStore(s => s.showError)
+  const { data: locations = [] } = useLocations()
+  const createMutation  = useCreateBook()
+  const uploadMutation  = useUploadBookImage()
+  const fileInputRef    = useRef<HTMLInputElement>(null)
+
+  const [uploadJobId, setUploadJobId] = useState<string | null>(null)
+  const [title, setTitle]             = useState('')
+  const [author, setAuthor]           = useState('')
+  const [isbn, setIsbn]               = useState('')
+  const [reading, setReading]         = useState<ReadingStatus>('unread')
+  const [lentTo, setLentTo]           = useState('')
+
+  // Three-level location picker
+  const [selRoom, setSelRoom]       = useState('')
+  const [selFurniture, setSelFurniture] = useState('')
+  const [selShelf, setSelShelf]     = useState('')
+
+  const rooms      = [...new Set(locations.map(l => l.room))]
+  const furnitures = [...new Set(locations.filter(l => l.room === selRoom).map(l => l.furniture))]
+  const shelves    = [...new Set(locations.filter(l => l.room === selRoom && l.furniture === selFurniture).map(l => l.shelf))]
+  const resolvedId = locations.find(l => l.room === selRoom && l.furniture === selFurniture && l.shelf === selShelf)?.id ?? null
+
+  // Poll upload job
+  const uploadJobStatusQuery = useJobStatus(uploadJobId)
+
+  useEffect(() => {
+    const status = uploadJobStatusQuery.data?.status
+    if (status === 'done' || status === 'failed') {
+      if (status === 'failed') {
+        showError(uploadJobStatusQuery.data?.error_message ?? 'Zpracování obrázku selhalo.')
+      }
+      setUploadJobId(null)
+    }
+  }, [uploadJobStatusQuery.data?.status, uploadJobStatusQuery.data?.error_message, showError])
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    uploadMutation.mutate(file, {
+      onSuccess: res => setUploadJobId(res.job_id),
+      onError:   ()  => showError('Upload obrázku selhal.'),
+    })
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!title.trim()) { showError('Název knihy je povinný.'); return }
+    const payload: BookCreateRequest = {
+      title: title.trim(),
+      author:         author.trim() || null,
+      isbn:           isbn.trim()   || null,
+      location_id:    resolvedId,
+      reading_status: reading,
+      lent_to:        reading === 'lent' ? (lentTo.trim() || null) : null,
+    }
+    createMutation.mutate(payload, {
+      onSuccess: () => navigate(ROUTES.books),
+      onError:   ()  => showError('Nepodařilo se přidat knihu.'),
+    })
+  }
+
+  return (
+    <div style={{ padding: '16px 16px 0' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 20 }}>
+        <button
+          onClick={() => navigate(ROUTES.books)}
+          style={{ width: 36, height: 36, borderRadius: 10, border: '0.5px solid rgba(0,0,0,0.15)', background: '#F7F7F5', cursor: 'pointer', fontSize: 16 }}
+        >
+          ←
+        </button>
+        <h2 style={{ fontSize: 18, fontWeight: 500 }}>Přidat knihu</h2>
+      </div>
+
+      {/* Scan area */}
+      <div
+        onClick={() => fileInputRef.current?.click()}
+        style={{
+          border: '1.5px dashed rgba(0,0,0,0.18)',
+          borderRadius: 14,
+          height: 150,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 8,
+          cursor: 'pointer',
+          marginBottom: 18,
+          color: '#888',
+        }}
+      >
+        <span style={{ fontSize: 32 }}>📸</span>
+        <span style={{ fontSize: 14, fontWeight: 500 }}>
+          {uploadMutation.isPending ? 'Nahrávám…' : 'Naskenovat hřbet'}
+        </span>
+        <span style={{ fontSize: 11, color: '#aaa' }}>AI rozpozná název a autora</span>
+        <input ref={fileInputRef} type="file" accept="image/jpeg,image/png" style={{ display: 'none' }} onChange={handleFileChange} />
+      </div>
+      {uploadJobId && (
+        <p style={{ fontSize: 12, color: '#BA7517', marginBottom: 10, textAlign: 'center' }}>
+          ⏳ Zpracovávám obrázek…
+        </p>
+      )}
+
+      {/* Divider */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 18 }}>
+        <hr style={{ flex: 1, border: 'none', borderTop: '0.5px solid rgba(0,0,0,0.12)' }} />
+        <span style={{ fontSize: 12, color: '#aaa' }}>nebo zadat ručně</span>
+        <hr style={{ flex: 1, border: 'none', borderTop: '0.5px solid rgba(0,0,0,0.12)' }} />
+      </div>
+
+      {/* Form */}
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div>
+          <label style={{ fontSize: 12, color: '#666', display: 'block', marginBottom: 5 }}>Název *</label>
+          <input style={inputStyle} placeholder="např. Duna" value={title} onChange={e => setTitle(e.target.value)} required />
+        </div>
+
+        <div>
+          <label style={{ fontSize: 12, color: '#666', display: 'block', marginBottom: 5 }}>Autor</label>
+          <input style={inputStyle} placeholder="např. Frank Herbert" value={author} onChange={e => setAuthor(e.target.value)} />
+        </div>
+
+        {/* 3-level location */}
+        <div>
+          <label style={{ fontSize: 12, color: '#666', display: 'block', marginBottom: 5 }}>Umístění</label>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+            <div>
+              <label style={{ fontSize: 11, color: '#aaa', display: 'block', marginBottom: 3 }}>Místnost</label>
+              <select
+                style={inputStyle}
+                value={selRoom}
+                onChange={e => { setSelRoom(e.target.value); setSelFurniture(''); setSelShelf('') }}
+              >
+                <option value="">—</option>
+                {rooms.map(r => <option key={r} value={r}>{r}</option>)}
+              </select>
+            </div>
+            <div>
+              <label style={{ fontSize: 11, color: '#aaa', display: 'block', marginBottom: 3 }}>Knihovna</label>
+              <select
+                style={inputStyle}
+                value={selFurniture}
+                disabled={!selRoom}
+                onChange={e => { setSelFurniture(e.target.value); setSelShelf('') }}
+              >
+                <option value="">—</option>
+                {furnitures.map(f => <option key={f} value={f}>{f}</option>)}
+              </select>
+            </div>
+            <div>
+              <label style={{ fontSize: 11, color: '#aaa', display: 'block', marginBottom: 3 }}>Police</label>
+              <select
+                style={inputStyle}
+                value={selShelf}
+                disabled={!selFurniture}
+                onChange={e => setSelShelf(e.target.value)}
+              >
+                <option value="">—</option>
+                {shelves.map(s => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {/* Reading status */}
+        <div>
+          <label style={{ fontSize: 12, color: '#666', display: 'block', marginBottom: 5 }}>Stav</label>
+          <select
+            style={inputStyle}
+            value={reading}
+            onChange={e => setReading(e.target.value as ReadingStatus)}
+          >
+            <option value="unread">Nepřečteno</option>
+            <option value="reading">Čtu</option>
+            <option value="read">Přečteno</option>
+            <option value="lent">Půjčeno</option>
+          </select>
+        </div>
+
+        {reading === 'lent' && (
+          <div>
+            <label style={{ fontSize: 12, color: '#666', display: 'block', marginBottom: 5 }}>Půjčeno komu</label>
+            <input style={inputStyle} placeholder="Jméno nebo přezdívka" value={lentTo} onChange={e => setLentTo(e.target.value)} />
+          </div>
+        )}
+
+        <div>
+          <label style={{ fontSize: 12, color: '#666', display: 'block', marginBottom: 5 }}>ISBN (volitelné)</label>
+          <input style={inputStyle} placeholder="978-80-…" value={isbn} onChange={e => setIsbn(e.target.value)} />
+        </div>
+
+        <button
+          type="submit"
+          disabled={createMutation.isPending}
+          style={{
+            width: '100%',
+            padding: 13,
+            background: createMutation.isPending ? '#9FE1CB' : '#1D9E75',
+            color: 'white',
+            border: 'none',
+            borderRadius: 10,
+            fontSize: 14,
+            fontWeight: 500,
+            cursor: createMutation.isPending ? 'not-allowed' : 'pointer',
+            marginTop: 4,
+            marginBottom: 24,
+          }}
+        >
+          {createMutation.isPending ? 'Přidávám…' : 'Přidat do knihovny'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/AddBookPage.tsx
+++ b/frontend/src/pages/AddBookPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useCreateBook, useUploadBookImage, useJobStatus } from '../hooks/useBooks'
 import { useLocations } from '../hooks/useLocations'
@@ -54,16 +54,15 @@ export function AddBookPage() {
     }
   }, [uploadJobStatusQuery.data?.status, uploadJobStatusQuery.data?.error_message, showError])
 
-  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
     uploadMutation.mutate(file, {
       onSuccess: res => setUploadJobId(res.job_id),
-      onError:   ()  => showError('Upload obrázku selhal.'),
     })
   }
 
-  function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: FormEvent) {
     e.preventDefault()
     if (!title.trim()) { showError('Název knihy je povinný.'); return }
     const payload: BookCreateRequest = {

--- a/frontend/src/pages/BooksPage.test.tsx
+++ b/frontend/src/pages/BooksPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { type ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'

--- a/frontend/src/pages/BooksPage.test.tsx
+++ b/frontend/src/pages/BooksPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { type ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BooksPage } from './BooksPage'
 import { useToastStore } from '../lib/toast-store'
-import type { Book, BookListResponse, Location } from '../lib/types'
+import type { BookListResponse, Location } from '../lib/types'
 
 vi.mock('../lib/api', () => ({
   listBooks: vi.fn(),
@@ -20,20 +20,13 @@ vi.mock('../lib/api', () => ({
   formatApiError: vi.fn(() => 'API error'),
 }))
 
-import {
-  createBook,
-  deleteBook,
-  getJobStatus,
-  listBooks,
-  listLocations,
-  updateBook,
-  uploadBookImage,
-} from '../lib/api'
+import { deleteBook, listBooks, listLocations } from '../lib/api'
 
 function renderWithProviders(ui: ReactNode) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
+      mutations: { retry: false },
     },
   })
 
@@ -47,7 +40,7 @@ function renderWithProviders(ui: ReactNode) {
 const booksResponse: BookListResponse = {
   total: 1,
   page: 1,
-  page_size: 10,
+  page_size: 20,
   items: [
     {
       id: 'book-1',
@@ -80,7 +73,6 @@ const locations: Location[] = [
 
 describe('BooksPage', () => {
   beforeEach(() => {
-    vi.useRealTimers()
     vi.clearAllMocks()
     useToastStore.setState({ message: null })
     vi.mocked(listBooks).mockResolvedValue(booksResponse)
@@ -95,53 +87,33 @@ describe('BooksPage', () => {
   it('renders book list and submits search input', async () => {
     renderWithProviders(<BooksPage />)
 
-    expect(await screen.findByText('Clean Code')).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /delete-book-/ })).toBeInTheDocument()
 
     await userEvent.type(screen.getByLabelText('Search books'), 'Martin')
-    await userEvent.click(screen.getByRole('button', { name: 'Apply search' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Hledat' }))
 
     await waitFor(() => {
       expect(listBooks).toHaveBeenLastCalledWith(expect.objectContaining({ search: 'Martin' }))
     })
   })
 
-  it('polls job status and refreshes books on done', async () => {
-    vi.mocked(uploadBookImage).mockResolvedValue({ job_id: 'job-1', status: 'pending' })
-    vi.mocked(getJobStatus)
-      .mockResolvedValueOnce({ id: 'job-1', status: 'pending', book_id: null })
-      .mockResolvedValueOnce({ id: 'job-1', status: 'done', book_id: null })
-
+  it('requires confirmation before deleting a book', async () => {
     renderWithProviders(<BooksPage />)
-    await screen.findByText('Clean Code')
 
-    const file = new File(['img'], 'cover.png', { type: 'image/png' })
-    await userEvent.upload(screen.getByLabelText('Upload cover image'), file)
-    fireEvent.submit(screen.getByLabelText('upload-book-image-form'))
+    await screen.findByRole('button', { name: /delete-book-/ })
 
-    await waitFor(() => expect(uploadBookImage).toHaveBeenCalled(), { timeout: 7000 })
-    await waitFor(() => expect(screen.getByText(/Processing job job-1:/)).toBeInTheDocument(), { timeout: 7000 })
-    await waitFor(() => expect(getJobStatus).toHaveBeenCalled(), { timeout: 7000 })
-    await waitFor(() => expect(listBooks).toHaveBeenCalledTimes(2), { timeout: 7000 })
-  }, 10000)
+    await userEvent.click(screen.getByRole('button', { name: /delete-book-/ }))
 
-  it('shows error toast when job fails', async () => {
-    const showErrorSpy = vi.spyOn(useToastStore.getState(), 'showError')
-    vi.mocked(uploadBookImage).mockResolvedValue({ job_id: 'job-2', status: 'pending' })
-    vi.mocked(getJobStatus).mockResolvedValue({ id: 'job-2', status: 'failed', book_id: null })
+    expect(screen.getByRole('dialog', { name: 'delete-book-dialog' })).toBeInTheDocument()
 
-    renderWithProviders(<BooksPage />)
-    await screen.findByText('Clean Code')
+    await userEvent.click(screen.getByRole('button', { name: 'Smazat' }))
 
-    const file = new File(['img'], 'cover.png', { type: 'image/png' })
-    await userEvent.upload(screen.getByLabelText('Upload cover image'), file)
-    fireEvent.submit(screen.getByLabelText('upload-book-image-form'))
+    await waitFor(() => {
+      expect(deleteBook).toHaveBeenCalledWith('book-1')
+    })
+  })
 
-    await waitFor(() => expect(uploadBookImage).toHaveBeenCalled(), { timeout: 7000 })
-    await waitFor(() => expect(screen.getByText(/Processing job job-2:/)).toBeInTheDocument(), { timeout: 7000 })
-    await waitFor(() => expect(showErrorSpy).toHaveBeenCalled(), { timeout: 7000 })
-  }, 10000)
-
-  it('aggregates failed-book toast messages into one toast', async () => {
+  it('shows aggregated toast for failed books', async () => {
     const showErrorSpy = vi.spyOn(useToastStore.getState(), 'showError')
     vi.mocked(listBooks).mockResolvedValue({
       ...booksResponse,
@@ -154,74 +126,14 @@ describe('BooksPage', () => {
 
     renderWithProviders(<BooksPage />)
 
-    await screen.findByText('Book Failed 1')
+    const deleteButtons = await screen.findAllByRole('button', { name: /delete-book-/ })
+    expect(deleteButtons.length).toBe(2)
 
     await waitFor(() => {
       expect(showErrorSpy).toHaveBeenCalledTimes(1)
       expect(showErrorSpy).toHaveBeenCalledWith(
-        'Metadata extraction failed for 2 book(s): "Book Failed 1", "Book Failed 2"',
+        'Zpracování selhalo pro 2 knih: "Book Failed 1", "Book Failed 2"',
       )
     })
   })
-
-  it('submits create and edit forms', async () => {
-    vi.mocked(createBook).mockImplementation(async (payload) => ({
-      ...(booksResponse.items[0] as Book),
-      id: 'book-2',
-      title: payload.title,
-      author: payload.author ?? null,
-    }))
-    vi.mocked(updateBook).mockImplementation(async (_id, payload) => ({
-      ...(booksResponse.items[0] as Book),
-      ...payload,
-      author: payload.author ?? booksResponse.items[0].author,
-    }))
-
-    renderWithProviders(<BooksPage />)
-
-    await screen.findByText('Clean Code')
-
-    await userEvent.type(screen.getByLabelText('Title'), 'Refactoring')
-    await userEvent.type(screen.getByLabelText('Author'), 'Martin Fowler')
-    await userEvent.click(screen.getByRole('button', { name: 'Create book' }))
-
-    await waitFor(() => {
-      expect(createBook).toHaveBeenCalledWith(expect.objectContaining({ title: 'Refactoring' }))
-    })
-
-    const cleanCodeCard = (await screen.findByRole('link', { name: 'Clean Code' })).closest('[data-testid="book-card"]')
-    if (!cleanCodeCard) {
-      throw new Error('Expected book card to exist')
-    }
-
-    await userEvent.click(within(cleanCodeCard).getByRole('button', { name: 'Edit' }))
-    const editTitleInput = screen.getByLabelText('Edit title')
-    await userEvent.clear(editTitleInput)
-    await userEvent.type(editTitleInput, 'Clean Code 2nd Edition')
-    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
-
-    await waitFor(() => {
-      expect(updateBook).toHaveBeenCalledWith(
-        'book-1',
-        expect.objectContaining({ title: 'Clean Code 2nd Edition' }),
-      )
-    })
-  })
-
-  it('requires confirmation before deleting a book', async () => {
-    renderWithProviders(<BooksPage />)
-
-    await screen.findByText('Clean Code')
-    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
-
-    expect(screen.getByRole('dialog', { name: 'delete-book-dialog' })).toBeInTheDocument()
-
-    await userEvent.click(screen.getByRole('button', { name: 'Confirm delete' }))
-
-    await waitFor(() => {
-      expect(deleteBook).toHaveBeenCalledWith('book-1')
-    })
-  })
-
-
 })

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -1,412 +1,226 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
-
-import {
-  useBooks,
-  useCreateBook,
-  useDeleteBook,
-  useJobStatus,
-  useUpdateBook,
-  useUploadBookImage,
-} from '../hooks/useBooks'
+import { useBooks, useCreateBook, useDeleteBook, useJobStatus, useUpdateBook, useUploadBookImage } from '../hooks/useBooks'
 import { useLocations } from '../hooks/useLocations'
-import { getBookDetailRoute } from '../lib/routes'
 import { useToastStore } from '../lib/toast-store'
-import type { BookCreateRequest } from '../lib/types'
-import './BooksPage.css'
+import { BookCard } from '../components/BookCard'
+import { ShelfBreadcrumb } from '../components/ShelfBreadcrumb'
+import { StatBar } from '../components/StatBar'
+import type { Book, BookCreateRequest, Location } from '../lib/types'
 
-const PAGE_SIZE = 10
+const PAGE_SIZE = 20
 
 const EMPTY_FORM: BookCreateRequest = {
-  title: '',
-  author: '',
-  isbn: '',
-  publisher: '',
-  language: '',
-  description: '',
-  publication_year: null,
-  cover_image_url: '',
-  location_id: null,
+  title: '', author: '', isbn: '', location_id: null, reading_status: 'unread',
 }
 
 export function BooksPage() {
-  const [searchInput, setSearchInput] = useState('')
-  const [search, setSearch] = useState('')
-  const [selectedLocationId, setSelectedLocationId] = useState('')
-  const [page, setPage] = useState(1)
-  const [createForm, setCreateForm] = useState<BookCreateRequest>(EMPTY_FORM)
-  const [editingBookId, setEditingBookId] = useState<string | null>(null)
-  const [editForm, setEditForm] = useState<BookCreateRequest>(EMPTY_FORM)
-  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
-  const [uploadJobId, setUploadJobId] = useState<string | null>(null)
-  const toastedFailedIdsRef = useRef<Set<string>>(new Set())
+  const [searchInput, setSearchInput]         = useState('')
+  const [search, setSearch]                   = useState('')
+  const [page, setPage]                       = useState(1)
+  const [deleteTargetId, setDeleteTargetId]   = useState<string | null>(null)
+  const [uploadJobId, setUploadJobId]         = useState<string | null>(null)
+  const toastedFailedIdsRef                   = useRef<Set<string>>(new Set())
 
   const queryParams = useMemo(
-    () => ({ page, pageSize: PAGE_SIZE, search: search || undefined, locationId: selectedLocationId || undefined }),
-    [page, search, selectedLocationId],
+    () => ({ page, pageSize: PAGE_SIZE, search: search || undefined }),
+    [page, search],
   )
 
-  const booksQuery = useBooks(queryParams)
-  const refetchBooks = booksQuery.refetch
-  const locationsQuery = useLocations()
-  const createMutation = useCreateBook()
-  const updateMutation = useUpdateBook()
-  const deleteMutation = useDeleteBook()
-  const uploadMutation = useUploadBookImage()
+  const booksQuery          = useBooks(queryParams)
+  const locationsQuery      = useLocations()
+  const deleteMutation      = useDeleteBook()
+  const uploadMutation      = useUploadBookImage()
   const uploadJobStatusQuery = useJobStatus(uploadJobId)
-  const showError = useToastStore((state) => state.showError)
+  const showError           = useToastStore(s => s.showError)
 
-  const locationLabelById = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const location of locationsQuery.data ?? []) {
-      map.set(location.id, `${location.room} / ${location.furniture} / ${location.shelf}`)
-    }
-    return map
+  // Map locationId → Location object
+  const locationById = useMemo(() => {
+    const m = new Map<string, Location>()
+    for (const loc of locationsQuery.data ?? []) m.set(loc.id, loc)
+    return m
   }, [locationsQuery.data])
 
+  // Group books by location
+  const groups = useMemo(() => {
+    const map = new Map<string | null, Book[]>()
+    for (const b of booksQuery.data?.items ?? []) {
+      const key = b.location_id ?? null
+      if (!map.has(key)) map.set(key, [])
+      map.get(key)!.push(b)
+    }
+    return map
+  }, [booksQuery.data?.items])
+
+  // Toast for failed processing
   useEffect(() => {
-    const failedBooks = (booksQuery.data?.items ?? []).filter(
-      (book) => book.processing_status === 'failed' && !toastedFailedIdsRef.current.has(book.id),
+    const failed = (booksQuery.data?.items ?? []).filter(
+      b => b.processing_status === 'failed' && !toastedFailedIdsRef.current.has(b.id),
     )
-    if (failedBooks.length === 0) {
-      return
-    }
-    for (const book of failedBooks) {
-      toastedFailedIdsRef.current.add(book.id)
-    }
-    const titles = failedBooks.map((book) => `"${book.title}"`).join(', ')
-    showError(`Metadata extraction failed for ${failedBooks.length} book(s): ${titles}`)
+    if (!failed.length) return
+    for (const b of failed) toastedFailedIdsRef.current.add(b.id)
+    showError(`Zpracování selhalo pro ${failed.length} knih: ${failed.map(b => `"${b.title}"`).join(', ')}`)
   }, [booksQuery.data?.items, showError])
 
-  useEffect(() => {
-    if (!booksQuery.data) {
-      return
-    }
-
-    const { total, page: currentPage, page_size: currentPageSize, items } = booksQuery.data
-    if (total <= 0 || items.length > 0) {
-      return
-    }
-
-    const lastValidPage = Math.max(1, Math.ceil(total / currentPageSize))
-    if (currentPage > lastValidPage) {
-      setPage(lastValidPage)
-    }
-  }, [booksQuery.data])
-
+  // Upload job polling
   useEffect(() => {
     const status = uploadJobStatusQuery.data?.status
     if (status === 'done' || status === 'failed') {
-      if (status === 'failed') {
-        showError(uploadJobStatusQuery.data?.error_message ?? 'Image processing failed.')
-      }
+      if (status === 'failed') showError(uploadJobStatusQuery.data?.error_message ?? 'Zpracování obrázku selhalo.')
       setUploadJobId(null)
-      void refetchBooks()
-      return
+      void booksQuery.refetch()
     }
-
     if (uploadJobStatusQuery.isError) {
-      showError('Failed to check upload status.')
+      showError('Nepodařilo se zkontrolovat stav uploadu.')
     }
   }, [
-    refetchBooks,
+    booksQuery,
     showError,
     uploadJobStatusQuery.data?.error_message,
     uploadJobStatusQuery.data?.status,
     uploadJobStatusQuery.isError,
   ])
 
-  return (
-    <section className="books-page">
-      <header className="books-header">
-        <h2>Books</h2>
-        <p className="books-subtitle">Browse your library and quickly add new titles.</p>
-      </header>
+  const books = booksQuery.data?.items ?? []
+  const total = booksQuery.data?.total ?? 0
 
+  return (
+    <div>
+      {/* Header */}
+      <div style={{ padding: '16px 16px 0', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 500 }}>Shelfy</h1>
+          <p style={{ fontSize: 13, color: '#888' }}>{total} knih</p>
+        </div>
+      </div>
+
+      {/* Stat bar */}
+      <StatBar books={books} total={total} />
+
+      {/* Search */}
       <form
         aria-label="book-search-form"
-        className="books-panel books-search-form"
-        onSubmit={(event) => {
-          event.preventDefault()
-          setPage(1)
-          setSearch(searchInput.trim())
-        }}
+        onSubmit={e => { e.preventDefault(); setPage(1); setSearch(searchInput.trim()) }}
+        style={{ margin: '12px 16px 0', display: 'flex', gap: 8 }}
       >
-        <input
-          aria-label="Search books"
-          placeholder="Search by title, author, ISBN..."
-          value={searchInput}
-          onChange={(event) => setSearchInput(event.target.value)}
-        />
-        <select
-          aria-label="Filter by location"
-          value={selectedLocationId}
-          onChange={(event) => {
-            setSelectedLocationId(event.target.value)
-            setPage(1)
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          background: '#F7F7F5',
+          border: '0.5px solid rgba(0,0,0,0.10)',
+          borderRadius: 12,
+          padding: '10px 14px',
+        }}>
+          <span style={{ fontSize: 16, color: '#888' }}>⌕</span>
+          <input
+            aria-label="Search books"
+            placeholder="Hledat knihy, autory..."
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            style={{ flex: 1, border: 'none', background: 'transparent', fontSize: 14, outline: 'none' }}
+          />
+        </div>
+        <button
+          type="submit"
+          style={{
+            padding: '0 16px',
+            background: '#1D9E75',
+            color: 'white',
+            border: 'none',
+            borderRadius: 12,
+            fontSize: 13,
+            fontWeight: 500,
+            cursor: 'pointer',
           }}
         >
-          <option value="">All locations</option>
-          {(locationsQuery.data ?? []).map((location) => (
-            <option key={location.id} value={location.id}>
-              {location.room} / {location.furniture} / {location.shelf}
-            </option>
-          ))}
-        </select>
-        <button type="submit">Apply search</button>
-      </form>
-
-      <form
-        aria-label="upload-book-image-form"
-        className="books-panel books-upload-form"
-        onSubmit={(event) => {
-          event.preventDefault()
-          const formData = new FormData(event.currentTarget)
-          const file = formData.get('book-image')
-          if (!(file instanceof File)) {
-            return
-          }
-          uploadMutation.mutate(file, {
-            onSuccess: (response) => {
-              setUploadJobId(response.job_id)
-            },
-          })
-        }}
-      >
-        <label htmlFor="book-image">Upload cover image</label>
-        <input id="book-image" name="book-image" type="file" accept="image/jpeg,image/png" required />
-        <button type="submit" disabled={uploadMutation.isPending || Boolean(uploadJobId)}>
-          {uploadMutation.isPending ? 'Uploading…' : 'Upload image'}
+          Hledat
         </button>
       </form>
 
+      {/* Upload status */}
       {uploadJobId && (
-        <p className="books-job-status">
-          Processing job {uploadJobId}: {uploadJobStatusQuery.data?.status ?? 'pending'}
+        <p style={{ margin: '8px 16px', fontSize: 13, color: '#BA7517' }}>
+          ⏳ Zpracovávám obrázek… ({uploadJobStatusQuery.data?.status ?? 'pending'})
         </p>
       )}
 
-      <form
-        aria-label="create-book-form"
-        className="books-panel books-create-form"
-        onSubmit={(event) => {
-          event.preventDefault()
-          createMutation.mutate(createForm, {
-            onSuccess: () => setCreateForm(EMPTY_FORM),
-          })
-        }}
-      >
-        <h3>Add book</h3>
-        <input
-          aria-label="Title"
-          required
-          placeholder="Title"
-          value={createForm.title ?? ''}
-          onChange={(event) => setCreateForm((prev) => ({ ...prev, title: event.target.value }))}
-        />
-        <input
-          aria-label="Author"
-          placeholder="Author"
-          value={createForm.author ?? ''}
-          onChange={(event) => setCreateForm((prev) => ({ ...prev, author: event.target.value }))}
-        />
-        <input
-          aria-label="ISBN"
-          placeholder="ISBN"
-          value={createForm.isbn ?? ''}
-          onChange={(event) => setCreateForm((prev) => ({ ...prev, isbn: event.target.value }))}
-        />
-        <input
-          aria-label="Publisher"
-          placeholder="Publisher"
-          value={createForm.publisher ?? ''}
-          onChange={(event) => setCreateForm((prev) => ({ ...prev, publisher: event.target.value }))}
-        />
-        <input
-          aria-label="Language"
-          placeholder="Language"
-          value={createForm.language ?? ''}
-          onChange={(event) => setCreateForm((prev) => ({ ...prev, language: event.target.value }))}
-        />
-        <input
-          aria-label="Publication year"
-          type="number"
-          placeholder="Publication year"
-          value={createForm.publication_year ?? ''}
-          onChange={(event) =>
-            setCreateForm((prev) => ({ ...prev, publication_year: event.target.value ? Number(event.target.value) : null }))
-          }
-        />
-        <input
-          aria-label="Cover URL"
-          placeholder="Cover URL"
-          value={createForm.cover_image_url ?? ''}
-          onChange={(event) => setCreateForm((prev) => ({ ...prev, cover_image_url: event.target.value }))}
-        />
-        <select
-          aria-label="Location"
-          value={createForm.location_id ?? ''}
-          onChange={(event) => setCreateForm((prev) => ({ ...prev, location_id: event.target.value || null }))}
-        >
-          <option value="">Unassigned</option>
-          {(locationsQuery.data ?? []).map((location) => (
-            <option key={location.id} value={location.id}>
-              {location.room} / {location.furniture} / {location.shelf}
-            </option>
-          ))}
-        </select>
-        <textarea
-          aria-label="Description"
-          placeholder="Description"
-          value={createForm.description ?? ''}
-          onChange={(event) => setCreateForm((prev) => ({ ...prev, description: event.target.value }))}
-        />
-        <button type="submit" disabled={createMutation.isPending}>
-          {createMutation.isPending ? 'Creating…' : 'Create book'}
-        </button>
-      </form>
-
-      {booksQuery.isLoading && <p>Loading books…</p>}
-
-      {booksQuery.isError && (
-        <p>
-          Failed to load books.
-          <button type="button" onClick={() => void booksQuery.refetch()}>
-            Retry
-          </button>
-        </p>
-      )}
-
-      {booksQuery.data && booksQuery.data.total === 0 && <p>No books found.</p>}
-
-      {booksQuery.data && booksQuery.data.total > 0 && (
-        <>
-          <div className="books-list" aria-label="books-list">
-            {booksQuery.data.items.map((book) => {
-              const isEditing = editingBookId === book.id
-
-              return (
-                <article key={book.id} className="book-card" data-testid="book-card">
-                  {isEditing ? (
-                    <>
-                      <input
-                        aria-label="Edit title"
-                        value={editForm.title ?? ''}
-                        onChange={(event) => setEditForm((prev) => ({ ...prev, title: event.target.value }))}
-                      />
-                      <input
-                        aria-label="Edit author"
-                        value={editForm.author ?? ''}
-                        onChange={(event) => setEditForm((prev) => ({ ...prev, author: event.target.value }))}
-                      />
-                      <select
-                        aria-label="Edit location"
-                        value={editForm.location_id ?? ''}
-                        onChange={(event) => setEditForm((prev) => ({ ...prev, location_id: event.target.value || null }))}
-                      >
-                        <option value="">Unassigned</option>
-                        {(locationsQuery.data ?? []).map((location) => (
-                          <option key={location.id} value={location.id}>
-                            {location.room} / {location.furniture} / {location.shelf}
-                          </option>
-                        ))}
-                      </select>
-                      <div className="book-card-actions">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            updateMutation.mutate(
-                              { id: book.id, payload: editForm },
-                              { onSuccess: () => setEditingBookId(null) },
-                            )
-                          }}
-                        >
-                          Save
-                        </button>
-                        <button type="button" onClick={() => setEditingBookId(null)}>
-                          Cancel
-                        </button>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <h3>
-                        <Link to={getBookDetailRoute(book.id)}>{book.title}</Link>
-                      </h3>
-                      <p>
-                        <strong>Author:</strong> {book.author || '—'}
-                      </p>
-                      <p>
-                        <strong>Location:</strong>{' '}
-                        {(book.location_id ? locationLabelById.get(book.location_id) : null) ?? 'Unassigned'}
-                      </p>
-                      <div className="book-card-actions">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setEditingBookId(book.id)
-                            setEditForm({
-                              title: book.title,
-                              author: book.author,
-                              isbn: book.isbn,
-                              publisher: book.publisher,
-                              language: book.language,
-                              description: book.description,
-                              publication_year: book.publication_year,
-                              cover_image_url: book.cover_image_url,
-                              location_id: book.location_id,
-                            })
-                          }}
-                        >
-                          Edit
-                        </button>
-                        <button type="button" onClick={() => setDeleteTargetId(book.id)}>
-                          Delete
-                        </button>
-                      </div>
-                    </>
-                  )}
-                </article>
-              )
-            })}
-          </div>
-
-          <div className="books-pagination">
-            <button type="button" disabled={page <= 1} onClick={() => setPage((current) => current - 1)}>
-              Previous
+      {/* Book groups */}
+      <div style={{ padding: '14px 16px 0' }}>
+        {booksQuery.isLoading && <p style={{ color: '#888', fontSize: 14 }}>Načítám knihy…</p>}
+        {booksQuery.isError && (
+          <p style={{ color: '#E24B4A', fontSize: 14 }}>
+            Nepodařilo se načíst knihy.{' '}
+            <button onClick={() => void booksQuery.refetch()} style={{ color: '#1D9E75', background: 'none', border: 'none', cursor: 'pointer' }}>
+              Zkusit znovu
             </button>
-            <span>
-              Page {booksQuery.data.page} of {Math.max(1, Math.ceil(booksQuery.data.total / booksQuery.data.page_size))}
+          </p>
+        )}
+        {!booksQuery.isLoading && !booksQuery.isError && total === 0 && (
+          <p style={{ color: '#888', fontSize: 14 }}>Žádné knihy nenalezeny.</p>
+        )}
+
+        {Array.from(groups.entries()).map(([locId, groupBooks]) => {
+          const loc = locId ? locationById.get(locId) : null
+          return (
+            <div key={locId ?? 'unassigned'} style={{ marginBottom: 18 }}>
+              {loc
+                ? <ShelfBreadcrumb location={loc} />
+                : <p style={{ fontSize: 11, color: '#888', marginBottom: 10 }}>Bez umístění</p>
+              }
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+                {groupBooks.map(b => <BookCard key={b.id} book={b} onDelete={setDeleteTargetId} />)}
+              </div>
+            </div>
+          )
+        })}
+
+        {/* Pagination */}
+        {total > PAGE_SIZE && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 12, marginBottom: 8 }}>
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage(p => p - 1)}
+              style={{ padding: '8px 16px', borderRadius: 8, border: '0.5px solid rgba(0,0,0,0.15)', background: 'none', cursor: page <= 1 ? 'not-allowed' : 'pointer', opacity: page <= 1 ? 0.4 : 1 }}
+            >
+              ← Předchozí
+            </button>
+            <span style={{ fontSize: 13, color: '#888' }}>
+              {page} / {Math.ceil(total / PAGE_SIZE)}
             </span>
             <button
-              type="button"
-              disabled={page >= Math.ceil(booksQuery.data.total / booksQuery.data.page_size)}
-              onClick={() => setPage((current) => current + 1)}
+              disabled={page >= Math.ceil(total / PAGE_SIZE)}
+              onClick={() => setPage(p => p + 1)}
+              style={{ padding: '8px 16px', borderRadius: 8, border: '0.5px solid rgba(0,0,0,0.15)', background: 'none', cursor: page >= Math.ceil(total / PAGE_SIZE) ? 'not-allowed' : 'pointer', opacity: page >= Math.ceil(total / PAGE_SIZE) ? 0.4 : 1 }}
             >
-              Next
+              Další →
             </button>
           </div>
-        </>
-      )}
+        )}
+      </div>
 
+      {/* Delete dialog */}
       {deleteTargetId && (
-        <div role="dialog" aria-label="delete-book-dialog" className="books-delete-dialog">
-          <p>Are you sure you want to delete this book?</p>
-          <button
-            type="button"
-            onClick={() => {
-              deleteMutation.mutate(deleteTargetId, {
-                onSuccess: () => setDeleteTargetId(null),
-              })
-            }}
-          >
-            Confirm delete
-          </button>
-          <button type="button" onClick={() => setDeleteTargetId(null)}>
-            Cancel
-          </button>
+        <div role="dialog" aria-label="delete-book-dialog" style={{
+          position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 200, padding: '0 24px',
+        }}>
+          <div style={{ background: 'white', borderRadius: 16, padding: '20px 20px 16px', width: '100%', maxWidth: 360 }}>
+            <p style={{ fontSize: 15, marginBottom: 16 }}>Opravdu chceš smazat tuto knihu?</p>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button onClick={() => setDeleteTargetId(null)} style={{ padding: '9px 18px', borderRadius: 8, border: '0.5px solid rgba(0,0,0,0.15)', background: 'none', cursor: 'pointer', fontSize: 14 }}>
+                Zrušit
+              </button>
+              <button
+                onClick={() => deleteMutation.mutate(deleteTargetId, { onSuccess: () => setDeleteTargetId(null) })}
+                style={{ padding: '9px 18px', borderRadius: 8, border: 'none', background: '#E24B4A', color: 'white', cursor: 'pointer', fontSize: 14 }}
+              >
+                {deleteMutation.isPending ? 'Mažu…' : 'Smazat'}
+              </button>
+            </div>
+          </div>
         </div>
       )}
-    </section>
+    </div>
   )
 }

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -1,17 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useBooks, useCreateBook, useDeleteBook, useJobStatus, useUpdateBook, useUploadBookImage } from '../hooks/useBooks'
+import { useBooks, useDeleteBook, useJobStatus } from '../hooks/useBooks'
 import { useLocations } from '../hooks/useLocations'
 import { useToastStore } from '../lib/toast-store'
 import { BookCard } from '../components/BookCard'
 import { ShelfBreadcrumb } from '../components/ShelfBreadcrumb'
 import { StatBar } from '../components/StatBar'
-import type { Book, BookCreateRequest, Location } from '../lib/types'
+import type { Book, Location } from '../lib/types'
 
 const PAGE_SIZE = 20
-
-const EMPTY_FORM: BookCreateRequest = {
-  title: '', author: '', isbn: '', location_id: null, reading_status: 'unread',
-}
 
 export function BooksPage() {
   const [searchInput, setSearchInput]         = useState('')
@@ -29,7 +25,6 @@ export function BooksPage() {
   const booksQuery          = useBooks(queryParams)
   const locationsQuery      = useLocations()
   const deleteMutation      = useDeleteBook()
-  const uploadMutation      = useUploadBookImage()
   const uploadJobStatusQuery = useJobStatus(uploadJobId)
   const showError           = useToastStore(s => s.showError)
 

--- a/frontend/src/styles/shelfy.css
+++ b/frontend/src/styles/shelfy.css
@@ -1,0 +1,50 @@
+:root {
+  --sh-teal:      #1D9E75;
+  --sh-teal-dark: #0F6E56;
+  --sh-teal-bg:   #E1F5EE;
+  --sh-teal-text: #085041;
+  --sh-amber:     #BA7517;
+  --sh-amber-bg:  #FAEEDA;
+  --sh-amber-text:#633806;
+  --sh-blue:      #185FA5;
+  --sh-blue-bg:   #E6F1FB;
+  --sh-blue-text: #042C53;
+  --sh-purple-bg: #EEEDFE;
+  --sh-purple-text:#3C3489;
+  --sh-red-bg:    #FCEBEB;
+  --sh-red-text:  #A32D2D;
+  --sh-border:    rgba(0,0,0,0.10);
+  --sh-border-2:  rgba(0,0,0,0.18);
+  --sh-surface:   #F7F7F5;
+  --sh-radius-sm: 6px;
+  --sh-radius-md: 10px;
+  --sh-radius-lg: 14px;
+  --sh-radius-xl: 20px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: system-ui, -apple-system, sans-serif; background: var(--sh-surface); color: #111; }
+
+.sh-app {
+  max-width: 480px;
+  margin: 0 auto;
+  min-height: 100dvh;
+  background: white;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.sh-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 80px;
+}
+
+a { color: inherit; text-decoration: none; }
+
+.book-card:hover { border-color: rgba(0,0,0,0.25); }
+.nav-item:hover { color: var(--sh-teal); }
+.sh-btn-primary:hover { background: var(--sh-teal-dark); }
+.sh-input:focus { border-color: var(--sh-teal); box-shadow: 0 0 0 3px rgba(29,158,117,.15); outline: none; }
+.sh-select:focus { border-color: var(--sh-teal); box-shadow: 0 0 0 3px rgba(29,158,117,.15); outline: none; }


### PR DESCRIPTION
## Summary
Implements the new frontend redesign and includes visible delete action in the new card-based UI.

## What changed
- New mobile-first visual structure and components:
  - `BookCard`, `BottomNav`, `ReadingStatusBadge`, `ShelfBreadcrumb`, `StatBar`
  - New `AddBookPage`
  - Updated `BooksPage`, `App`, routes/types, main style import
  - Added design stylesheet `frontend/src/styles/shelfy.css`
- Delete UX in redesigned list:
  - delete affordance on card (`×` button)
  - existing confirm dialog and delete mutation flow remain wired

## Validation
- Production build succeeds:
  - `npm run build` (inside Node 20 container)

## Issue
Closes #80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Add Book" page with image upload, hierarchical location selector and lending fields
  * Book cards with reading-status badges, lending display and optional delete action
  * Bottom navigation and responsive app shell that hides on the login screen
  * Stats bar and shelf breadcrumb grouping books by shelf
  * New route for adding books; increased page size for book lists

* **Style**
  * New global stylesheet with brand tokens and layout/interaction styles

* **Tests**
  * Updated tests for pagination, search label, and delete confirmation flow; adjusted upload/job-related coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->