### PR TITLE
feat: isolate Gemini parsing with Pydantic models (issue #122)

### DIFF
--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -26,6 +26,7 @@ from redis import Redis
 from sqlalchemy import DateTime, Enum as SAEnum, ForeignKey, Integer, String, Text, Uuid, create_engine, exc, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+from gemini_parser import parse_gemini_candidates
 from settings import worker_settings
 
 CACHE_TTL_SECONDS = 24 * 60 * 60
@@ -250,43 +251,6 @@ def _extract_title_author_from_text(text: str) -> tuple[str | None, str | None]:
     return title, author
 
 
-def _extract_json_object(text: str) -> dict[str, object] | None:
-    start_index = text.find("{")
-    end_index = text.rfind("}")
-    if start_index == -1 or end_index == -1 or end_index <= start_index:
-        return None
-
-    try:
-        parsed = json.loads(text[start_index : end_index + 1])
-    except json.JSONDecodeError:
-        return None
-
-    return parsed if isinstance(parsed, dict) else None
-
-
-
-
-def _extract_json_array(text: str) -> list[dict[str, object]] | None:
-    start_index = text.find("[")
-    end_index = text.rfind("]")
-    if start_index == -1 or end_index == -1 or end_index <= start_index:
-        return None
-
-    try:
-        parsed = json.loads(text[start_index : end_index + 1])
-    except json.JSONDecodeError:
-        return None
-
-    if not isinstance(parsed, list):
-        return None
-
-    out: list[dict[str, object]] = []
-    for item in parsed:
-        if isinstance(item, dict):
-            out.append(item)
-    return out or None
-
-
 def _normalize_vision_result(parsed: dict[str, object]) -> dict[str, object] | None:
     try:
         from text_normalize import normalize_book_fields
@@ -423,31 +387,12 @@ async def _extract_shelf_metadata_with_gemini(image_bytes: bytes) -> list[dict[s
         logger.warning("gemini_shelf_scan_failed", error_type=type(exc).__name__)
         return None
 
-    candidates = payload.get("candidates")
-    if not isinstance(candidates, list) or not candidates:
+    parsed_result = parse_gemini_candidates(payload)
+    if parsed_result is None:
+        logger.warning("shelf_scan_json_parse_failed")
         return None
-
-    content = candidates[0].get("content", {})
-    parts = content.get("parts", [])
-    if not isinstance(parts, list):
-        return None
-
-    text_blocks = [part.get("text") for part in parts if isinstance(part, dict) and isinstance(part.get("text"), str)]
-    if not text_blocks:
-        return None
-
-    blob = "\n".join(text_blocks)
-    parsed_array = _extract_json_array(blob)
-    parse_method = "json_array"
-    if parsed_array is None:
-        parsed_obj = _extract_json_object(blob)
-        if parsed_obj is None:
-            logger.warning("shelf_scan_json_parse_failed", blob_length=len(blob))
-            return None
-        parsed_array = [parsed_obj]
-        parse_method = "json_object_fallback"
-
-    logger.info("shelf_scan_json_parsed", method=parse_method, item_count=len(parsed_array))
+    parsed_items, parse_method = parsed_result
+    logger.info("shelf_scan_json_parsed", method=parse_method, item_count=len(parsed_items))
 
     # Import audit heuristics (sys.path already set up by _normalize_vision_result)
     try:
@@ -461,9 +406,9 @@ async def _extract_shelf_metadata_with_gemini(image_bytes: bytes) -> list[dict[s
         from text_normalize import audit_book_row
 
     normalized_results: list[dict[str, object]] = []
-    for parsed in parsed_array:
-        confidence = parsed.get("confidence") if isinstance(parsed.get("confidence"), str) else "medium"
-        normalized = _normalize_vision_result(parsed)
+    for parsed in parsed_items:
+        confidence = parsed.confidence
+        normalized = _normalize_vision_result(parsed.model_dump())
         if normalized is not None:
             # Run quality heuristics — downgrade confidence when flagged
             quality_flags = audit_book_row(normalized)
@@ -481,7 +426,7 @@ async def _extract_shelf_metadata_with_gemini(image_bytes: bytes) -> list[dict[s
             normalized_results.append(normalized)
         else:
             # Still include unrecognized items for user review
-            observed = parsed.get("observed_text") if isinstance(parsed.get("observed_text"), str) else None
+            observed = parsed.observed_text
             normalized_results.append({
                 "isbn": None,
                 "title": None,
@@ -550,33 +495,14 @@ async def _extract_spine_metadata_with_gemini(image_bytes: bytes) -> list[dict[s
         )
         return None
 
-    candidates = payload.get("candidates")
-    if not isinstance(candidates, list) or not candidates:
+    parsed_result = parse_gemini_candidates(payload)
+    if parsed_result is None:
         return None
-
-    content = candidates[0].get("content", {})
-    parts = content.get("parts", [])
-    if not isinstance(parts, list):
-        return None
-
-    text_blocks = [part.get("text") for part in parts if isinstance(part, dict) and isinstance(part.get("text"), str)]
-    if not text_blocks:
-        return None
-
-    blob = "\n".join(text_blocks)
-    parsed_array = _extract_json_array(blob)
-    parsed_items: list[dict[str, object]]
-    if parsed_array is not None:
-        parsed_items = parsed_array
-    else:
-        parsed_obj = _extract_json_object(blob)
-        if parsed_obj is None:
-            return None
-        parsed_items = [parsed_obj]
+    parsed_items, _parse_method = parsed_result
 
     normalized_results: list[dict[str, object]] = []
     for parsed in parsed_items:
-        normalized = _normalize_vision_result(parsed)
+        normalized = _normalize_vision_result(parsed.model_dump())
         if normalized is not None:
             normalized_results.append(normalized)
 

--- a/worker/gemini_parser.py
+++ b/worker/gemini_parser.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+class GeminiBookCandidate(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    title: str | None = None
+    author: str | None = None
+    isbn: str | None = None
+    observed_text: str | None = None
+    confidence: Literal["high", "medium", "low"] = "medium"
+
+
+class GeminiResponsePart(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    text: str | None = None
+
+
+class GeminiResponseContent(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    parts: list[GeminiResponsePart] = []
+
+
+class GeminiResponseCandidate(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    content: GeminiResponseContent
+
+
+class GeminiGenerateContentResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    candidates: list[GeminiResponseCandidate] = []
+
+
+def _extract_json_object(text: str) -> dict[str, object] | None:
+    start_index = text.find("{")
+    end_index = text.rfind("}")
+    if start_index == -1 or end_index == -1 or end_index <= start_index:
+        return None
+
+    try:
+        parsed = json.loads(text[start_index : end_index + 1])
+    except json.JSONDecodeError:
+        return None
+
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _extract_json_array(text: str) -> list[dict[str, object]] | None:
+    start_index = text.find("[")
+    end_index = text.rfind("]")
+    if start_index == -1 or end_index == -1 or end_index <= start_index:
+        return None
+
+    try:
+        parsed = json.loads(text[start_index : end_index + 1])
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(parsed, list):
+        return None
+
+    out: list[dict[str, object]] = []
+    for item in parsed:
+        if isinstance(item, dict):
+            out.append(item)
+    return out or None
+
+
+def parse_gemini_text_blob(text_blob: str) -> tuple[list[GeminiBookCandidate], str] | None:
+    parsed_array = _extract_json_array(text_blob)
+    parse_method = "json_array"
+    if parsed_array is None:
+        parsed_obj = _extract_json_object(text_blob)
+        if parsed_obj is None:
+            return None
+        parsed_array = [parsed_obj]
+        parse_method = "json_object_fallback"
+
+    items: list[GeminiBookCandidate] = []
+    for raw_item in parsed_array:
+        try:
+            items.append(GeminiBookCandidate.model_validate(raw_item))
+        except ValidationError:
+            continue
+    return (items, parse_method) if items else None
+
+
+def parse_gemini_candidates(payload: dict[str, object]) -> tuple[list[GeminiBookCandidate], str] | None:
+    try:
+        response = GeminiGenerateContentResponse.model_validate(payload)
+    except ValidationError:
+        return None
+
+    if not response.candidates:
+        return None
+
+    text_blocks = [part.text for part in response.candidates[0].content.parts if part.text]
+    if not text_blocks:
+        return None
+
+    return parse_gemini_text_blob("\n".join(text_blocks))

--- a/worker/tests/test_gemini_parser.py
+++ b/worker/tests/test_gemini_parser.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gemini_parser import parse_gemini_candidates, parse_gemini_text_blob
+
+
+def test_parse_gemini_candidates_json_array() -> None:
+    payload: dict[str, object] = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": (
+                                '[{"title":"Dune","author":"Frank Herbert","isbn":null,'
+                                '"observed_text":"Dune Frank Herbert","confidence":"high"}]'
+                            )
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    result = parse_gemini_candidates(payload)
+
+    assert result is not None
+    items, parse_method = result
+    assert parse_method == "json_array"
+    assert len(items) == 1
+    assert items[0].title == "Dune"
+    assert items[0].author == "Frank Herbert"
+    assert items[0].confidence == "high"
+
+
+def test_parse_gemini_candidates_json_object_fallback() -> None:
+    payload: dict[str, object] = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": (
+                                '{"title":"The Trial","author":"Franz Kafka","isbn":null,'
+                                '"observed_text":"The Trial Franz Kafka","confidence":"medium"}'
+                            )
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    result = parse_gemini_candidates(payload)
+
+    assert result is not None
+    items, parse_method = result
+    assert parse_method == "json_object_fallback"
+    assert len(items) == 1
+    assert items[0].title == "The Trial"
+
+
+def test_parse_gemini_text_blob_skips_invalid_confidence() -> None:
+    blob = (
+        "["
+        '{"title":"A","author":"B","isbn":null,"observed_text":"A B","confidence":"unknown"},'
+        '{"title":"Clean","author":"Row","isbn":null,"observed_text":"Clean Row","confidence":"low"}'
+        "]"
+    )
+
+    result = parse_gemini_text_blob(blob)
+
+    assert result is not None
+    items, parse_method = result
+    assert parse_method == "json_array"
+    assert len(items) == 1
+    assert items[0].title == "Clean"
+    assert items[0].confidence == "low"


### PR DESCRIPTION
### Motivation

- Separate and type the Gemini Vision response parsing to make worker code thinner, easier to reason about, and unit-testable per Issue #122.
- Move JSON extraction and candidate validation into a dedicated layer so parsing errors and schema deviations are handled explicitly.

### Description

- Added `worker/gemini_parser.py` which defines Pydantic models (`GeminiBookCandidate`, `GeminiGenerateContentResponse`, etc.) and parsing helpers `parse_gemini_candidates` and `parse_gemini_text_blob` that extract/validate JSON arrays or object fallbacks.
- Updated `worker/celery_app.py` to consume `parse_gemini_candidates(...)` instead of inlined JSON scraping, adapting shelf- and spine-extraction paths to iterate validated candidates and pass them through existing normalization/audit logic.
- Added unit tests `worker/tests/test_gemini_parser.py` covering JSON array parsing, object-fallback parsing, and filtering of invalid candidate rows.

### Testing

- Ran `GEMINI_API_KEY=dummy pytest worker/tests/test_gemini_parser.py worker/tests/test_celery_app.py -q` and received all tests passing (`23 passed`).
- Ran `ruff check worker/celery_app.py worker/gemini_parser.py worker/tests/test_gemini_parser.py` and it passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a4b33aa4832583714e8c3cb7d766)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Gemini response parsing with a new typed extraction system for book metadata from shelf and spine scans, replacing bespoke string-matching helpers.
  * Improved error handling and logging for parsing failures during book metadata extraction.
  * Structured parsed results now use validated model objects for more reliable data access.

* **Tests**
  * Added comprehensive test coverage for Gemini response parsing, including JSON array and object fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->