### PR TITLE
Stabilize auth transitions and gate background queries on authentication

### DIFF
--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -29,6 +29,10 @@ interface Deferred<T> {
 }
 
 const meQueue: Deferred<{ id: string; email: string }>[] = []
+let authHandlers: {
+  onUnauthorized: (() => void) | null
+  onTokenRefresh: ((accessToken: string) => void) | null
+} = { onUnauthorized: null, onTokenRefresh: null }
 
 function enqueueDeferred(): Deferred<{ id: string; email: string }> {
   let resolve!: (value: { id: string; email: string }) => void
@@ -59,7 +63,12 @@ vi.mock('../lib/api', () => {
     register: vi.fn(() => Promise.resolve({ id: 'u1', email: 'a@b.co' })),
     logout: vi.fn(() => Promise.resolve()),
     googleOAuthCallback: vi.fn(() => Promise.resolve({ access_token: 'tok-google' })),
-    registerAuthHandlers: vi.fn(),
+    registerAuthHandlers: vi.fn((handlers: {
+      onUnauthorized: (() => void) | null
+      onTokenRefresh: ((accessToken: string) => void) | null
+    }) => {
+      authHandlers = handlers
+    }),
   }
 })
 
@@ -135,6 +144,7 @@ function renderWithProviders(onSnapshot: (row: SnapshotRow) => void) {
 
 beforeEach(() => {
   meQueue.length = 0
+  authHandlers = { onUnauthorized: null, onTokenRefresh: null }
   vi.mocked(apiModule.login).mockClear()
   vi.mocked(apiModule.logout).mockClear()
   vi.mocked(apiModule.getCurrentUser).mockClear()
@@ -260,6 +270,39 @@ describe('AuthContext — login flow', () => {
     // "flash of wrong data" symptom described in #125.
     expect(client.getQueryData(['stale-books'])).toBeUndefined()
   })
+
+  it('ignores stale unauthorized callbacks while login transition is in flight', async () => {
+    renderWithProviders(() => {})
+
+    const bootstrapMe = await waitForNextMeCall()
+    await act(async () => {
+      bootstrapMe.reject(new Error('401'))
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-flag').textContent).toBe('no'),
+    )
+
+    await act(async () => {
+      screen.getByTestId('do-login').click()
+    })
+
+    // Simulate race from stale in-flight request:
+    // /auth/me -> 401, refresh -> 401, interceptor calls onUnauthorized.
+    await act(async () => {
+      authHandlers.onUnauthorized?.()
+      authHandlers.onUnauthorized?.()
+    })
+
+    const loginMe = await waitForNextMeCall()
+    await act(async () => {
+      loginMe.resolve({ id: 'u2', email: 'u2@example.com' })
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-flag').textContent).toBe('yes'),
+    )
+    expect(vi.mocked(apiModule.logout)).not.toHaveBeenCalled()
+  })
 })
 
 describe('AuthContext — logout', () => {
@@ -285,5 +328,43 @@ describe('AuthContext — logout', () => {
       expect(screen.getByTestId('auth-flag').textContent).toBe('no'),
     )
     expect(client.getQueryData(['stale-books'])).toBeUndefined()
+  })
+
+  it('supports quick logout -> login without ending in an unauthenticated state', async () => {
+    renderWithProviders(() => {})
+
+    const bootstrapMe = await waitForNextMeCall()
+    await act(async () => {
+      bootstrapMe.resolve({ id: 'u1', email: 'a@b.co' })
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-flag').textContent).toBe('yes'),
+    )
+
+    await act(async () => {
+      screen.getByTestId('do-logout').click()
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-flag').textContent).toBe('no'),
+    )
+
+    await act(async () => {
+      screen.getByTestId('do-login').click()
+    })
+
+    // A late stale unauthorized signal should be ignored during this transition.
+    await act(async () => {
+      authHandlers.onUnauthorized?.()
+    })
+
+    const loginMe = await waitForNextMeCall()
+    await act(async () => {
+      loginMe.resolve({ id: 'u3', email: 'u3@example.com' })
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-flag').textContent).toBe('yes'),
+    )
+    expect(screen.getByTestId('loading-flag').textContent).toBe('no')
   })
 })

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useMemo,
   useReducer,
+  useRef,
   type ReactNode,
 } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -65,6 +66,8 @@ interface AuthState {
 }
 
 type AuthAction =
+  | { type: 'transition_started' }
+  | { type: 'transition_finished' }
   | { type: 'bootstrap_settled'; user: User | null; accessToken: string | null }
   | { type: 'session_established'; user: User; accessToken: string }
   | { type: 'session_cleared' }
@@ -72,6 +75,10 @@ type AuthAction =
 
 function authReducer(state: AuthState, action: AuthAction): AuthState {
   switch (action.type) {
+    case 'transition_started':
+      return { ...state, isLoading: true }
+    case 'transition_finished':
+      return { ...state, isLoading: false }
     case 'bootstrap_settled':
       return { user: action.user, accessToken: action.accessToken, isLoading: false }
     case 'session_established':
@@ -92,6 +99,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [state, dispatch] = useReducer(authReducer, INITIAL_STATE)
+  const transitionSequenceRef = useRef(0)
+  const activeTransitionRef = useRef<number | null>(null)
+
+  const beginTransition = useCallback(() => {
+    const transitionId = ++transitionSequenceRef.current
+    activeTransitionRef.current = transitionId
+    dispatch({ type: 'transition_started' })
+    return transitionId
+  }, [])
+
+  const endTransition = useCallback((transitionId: number) => {
+    if (activeTransitionRef.current !== transitionId) return
+    activeTransitionRef.current = null
+    dispatch({ type: 'transition_finished' })
+  }, [])
 
   // ── Query-cache hygiene ────────────────────────────────────────────────
   // The query cache MUST be wiped on every auth boundary:
@@ -110,6 +132,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [queryClient])
 
   const logout = useCallback(() => {
+    const transitionId = beginTransition()
     // Fire-and-forget; the server clears the auth cookies server-side.
     void apiLogout()
     clearTokens()
@@ -123,7 +146,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     dispatch({ type: 'session_cleared' })
     resetUser()
     navigate('/login', { replace: true })
-  }, [navigate, resetQueryCache])
+    endTransition(transitionId)
+  }, [beginTransition, endTransition, navigate, resetQueryCache])
 
   /**
    * Establish a session atomically: one call to the backend for the user,
@@ -132,11 +156,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
    * ever sees the half-applied auth state that used to cause blank renders.
    */
   const establishSession = useCallback(
-    async (accessTokenMarker: string) => {
+    async (accessTokenMarker: string, transitionId: number) => {
       // Keep the in-memory module singleton in sync so the axios interceptors
       // that live outside React can still read "has token" synchronously.
       setAccessToken(accessTokenMarker)
       const user = await getCurrentUser()
+      if (activeTransitionRef.current !== transitionId) return
       identifyUser(user.id)
       // Wipe any cached queries from a previous session before the UI can
       // remount under the new auth identity. Done BEFORE the dispatch so
@@ -153,10 +178,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = useCallback(
     async (email: string, password: string) => {
-      const tokens = await apiLogin({ email, password })
-      await establishSession(tokens.access_token)
+      const transitionId = beginTransition()
+      try {
+        const tokens = await apiLogin({ email, password })
+        await establishSession(tokens.access_token, transitionId)
+      } catch (error) {
+        dispatch({ type: 'session_cleared' })
+        throw error
+      } finally {
+        endTransition(transitionId)
+      }
     },
-    [establishSession],
+    [beginTransition, endTransition, establishSession],
   )
 
   const register = useCallback(
@@ -172,31 +205,46 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const loginWithGoogle = useCallback(
     async (code: string, state: string) => {
-      const tokens = await googleOAuthCallback({ code, state })
-      await establishSession(tokens.access_token)
+      const transitionId = beginTransition()
+      try {
+        const tokens = await googleOAuthCallback({ code, state })
+        await establishSession(tokens.access_token, transitionId)
+      } catch (error) {
+        dispatch({ type: 'session_cleared' })
+        throw error
+      } finally {
+        endTransition(transitionId)
+      }
     },
-    [establishSession],
+    [beginTransition, endTransition, establishSession],
   )
 
   const handleTokenRefresh = useCallback((token: string) => {
+    if (activeTransitionRef.current !== null) return
     setAccessToken(token)
     dispatch({ type: 'token_refreshed', accessToken: token })
   }, [])
 
+  const handleUnauthorized = useCallback(() => {
+    if (activeTransitionRef.current !== null) return
+    logout()
+  }, [logout])
+
   useEffect(() => {
     registerAuthHandlers({
-      onUnauthorized: logout,
+      onUnauthorized: handleUnauthorized,
       onTokenRefresh: handleTokenRefresh,
     })
 
     return () => registerAuthHandlers({ onUnauthorized: null, onTokenRefresh: null })
-  }, [handleTokenRefresh, logout])
+  }, [handleTokenRefresh, handleUnauthorized])
 
   useEffect(() => {
     // Bootstrap: if the HttpOnly cookie is still valid, /auth/me returns the
     // user. If not, surface the unauthenticated state. No token plumbing from
     // client-side storage is needed — everything flows through cookies.
     let cancelled = false
+    const transitionId = beginTransition()
     const bootstrap = async () => {
       try {
         const user = await getCurrentUser()
@@ -215,6 +263,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (cancelled) return
         clearTokens()
         dispatch({ type: 'bootstrap_settled', user: null, accessToken: null })
+      } finally {
+        endTransition(transitionId)
       }
     }
 
@@ -222,7 +272,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [beginTransition, endTransition])
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/frontend/src/hooks/useBooks.ts
+++ b/frontend/src/hooks/useBooks.ts
@@ -157,10 +157,11 @@ export function useBulkUpdateStatus() {
 }
 
 export function useJobStatus(jobId: string | null) {
+  const { isAuthenticated } = useAuth()
   return useQuery({
     queryKey: ['job-status', jobId],
     queryFn: () => getJobStatus(jobId as string),
-    enabled: Boolean(jobId),
+    enabled: isAuthenticated && Boolean(jobId),
     refetchInterval: (query) => {
       const status = query.state.data?.status
       return status === 'done' || status === 'failed' ? false : 2000

--- a/frontend/src/hooks/useLoans.ts
+++ b/frontend/src/hooks/useLoans.ts
@@ -3,16 +3,18 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 
 import { createLoan, formatApiError, listLoans, returnLoan } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
 import { useToastStore } from '../lib/toast-store'
 import type { LoanCreateRequest, LoanReturnRequest } from '../lib/types'
 
 const loansKey = (bookId: string) => ['loans', bookId]
 
 export function useLoans(bookId: string) {
+  const { isAuthenticated } = useAuth()
   return useQuery({
     queryKey: loansKey(bookId),
     queryFn: () => listLoans(bookId),
-    enabled: Boolean(bookId),
+    enabled: isAuthenticated && Boolean(bookId),
     retry: false,
   })
 }

--- a/frontend/src/hooks/useScan.ts
+++ b/frontend/src/hooks/useScan.ts
@@ -9,6 +9,7 @@ import {
   listBooksByLocation,
   scanShelf,
 } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
 import { useToastStore } from '../lib/toast-store'
 import type { ShelfScanConfirmRequest } from '../lib/types'
 import { BOOKS_QUERY_KEY } from './useBooks'
@@ -26,10 +27,11 @@ export function useScanShelf() {
 }
 
 export function useShelfScanResult(jobId: string | null) {
+  const { isAuthenticated } = useAuth()
   return useQuery({
     queryKey: ['shelf-scan', jobId],
     queryFn: () => getShelfScanResult(jobId as string),
-    enabled: Boolean(jobId),
+    enabled: isAuthenticated && Boolean(jobId),
     refetchInterval: (query) => {
       const status = query.state.data?.status
       return status === 'done' || status === 'failed' ? false : 2000
@@ -57,10 +59,11 @@ export function useConfirmShelfScan() {
 }
 
 export function useBooksByLocation(locationId: string | null) {
+  const { isAuthenticated } = useAuth()
   return useQuery({
     queryKey: ['books-by-location', locationId],
     queryFn: () => listBooksByLocation(locationId as string),
-    enabled: Boolean(locationId),
+    enabled: isAuthenticated && Boolean(locationId),
     retry: false,
   })
 }


### PR DESCRIPTION
### Motivation

- Fix race conditions where late `401`/unauthorized signals or mid-flight token rotations could leave the UI briefly unauthenticated or show stale data (the blank-screen / "ghost data" symptom in #125).
- Ensure the TanStack Query cache is reliably wiped on auth boundaries so a new session never sees a previous user's data.
- Prevent background polling queries from running when the user is not authenticated to avoid unnecessary requests and spurious errors.

### Description

- Add transition tracking (`transitionSequenceRef`, `activeTransitionRef`) and reducer actions (`transition_started`, `transition_finished`) to serialize auth transitions via `beginTransition` and `endTransition` so only the active transition may complete state changes.
- Thread transition ids into `login`, `loginWithGoogle`, `bootstrap`, and `establishSession` so stale responses or callbacks are ignored when they don't belong to the active transition.
- Make token refresh and unauthorized handlers no-ops while a transition is active by wiring `handleTokenRefresh` and `handleUnauthorized` into `registerAuthHandlers` and guarding on `activeTransitionRef`.
- Update hooks to avoid unauthenticated polling by importing `useAuth` and gating `enabled` with `isAuthenticated` in `useJobStatus`, `useLoans`, `useShelfScanResult`, and `useBooksByLocation`.
- Update tests to mock `registerAuthHandlers` so tests can drive `onUnauthorized`/`onTokenRefresh`, and add tests ensuring stale unauthorized callbacks are ignored during login and that a rapid logout→login doesn't leave the app unauthenticated.

### Testing

- Ran unit tests with `vitest` for `AuthContext` and related hooks, including the new tests that simulate stale unauthorized callbacks, and they passed.
- Existing test suite for query behavior and cache wiping was executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7093694308325bd1a629310385bcb)