### PR TITLE
fix(auth): gate protected queries during auth bootstrap to avoid blank UI (#125)

### DIFF
--- a/frontend/src/hooks/useBooks.ts
+++ b/frontend/src/hooks/useBooks.ts
@@ -157,10 +157,11 @@ export function useBulkUpdateStatus() {
 }
 
 export function useJobStatus(jobId: string | null) {
+  const { isAuthenticated } = useAuth()
   return useQuery({
     queryKey: ['job-status', jobId],
     queryFn: () => getJobStatus(jobId as string),
-    enabled: Boolean(jobId),
+    enabled: isAuthenticated && Boolean(jobId),
     refetchInterval: (query) => {
       const status = query.state.data?.status
       return status === 'done' || status === 'failed' ? false : 2000

--- a/frontend/src/hooks/useLoans.ts
+++ b/frontend/src/hooks/useLoans.ts
@@ -3,16 +3,18 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 
 import { createLoan, formatApiError, listLoans, returnLoan } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
 import { useToastStore } from '../lib/toast-store'
 import type { LoanCreateRequest, LoanReturnRequest } from '../lib/types'
 
 const loansKey = (bookId: string) => ['loans', bookId]
 
 export function useLoans(bookId: string) {
+  const { isAuthenticated } = useAuth()
   return useQuery({
     queryKey: loansKey(bookId),
     queryFn: () => listLoans(bookId),
-    enabled: Boolean(bookId),
+    enabled: isAuthenticated && Boolean(bookId),
     retry: false,
   })
 }

--- a/frontend/src/hooks/useScan.ts
+++ b/frontend/src/hooks/useScan.ts
@@ -9,6 +9,7 @@ import {
   listBooksByLocation,
   scanShelf,
 } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
 import { useToastStore } from '../lib/toast-store'
 import type { ShelfScanConfirmRequest } from '../lib/types'
 import { BOOKS_QUERY_KEY } from './useBooks'
@@ -26,10 +27,11 @@ export function useScanShelf() {
 }
 
 export function useShelfScanResult(jobId: string | null) {
+  const { isAuthenticated } = useAuth()
   return useQuery({
     queryKey: ['shelf-scan', jobId],
     queryFn: () => getShelfScanResult(jobId as string),
-    enabled: Boolean(jobId),
+    enabled: isAuthenticated && Boolean(jobId),
     refetchInterval: (query) => {
       const status = query.state.data?.status
       return status === 'done' || status === 'failed' ? false : 2000
@@ -57,10 +59,11 @@ export function useConfirmShelfScan() {
 }
 
 export function useBooksByLocation(locationId: string | null) {
+  const { isAuthenticated } = useAuth()
   return useQuery({
     queryKey: ['books-by-location', locationId],
     queryFn: () => listBooksByLocation(locationId as string),
-    enabled: Boolean(locationId),
+    enabled: isAuthenticated && Boolean(locationId),
     retry: false,
   })
 }


### PR DESCRIPTION
### Motivation
- Users reported a blank/incomplete UI after login until a manual refresh caused by protected React Query hooks firing during the auth bootstrap/login window and caching transient error states (issue #125). 
- The intent is to ensure no protected queries run until auth has settled so the UI always renders a deterministic loading/authenticated state. 

### Description
- Gate queries on auth state by adding `isAuthenticated` checks to the protected hooks so they only run after a session is established. 
- Updated `useJobStatus` in `frontend/src/hooks/useBooks.ts` to require `isAuthenticated && Boolean(jobId)`. 
- Updated `useLoans` in `frontend/src/hooks/useLoans.ts` to require `isAuthenticated && Boolean(bookId)`. 
- Updated `useShelfScanResult` and `useBooksByLocation` in `frontend/src/hooks/useScan.ts` to require `isAuthenticated` in addition to their id guards. 

### Testing
- Ran focused ESLint on the modified files with `cd frontend && npx eslint src/hooks/useBooks.ts src/hooks/useLoans.ts src/hooks/useScan.ts`, which passed for the changed files. 
- Ran the focused test subset with `cd frontend && npm test -- --run src/App.test.tsx src/contexts/AuthContext.test.tsx`, and those tests passed. 
- `cd frontend && npm run lint` (full lint) fails due to pre-existing unrelated lint errors elsewhere in the repo and was not introduced by this change. 
- `cd frontend && npm test -- --run` (full suite) also fails due to unrelated environment/test issues not introduced by these hook changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7093694308325bd1a629310385bcb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a security issue where data queries could execute without proper user authentication. Queries for job status, loans, and shelf scans now correctly require users to be authenticated before retrieving information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->