### PR TITLE
feat: add Alembic migration for reading_status and lent_to fields on books

### DIFF
--- a/backend/alembic/versions/20260916_000005_add_reading_status_to_books.py
+++ b/backend/alembic/versions/20260916_000005_add_reading_status_to_books.py
@@ -1,0 +1,58 @@
+"""add reading_status and lent_to to books
+
+Revision ID: 20260916_000005
+Revises: 20260912_000004
+Create Date: 2026-09-16 00:00:05
+"""
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260916_000005"
+down_revision: str | None = "20260912_000004"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+reading_status_enum = postgresql.ENUM(
+    "unread",
+    "reading",
+    "read",
+    "lent",
+    name="reading_status",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    if is_postgresql:
+        reading_status_enum.create(bind, checkfirst=True)
+
+    op.add_column(
+        "books",
+        sa.Column(
+            "reading_status",
+            reading_status_enum if is_postgresql else sa.String(length=20),
+            nullable=True,
+            server_default="unread",
+        ),
+    )
+    op.add_column("books", sa.Column("lent_to", sa.String(length=300), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    op.drop_column("books", "lent_to")
+    op.drop_column("books", "reading_status")
+
+    if is_postgresql:
+        reading_status_enum.drop(bind, checkfirst=True)


### PR DESCRIPTION
## Summary
Adds missing Alembic migration for `reading_status` and `lent_to` fields on `books`.

## What this PR adds
- New migration: `20260916_000005_add_reading_status_to_books.py`
- Revision chain:
  - `revision = "20260916_000005"`
  - `down_revision = "20260912_000004"`

## Migration behavior
- PostgreSQL guarded operations (`bind.dialect.name == "postgresql"`)
- Creates enum type `reading_status` (`unread`, `reading`, `read`, `lent`) using `create_type=False` + `checkfirst=True`
- Adds columns to `books`:
  - `reading_status` (nullable, `server_default="unread"`)
  - `lent_to` (`VARCHAR(300)`, nullable)
- Downgrade drops both columns and drops enum type with `checkfirst=True`

## Verification performed
- `alembic upgrade head` on fresh PostgreSQL DB ✅
- `alembic downgrade -1` then `alembic upgrade head` ✅
- `ruff check app tests` ✅
- `mypy app tests` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Each book can now have a reading status assigned, allowing you to mark books as unread, currently reading, completed, or lent out
  * Added the ability to record who you've lent a book to, making it easier to track borrowed items and manage your library

<!-- end of auto-generated comment: release notes by coderabbit.ai -->