### PR TITLE
[Phase LP-4] Add landing analytics events and A/B test readiness

### DIFF
--- a/frontend/src/components/AccordionSection.tsx
+++ b/frontend/src/components/AccordionSection.tsx
@@ -4,17 +4,24 @@ interface AccordionSectionProps {
   title: string
   defaultOpen?: boolean
   badge?: ReactNode
+  onToggle?: (isOpen: boolean) => void
   children: ReactNode
 }
 
-export function AccordionSection({ title, defaultOpen = true, badge, children }: AccordionSectionProps) {
+export function AccordionSection({ title, defaultOpen = true, badge, onToggle, children }: AccordionSectionProps) {
   const [open, setOpen] = useState(defaultOpen)
 
   return (
     <div style={{ borderBottom: '1px solid var(--sh-border)' }}>
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() =>
+          setOpen((v) => {
+            const next = !v
+            onToggle?.(next)
+            return next
+          })
+        }
         aria-expanded={open}
         style={{
           width: '100%',

--- a/frontend/src/lib/landingAnalytics.ts
+++ b/frontend/src/lib/landingAnalytics.ts
@@ -1,0 +1,82 @@
+import { trackEvent } from './analytics'
+
+const LANDING_VARIANT_QUERY_KEYS = ['lp_variant', 'variant']
+const DEFAULT_VARIANT_ID = 'control'
+
+function sanitizeVariantId(input: string | null): string {
+  if (!input) return DEFAULT_VARIANT_ID
+  const normalized = input.trim().toLowerCase()
+  if (!normalized) return DEFAULT_VARIANT_ID
+  if (!/^[a-z0-9_-]{1,48}$/.test(normalized)) return DEFAULT_VARIANT_ID
+  return normalized
+}
+
+export function resolveLandingVariantId(searchParams: URLSearchParams): string {
+  for (const key of LANDING_VARIANT_QUERY_KEYS) {
+    const candidate = sanitizeVariantId(searchParams.get(key))
+    if (candidate !== DEFAULT_VARIANT_ID) return candidate
+  }
+  return DEFAULT_VARIANT_ID
+}
+
+function getLandingDeviceType(): 'mobile' | 'desktop' | 'unknown' {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return 'unknown'
+  return window.matchMedia('(max-width: 767px)').matches ? 'mobile' : 'desktop'
+}
+
+function getLandingReferrer(): string {
+  if (typeof document === 'undefined' || !document.referrer) return 'direct'
+  try {
+    const hostname = new URL(document.referrer).hostname
+    return hostname || 'direct'
+  } catch {
+    return 'direct'
+  }
+}
+
+export function trackLandingView(variantId: string, locale: string): void {
+  trackEvent('lp_view', {
+    variant_id: variantId,
+    locale,
+    device_type: getLandingDeviceType(),
+    referrer: getLandingReferrer(),
+  })
+}
+
+export function trackHeroCtaClick(ctaLabel: string, variantId: string): void {
+  trackEvent('lp_hero_cta_click', {
+    cta_label: ctaLabel,
+    variant_id: variantId,
+    section: 'hero',
+  })
+}
+
+export function trackSupportingCtaClick(ctaLabel: string, section: string): void {
+  trackEvent('lp_supporting_cta_click', {
+    cta_label: ctaLabel,
+    section,
+  })
+}
+
+export function trackPricingTeaserClick(ctaLabel: string, variantId: string): void {
+  trackEvent('lp_pricing_teaser_click', {
+    cta_label: ctaLabel,
+    plan_hint: 'mixed',
+    variant_id: variantId,
+  })
+}
+
+export function trackFaqExpand(faqId: string, faqTopic: string): void {
+  trackEvent('lp_faq_expand', {
+    faq_id: faqId,
+    faq_topic: faqTopic,
+  })
+}
+
+export function trackSignupStart(sourceSection: string, ctaLabel: string, variantId: string): void {
+  trackEvent('lp_signup_start', {
+    source_section: sourceSection,
+    cta_label: ctaLabel,
+    variant_id: variantId,
+  })
+}

--- a/frontend/src/pages/LandingPage.test.tsx
+++ b/frontend/src/pages/LandingPage.test.tsx
@@ -1,12 +1,22 @@
 import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LandingPage } from './LandingPage'
 
+const trackEventMock = vi.fn()
+
+vi.mock('../lib/analytics', () => ({
+  trackEvent: (event: string, props?: Record<string, unknown>) => trackEventMock(event, props),
+}))
+
 afterEach(() => {
   cleanup()
+})
+
+beforeEach(() => {
+  trackEventMock.mockReset()
 })
 
 describe('LandingPage conversion sections', () => {
@@ -45,5 +55,68 @@ describe('LandingPage conversion sections', () => {
 
     expect(secondQuestion).toHaveAttribute('aria-expanded', 'true')
     expect(faqWithin.getAllByText('landing.faq_a_2').length).toBeGreaterThan(0)
+  })
+
+  it('tracks landing view with experiment variant from URL', () => {
+    render(
+      <MemoryRouter initialEntries={['/?lp_variant=hero_b']}>
+        <LandingPage />
+      </MemoryRouter>,
+    )
+
+    expect(trackEventMock).toHaveBeenCalledWith(
+      'lp_view',
+      expect.objectContaining({
+        variant_id: 'hero_b',
+        locale: 'cs',
+      }),
+    )
+  })
+
+  it('tracks hero signup CTA click and signup start event', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getAllByRole('button', { name: 'landing.hero_cta_signup' })[0])
+
+    expect(trackEventMock).toHaveBeenCalledWith(
+      'lp_signup_start',
+      expect.objectContaining({
+        source_section: 'hero',
+        cta_label: 'landing.hero_cta_signup',
+      }),
+    )
+    expect(trackEventMock).toHaveBeenCalledWith(
+      'lp_hero_cta_click',
+      expect.objectContaining({
+        section: 'hero',
+      }),
+    )
+  })
+
+  it('tracks faq expand events when closed question is opened', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    )
+
+    const secondQuestion = screen.getByRole('button', { name: 'landing.faq_q_2' })
+    await user.click(secondQuestion)
+
+    expect(trackEventMock).toHaveBeenCalledWith(
+      'lp_faq_expand',
+      expect.objectContaining({
+        faq_id: 'faq_2',
+        faq_topic: 'landing.faq_q_2',
+      }),
+    )
   })
 })

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,8 +1,17 @@
 import type { CSSProperties } from 'react'
-import { useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { AccordionSection } from '../components/AccordionSection'
+import {
+  resolveLandingVariantId,
+  trackFaqExpand,
+  trackHeroCtaClick,
+  trackLandingView,
+  trackPricingTeaserClick,
+  trackSignupStart,
+  trackSupportingCtaClick,
+} from '../lib/landingAnalytics'
 import { ROUTES } from '../lib/routes'
 
 const FEATURE_ICON_STYLE: CSSProperties = {
@@ -20,9 +29,25 @@ const FEATURE_CARD_STYLE: CSSProperties = {
 }
 
 export function LandingPage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const howItWorksRef = useRef<HTMLElement | null>(null)
+  const variantId = useMemo(() => resolveLandingVariantId(searchParams), [searchParams])
+
+  useEffect(() => {
+    trackLandingView(variantId, i18n.language)
+  }, [i18n.language, variantId])
+
+  function handleSignupCtaClick(sourceSection: string, ctaLabel: string, isHero: boolean): void {
+    trackSignupStart(sourceSection, ctaLabel, variantId)
+    if (isHero) {
+      trackHeroCtaClick(ctaLabel, variantId)
+    } else {
+      trackSupportingCtaClick(ctaLabel, sourceSection)
+    }
+    navigate(ROUTES.login)
+  }
 
   const howItWorksSteps = useMemo(
     () => [
@@ -108,7 +133,10 @@ export function LandingPage() {
   )
 
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--sh-bg)', display: 'flex', flexDirection: 'column' }}>
+    <div
+      style={{ minHeight: '100vh', background: 'var(--sh-bg)', display: 'flex', flexDirection: 'column' }}
+      data-landing-variant={variantId}
+    >
       {/* ── Top bar ── */}
       <header
         style={{
@@ -125,7 +153,10 @@ export function LandingPage() {
           type='button'
           className='sh-btn-secondary'
           style={{ fontSize: 14 }}
-          onClick={() => navigate(ROUTES.login)}
+          onClick={() => {
+            trackSupportingCtaClick(t('landing.hero_cta_login'), 'header')
+            navigate(ROUTES.login)
+          }}
         >
           {t('landing.hero_cta_login')}
         </button>
@@ -172,7 +203,7 @@ export function LandingPage() {
                 type='button'
                 className='sh-btn-primary'
                 style={{ fontSize: 16, padding: '12px 28px' }}
-                onClick={() => navigate(ROUTES.login)}
+                onClick={() => handleSignupCtaClick('hero', t('landing.hero_cta_signup'), true)}
               >
                 {t('landing.hero_cta_signup')}
               </button>
@@ -180,7 +211,10 @@ export function LandingPage() {
                 type='button'
                 className='sh-btn-secondary'
                 style={{ fontSize: 16, padding: '12px 28px' }}
-                onClick={() => howItWorksRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+                onClick={() => {
+                  trackSupportingCtaClick(t('landing.hero_cta_watch_demo'), 'hero')
+                  howItWorksRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                }}
               >
                 {t('landing.hero_cta_watch_demo')}
               </button>
@@ -451,7 +485,10 @@ export function LandingPage() {
               type='button'
               className='sh-btn-primary'
               style={{ fontSize: 15 }}
-              onClick={() => navigate(ROUTES.pricing)}
+              onClick={() => {
+                trackPricingTeaserClick(t('landing.see_pricing'), variantId)
+                navigate(ROUTES.pricing)
+              }}
             >
               {t('landing.see_pricing')}
             </button>
@@ -459,7 +496,10 @@ export function LandingPage() {
               type='button'
               className='sh-btn-secondary'
               style={{ fontSize: 15 }}
-              onClick={() => navigate(ROUTES.pricing)}
+              onClick={() => {
+                trackPricingTeaserClick(t('landing.pricing_compare'), variantId)
+                navigate(ROUTES.pricing)
+              }}
             >
               {t('landing.pricing_compare')}
             </button>
@@ -486,7 +526,15 @@ export function LandingPage() {
             }}
           >
             {faqItems.map((item, index) => (
-              <AccordionSection key={item.question} title={item.question} defaultOpen={index === 0}>
+              <AccordionSection
+                key={item.question}
+                title={item.question}
+                defaultOpen={index === 0}
+                onToggle={(isOpen) => {
+                  if (!isOpen) return
+                  trackFaqExpand(`faq_${index + 1}`, item.question)
+                }}
+              >
                 <p style={{ margin: 0, fontSize: 14, lineHeight: 1.6, color: 'var(--sh-text-secondary)' }}>{item.answer}</p>
               </AccordionSection>
             ))}
@@ -496,7 +544,7 @@ export function LandingPage() {
               type='button'
               className='sh-btn-primary'
               style={{ fontSize: 15 }}
-              onClick={() => navigate(ROUTES.login)}
+              onClick={() => handleSignupCtaClick('faq', t('landing.hero_cta_signup'), false)}
             >
               {t('landing.hero_cta_signup')}
             </button>
@@ -504,7 +552,10 @@ export function LandingPage() {
               type='button'
               className='sh-btn-secondary'
               style={{ fontSize: 15 }}
-              onClick={() => navigate(ROUTES.login)}
+              onClick={() => {
+                trackSupportingCtaClick(t('landing.faq_cta_support'), 'faq')
+                navigate(ROUTES.login)
+              }}
             >
               {t('landing.faq_cta_support')}
             </button>
@@ -539,7 +590,7 @@ export function LandingPage() {
                 type='button'
                 className='sh-btn-primary'
                 style={{ fontSize: 15 }}
-                onClick={() => navigate(ROUTES.login)}
+                onClick={() => handleSignupCtaClick('final_cta', t('landing.hero_cta_signup'), false)}
               >
                 {t('landing.hero_cta_signup')}
               </button>
@@ -547,7 +598,10 @@ export function LandingPage() {
                 type='button'
                 className='sh-btn-secondary'
                 style={{ fontSize: 15 }}
-                onClick={() => navigate(ROUTES.login)}
+                onClick={() => {
+                  trackSupportingCtaClick(t('landing.hero_cta_login'), 'final_cta')
+                  navigate(ROUTES.login)
+                }}
               >
                 {t('landing.hero_cta_login')}
               </button>


### PR DESCRIPTION
### Motivation
- Enable product analytics and A/B experiment readiness for the public landing page by emitting well‑scoped PostHog events and exposing a variant identifier for experiment tooling.
- Provide a small, centralized helper for landing-specific event names/props so the page and tests stay decoupled from the raw analytics implementation.

### Description
- Added `frontend/src/lib/landingAnalytics.ts` which resolves sanitized experiment variant ids from query params (`lp_variant` / `variant`), determines device/referrer, and exposes tracking helpers such as `trackLandingView`, `trackHeroCtaClick`, `trackSupportingCtaClick`, `trackPricingTeaserClick`, `trackFaqExpand`, and `trackSignupStart`.
- Instrumented `frontend/src/pages/LandingPage.tsx` to: fire `lp_view` on mount with variant/locale/device/referrer, attach CTA click tracking (`lp_hero_cta_click`, `lp_supporting_cta_click`, `lp_pricing_teaser_click`), emit `lp_signup_start` on signup CTAs, and emit `lp_faq_expand` on FAQ opens, and add `data-landing-variant` on the root container for experiment tooling.
- Extended `frontend/src/components/AccordionSection.tsx` with an optional `onToggle` callback so FAQ opens can be tracked from the page without coupling analytics into the shared component internals.
- Added/updated unit tests in `frontend/src/pages/LandingPage.test.tsx` to cover variant-aware `lp_view`, hero CTA tracking (signup start + hero click), and FAQ expand tracking.

### Testing
- Ran backend checks: `cd backend && ruff check app tests` and `cd backend && mypy app tests`, both of which failed due to pre-existing lint/type issues unrelated to this landing change.
- Ran backend pytest with coverage flags (`TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`) which failed here because the environment did not accept the coverage CLI options (`unrecognized arguments`).
- Ran frontend project checks: `cd frontend && npm run lint` and full `npm test -- --run`, both of which failed due to unrelated existing frontend lint/test failures in other areas of the app.
- Focused checks for touched files passed: `npx eslint` targeting the modified files succeeded and `npx vitest run src/pages/LandingPage.test.tsx` succeeded (the landing page tests pass locally in the change set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7849ea5a08325ae46a7e202f65b03)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive analytics tracking to the landing page to monitor user interactions with call-to-action buttons, FAQ sections, and signup flows
  * Enhanced accordion components to support interaction callbacks

* **Tests**
  * Added test coverage for landing page analytics event tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->