### PR TITLE
fix: enforce lent_to auto-clear when status leaves lent

### DIFF
--- a/backend/app/services/book.py
+++ b/backend/app/services/book.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
-from app.models.book import Book
+from app.models.book import Book, ReadingStatus
 from app.models.location import Location
 from app.schemas.book import BookCreateRequest, BookUpdateRequest
 
@@ -97,6 +97,9 @@ async def update_book(session: AsyncSession, book_id: uuid.UUID, payload: BookUp
 
     for field_name, value in update_data.items():
         setattr(book, field_name, value)
+
+    if book.reading_status != ReadingStatus.LENT:
+        book.lent_to = None
 
     try:
         await session.commit()

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -446,3 +446,31 @@ async def test_lent_to_cleared_when_status_changes_from_lent(
     assert updated.status_code == 200
     assert updated.json()["reading_status"] == "read"
     assert updated.json()["lent_to"] is None
+
+
+
+@pytest.mark.asyncio
+async def test_lent_to_auto_cleared_when_status_changes_without_explicit_null(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        created = await client.post(
+            "/api/v1/books",
+            json={"title": "Implicit clear", "reading_status": "lent", "lent_to": "John"},
+            headers=headers,
+        )
+        assert created.status_code == 201
+        book_id = created.json()["id"]
+
+        updated = await client.patch(
+            f"/api/v1/books/{book_id}",
+            json={"reading_status": "read"},
+            headers=headers,
+        )
+
+    assert updated.status_code == 200
+    assert updated.json()["reading_status"] == "read"
+    assert updated.json()["lent_to"] is None


### PR DESCRIPTION
## Summary
Enforces business rule in backend service: whenever a book reading_status is not `lent`, `lent_to` is automatically set to null regardless of client payload.

## Changes
- `backend/app/services/book.py`
  - in update flow, after patch application:
  - `if book.reading_status != ReadingStatus.LENT: book.lent_to = None`
- `backend/tests/test_books.py`
  - added `test_lent_to_auto_cleared_when_status_changes_without_explicit_null`

## Verification
- `ruff check app tests`
- `mypy app tests`
- `pytest -q tests/test_books.py`

No schema changes in this PR, so OpenAPI regeneration was not required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "lent to" field is now automatically cleared when a book's reading status is changed away from "lent".

* **Tests**
  * Added test coverage for automatic clearing of book lending information when status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->