### PR TITLE
fix(security): enforce 403 on foreign X-Library-Id instead of silent fallback

### DIFF
--- a/backend/app/api/dependencies/library.py
+++ b/backend/app/api/dependencies/library.py
@@ -23,13 +23,8 @@ async def get_library_id(
         except ValueError as exc:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid X-Library-Id") from exc
 
-        try:
-            await require_library_role(session, current_user.id, candidate_library_id, LibraryRole.VIEWER)
-            return candidate_library_id
-        except HTTPException as exc:
-            if exc.status_code != status.HTTP_403_FORBIDDEN:
-                raise
-            # Stale/inaccessible header: safely fall back to the user's default library.
+        await require_library_role(session, current_user.id, candidate_library_id, LibraryRole.VIEWER)
+        return candidate_library_id
 
     library_id = await get_default_user_library_id(session, current_user.id)
     await require_library_role(session, current_user.id, library_id, LibraryRole.VIEWER)

--- a/backend/tests/test_isolation.py
+++ b/backend/tests/test_isolation.py
@@ -178,7 +178,6 @@ async def test_user_a_cannot_see_library_b_data(
     assert "Book B" not in titles
 
 
-@pytest.mark.xfail(strict=True, reason="Known bug (tracked): library membership check does not enforce 403 when user passes a foreign X-Library-Id header — GET /books returns 200 instead.")
 @pytest.mark.asyncio
 async def test_user_a_cannot_access_library_b_directly(
     test_session: async_sessionmaker[AsyncSession],
@@ -196,6 +195,61 @@ async def test_user_a_cannot_access_library_b_directly(
         resp = await client.get("/api/v1/books", headers=headers_a)
 
     assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_foreign_library_header_denied_on_write_endpoints(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """POST /books with a foreign X-Library-Id also returns 403 (not silently routed)."""
+    async with test_session() as session:
+        user_a = await _create_user(session, "writeA@example.com")
+        user_b = await _create_user(session, "writeB@example.com")
+        await _create_library(session, user_a, "Library A")
+        lib_b = await _create_library(session, user_b, "Library B")
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers_a = {**await _login(client, "writeA@example.com"), **_lib_header(lib_b.id)}
+        resp = await client.post("/api/v1/books", json={"title": "Smuggled"}, headers=headers_a)
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_no_library_header_falls_back_to_default(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """Omitting X-Library-Id still works — default library is used."""
+    async with test_session() as session:
+        user = await _create_user(session, "noheader@example.com")
+        lib = await _create_library(session, user, "Default Library")
+        session.add(Book(library_id=lib.id, title="My Book"))
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        auth = await _login(client, "noheader@example.com")
+        resp = await client.get("/api/v1/books", headers=auth)
+
+    assert resp.status_code == 200
+    assert any(b["title"] == "My Book" for b in resp.json()["items"])
+
+
+@pytest.mark.asyncio
+async def test_invalid_uuid_library_header_returns_400(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """X-Library-Id with a non-UUID value returns 400."""
+    async with test_session() as session:
+        user = await _create_user(session, "baduuid@example.com")
+        await _create_library(session, user, "Default Library")
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        auth = await _login(client, "baduuid@example.com")
+        resp = await client.get("/api/v1/books", headers={**auth, "X-Library-Id": "not-a-uuid"})
+
+    assert resp.status_code == 400
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #157 — security bug where `GET /api/v1/books` returned 200 when an authenticated user sent a foreign `X-Library-Id` header.

## Root cause

`get_library_id()` in `app/api/dependencies/library.py` contained a try/except that swallowed `403 Forbidden` from `require_library_role()`:

```python
# BEFORE (vulnerable):
try:
    await require_library_role(session, current_user.id, candidate_library_id, LibraryRole.VIEWER)
    return candidate_library_id
except HTTPException as exc:
    if exc.status_code != status.HTTP_403_FORBIDDEN:
        raise
    # Stale/inaccessible header: safely fall back to the user's default library.
```

When user A sent `X-Library-Id: <library-B-uuid>`:
1. `require_library_role()` correctly raised 403
2. The 403 was silently caught
3. Code fell back to user A's **default library** and returned 200

The intent was UX convenience ("stale header = graceful fallback"), but it created a data isolation bypass — the client received data and a 200 status with no indication the header was rejected.

## Fix

Remove the swallowing try/except. Let the 403 propagate:

```python
# AFTER (fixed):
await require_library_role(session, current_user.id, candidate_library_id, LibraryRole.VIEWER)
return candidate_library_id
```

**Scope:** `get_library_id` is the single dependency used by all 50+ library-scoped endpoints (`GET /books`, `POST /books`, `PATCH /books/{id}`, `DELETE /books/{id}`, `GET /locations`, `GET /scan/jobs`, etc.). One fix hardens all of them.

## Files changed

| File | Change |
|------|--------|
| `backend/app/api/dependencies/library.py` | Remove the try/except block that swallowed 403 (−7 lines) |
| `backend/tests/test_isolation.py` | Remove `xfail` from existing test; add 3 new regression tests (+56 lines) |

## Tests

New/fixed tests in `test_isolation.py`:

| Test | What it asserts |
|------|----------------|
| `test_user_a_cannot_access_library_b_directly` | GET /books with foreign header → 403 (was xfail, now passing) |
| `test_foreign_library_header_denied_on_write_endpoints` | POST /books with foreign header → 403 |
| `test_no_library_header_falls_back_to_default` | Omitting header still works → 200 with own books |
| `test_invalid_uuid_library_header_returns_400` | Malformed UUID header → 400 |

Local run (SQLite): 4/4 pass. Full suite: 14/16 pass (2 pre-existing `xfail(strict)` XPASS on SQLite — known Postgres-vs-SQLite difference tracked in #158/#159, unrelated to this change).

## Follow-up risks

- **Frontend stale-header UX**: If the frontend relied on the silent fallback to recover from a stale cached library ID, it will now get 403 errors. The frontend should handle 403 on library-scoped requests by clearing the cached library ID and retrying or redirecting to library selection.
- Issues #158 and #159 remain open (unrelated bugs, still xfail on Postgres CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened library access validation to enforce role-based authorization when the `X-Library-Id` header is provided, preventing fallback to default library for unauthorized access attempts.

* **Tests**
  * Expanded test coverage for library isolation and access control, including scenarios for denied foreign library access, invalid header formats, and default library fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->