### PR TITLE
fix: restore reading_status regression and switch backend CI tests to Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,20 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: shelfy_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - name: Checkout
@@ -35,7 +49,7 @@ jobs:
       - name: Pytest with coverage gate
         working-directory: backend
         env:
-          TEST_DATABASE_URL: sqlite+aiosqlite:///./ci_test.db
+          TEST_DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/shelfy_test
         run: pytest --cov=app --cov-fail-under=80 tests
 
 

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -8,6 +8,13 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.db.base import Base
 
 
+class ReadingStatus(str, Enum):
+    UNREAD = "unread"
+    READING = "reading"
+    READ = "read"
+    LENT = "lent"
+
+
 class BookProcessingStatus(str, Enum):
     MANUAL = "manual"
     PENDING = "pending"
@@ -31,6 +38,19 @@ class Book(Base):
     location_id: Mapped[uuid.UUID | None] = mapped_column(
         Uuid(as_uuid=True), ForeignKey("locations.id", ondelete="RESTRICT"), nullable=True, index=True
     )
+    reading_status: Mapped[ReadingStatus | None] = mapped_column(
+        SAEnum(
+            ReadingStatus,
+            values_callable=lambda e: [member.value for member in e],
+            validate_strings=True,
+            name="reading_status",
+            create_type=False,
+        ),
+        nullable=True,
+        default=ReadingStatus.UNREAD,
+        server_default=ReadingStatus.UNREAD.value,
+    )
+    lent_to: Mapped[str | None] = mapped_column(String(300), nullable=True)
     processing_status: Mapped[BookProcessingStatus] = mapped_column(
         SAEnum(
             BookProcessingStatus,

--- a/backend/app/schemas/book.py
+++ b/backend/app/schemas/book.py
@@ -3,7 +3,7 @@ import uuid
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from app.models.book import BookProcessingStatus
+from app.models.book import BookProcessingStatus, ReadingStatus
 
 
 class BookBaseRequest(BaseModel):
@@ -16,6 +16,8 @@ class BookBaseRequest(BaseModel):
     publication_year: int | None = Field(default=None, ge=0, le=9999)
     cover_image_url: str | None = Field(default=None, max_length=500)
     location_id: uuid.UUID | None = None
+    reading_status: ReadingStatus | None = ReadingStatus.UNREAD
+    lent_to: str | None = Field(default=None, min_length=1, max_length=300)
     processing_status: BookProcessingStatus = BookProcessingStatus.MANUAL
 
 
@@ -33,11 +35,13 @@ class BookUpdateRequest(BaseModel):
     publication_year: int | None = Field(default=None, ge=0, le=9999)
     cover_image_url: str | None = Field(default=None, max_length=500)
     location_id: uuid.UUID | None = None
+    reading_status: ReadingStatus | None = None
+    lent_to: str | None = Field(default=None, min_length=1, max_length=300)
     processing_status: BookProcessingStatus | None = None
 
     @model_validator(mode="after")
     def reject_explicit_nulls(self) -> "BookUpdateRequest":
-        nullable_fields = {"author", "isbn", "publisher", "language", "description", "publication_year", "cover_image_url", "location_id"}
+        nullable_fields = {"author", "isbn", "publisher", "language", "description", "publication_year", "cover_image_url", "location_id", "reading_status", "lent_to"}
         for field_name in self.model_fields_set:
             if field_name not in nullable_fields and getattr(self, field_name) is None:
                 raise ValueError(f"{field_name} cannot be null")
@@ -57,6 +61,8 @@ class BookResponse(BaseModel):
     publication_year: int | None
     cover_image_url: str | None
     location_id: uuid.UUID | None
+    reading_status: ReadingStatus | None
+    lent_to: str | None
     processing_status: BookProcessingStatus
     created_at: datetime
     updated_at: datetime

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -377,3 +377,72 @@ async def test_books_export_requires_authentication() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get('/api/v1/books/export')
     assert response.status_code == 401
+
+
+
+@pytest.mark.asyncio
+async def test_create_book_with_reading_status(test_session: async_sessionmaker[AsyncSession]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        response = await client.post(
+            "/api/v1/books",
+            json={"title": "Reading Status Book", "reading_status": "reading"},
+            headers=headers,
+        )
+
+    assert response.status_code == 201
+    assert response.json()["reading_status"] == "reading"
+
+
+@pytest.mark.asyncio
+async def test_update_book_reading_status_to_lent(test_session: async_sessionmaker[AsyncSession]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        created = await client.post(
+            "/api/v1/books",
+            json={"title": "Lendable Book"},
+            headers=headers,
+        )
+        assert created.status_code == 201
+        book_id = created.json()["id"]
+
+        updated = await client.patch(
+            f"/api/v1/books/{book_id}",
+            json={"reading_status": "lent", "lent_to": "John"},
+            headers=headers,
+        )
+
+    assert updated.status_code == 200
+    assert updated.json()["reading_status"] == "lent"
+    assert updated.json()["lent_to"] == "John"
+
+
+@pytest.mark.asyncio
+async def test_lent_to_cleared_when_status_changes_from_lent(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        created = await client.post(
+            "/api/v1/books",
+            json={"title": "Previously Lent", "reading_status": "lent", "lent_to": "John"},
+            headers=headers,
+        )
+        assert created.status_code == 201
+        book_id = created.json()["id"]
+
+        updated = await client.patch(
+            f"/api/v1/books/{book_id}",
+            json={"reading_status": "read", "lent_to": None},
+            headers=headers,
+        )
+
+    assert updated.status_code == 200
+    assert updated.json()["reading_status"] == "read"
+    assert updated.json()["lent_to"] is None

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -23,12 +23,12 @@ Last updated: 2026-03-27
 
 ## In Progress
 
-- `reading_status` + `lent_to` fields on Book (branch: `feat/alembic-reading-status-migration`, PR #83)
-- Frontend BookDetailPage tabs + empty states (PR #84)
-- Production readiness foundation v2 (PR #96)
+Nothing active. All planned phases complete as of 2026-03-27.
 
 ## Known Issues
 
+- reading_status + lent_to were missing from backend model/schemas after PR #96 merge conflict — restored in this PR
+- CI backend tests were using SQLite instead of PostgreSQL — fixed in this PR
 - Entity design doc (`docs/entity-design.md`) was missing `reading_status` and `lent_to` — now updated
 - Branch naming in practice uses `feat/` and `fix/` prefixes, not `feature/` as originally documented — standard updated to match reality
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -527,6 +527,30 @@
         }
       }
     },
+    "/api/v1/books/export": {
+      "get": {
+        "tags": [
+          "books"
+        ],
+        "summary": "Export Books Csv",
+        "operationId": "export_books_csv_api_v1_books_export_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/books/{book_id}": {
       "get": {
         "tags": [
@@ -956,6 +980,30 @@
             ],
             "title": "Location Id"
           },
+          "reading_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReadingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "unread"
+          },
+          "lent_to": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 300,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lent To"
+          },
           "processing_status": {
             "$ref": "#/components/schemas/BookProcessingStatus",
             "default": "manual"
@@ -1109,6 +1157,27 @@
             ],
             "title": "Location Id"
           },
+          "reading_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReadingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lent_to": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lent To"
+          },
           "processing_status": {
             "$ref": "#/components/schemas/BookProcessingStatus"
           },
@@ -1135,6 +1204,8 @@
           "publication_year",
           "cover_image_url",
           "location_id",
+          "reading_status",
+          "lent_to",
           "processing_status",
           "created_at",
           "updated_at"
@@ -1256,6 +1327,29 @@
               }
             ],
             "title": "Location Id"
+          },
+          "reading_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReadingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lent_to": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 300,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lent To"
           },
           "processing_status": {
             "anyOf": [
@@ -1513,6 +1607,16 @@
           "failed"
         ],
         "title": "ProcessingJobStatus"
+      },
+      "ReadingStatus": {
+        "type": "string",
+        "enum": [
+          "unread",
+          "reading",
+          "read",
+          "lent"
+        ],
+        "title": "ReadingStatus"
       },
       "RefreshRequest": {
         "properties": {


### PR DESCRIPTION
## What regressed and why

PR #96 introduced a merge-conflict regression where `reading_status` and `lent_to` were dropped from the SQLAlchemy Book model and Pydantic book schemas, even though the DB migration (`20260916_000005`) and frontend still require these fields. This made backend silently ignore expected payload/response fields.

## What this PR fixes

- Restores `ReadingStatus` enum and `reading_status` + `lent_to` columns in `backend/app/models/book.py`
- Restores `reading_status` + `lent_to` in request/response schemas (`backend/app/schemas/book.py`)
- Updates nullable field handling in `BookUpdateRequest` validator
- Switches backend CI test DB from SQLite to PostgreSQL service in `.github/workflows/ci.yml`
- Updates `docs/current-status.md` In Progress/Known Issues section for current reality

## Tests covering restored fields

Added in `backend/tests/test_books.py`:
- `test_create_book_with_reading_status`
- `test_update_book_reading_status_to_lent`
- `test_lent_to_cleared_when_status_changes_from_lent`

Validation run:
- `ruff check app tests`
- `mypy app tests`
- `pytest -q tests/test_books.py`

## OpenAPI regeneration

Confirmed: `docs/openapi.yaml` was regenerated using:

`python scripts/generate_openapi.py`

and committed in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added reading status tracking for books with four states: unread, reading, read, and lent.
  * Added ability to record who books are lent to.
  * Added books export functionality with authenticated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->