### PR TITLE
fix(security): unauthenticated onboarding returns 401; re-enable IP rate-limit test

### DIFF
--- a/backend/app/core/csrf.py
+++ b/backend/app/core/csrf.py
@@ -7,7 +7,8 @@ Why double-submit and not a session-bound server secret?
   SameSite=Lax + Secure and the comparison is constant-time.
 
 Invariant enforced:
-  For every unsafe (POST/PUT/PATCH/DELETE) request to a protected path:
+  For every unsafe (POST/PUT/PATCH/DELETE) request to a protected path
+  where the client has an active ``access_token`` cookie:
     EITHER
       - the request authenticates via ``Authorization: Bearer …``
         (mobile / CLI client — cross-origin fetch can't attach this
@@ -16,6 +17,10 @@ Invariant enforced:
       - the request carries BOTH a ``csrf_token`` cookie AND a matching
         ``X-CSRF-Token`` header (constant-time compare).
     Otherwise the request is rejected 403.
+
+  Requests with no ``access_token`` cookie are not cookie-authenticated
+  sessions and therefore not CSRF targets. They pass through so the
+  route's auth dependency can return the semantically correct 401.
 
 Whitelist (no CSRF enforced):
   - Unauthenticated endpoints that *establish* a session — login,
@@ -38,7 +43,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
-from app.core.cookies import CSRF_COOKIE_NAME, CSRF_HEADER_NAME
+from app.core.cookies import ACCESS_COOKIE_NAME, CSRF_COOKIE_NAME, CSRF_HEADER_NAME
 
 _SAFE_METHODS: Final = frozenset({"GET", "HEAD", "OPTIONS"})
 
@@ -84,6 +89,12 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         # Bearer clients are immune to CSRF (see module docstring).
         auth_header = request.headers.get("authorization", "")
         if auth_header.lower().startswith("bearer "):
+            return await call_next(request)
+
+        # No active session cookie → request is not cookie-authenticated.
+        # CSRF only protects sessions that exist; let the route's auth
+        # dependency handle the missing credentials and return 401.
+        if not request.cookies.get(ACCESS_COOKIE_NAME):
             return await call_next(request)
 
         # Cookie-bearing clients MUST prove possession of the csrf_token

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -65,7 +65,6 @@ async def _seed_and_login(session: AsyncSession, client: AsyncClient) -> dict[st
 
 # ── Auth guard ────────────────────────────────────────────────
 
-@pytest.mark.xfail(strict=True, reason="Known bug (tracked): onboarding endpoints return 403 (CSRF middleware intercepts first) instead of 401 for unauthenticated requests. Auth ordering needs fixing.")
 @pytest.mark.asyncio
 async def test_onboarding_endpoints_require_auth() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -73,6 +72,37 @@ async def test_onboarding_endpoints_require_auth() -> None:
         assert (await client.post("/api/v1/settings/onboarding/complete")).status_code == 401
         assert (await client.post("/api/v1/settings/onboarding/skip")).status_code == 401
         assert (await client.post("/api/v1/settings/onboarding/reset")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_csrf_still_enforced_for_cookie_session(test_session: AsyncSession) -> None:
+    """Regression: cookie-auth POST without CSRF header → 403, not 401.
+
+    The CSRF fix must only relax enforcement for unauthenticated requests
+    (no access_token cookie). Once a session exists, CSRF must still block
+    requests that omit the X-CSRF-Token header.
+    """
+    test_session.add(User(email="csrf-guard@example.com", hashed_password=get_password_hash("secret")))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "csrf-guard@example.com", "password": "secret"},
+        )
+        assert login.status_code == 200
+        token = login.json()["access_token"]
+
+        # Inject the access_token cookie manually so it reaches the CSRF
+        # middleware (Python's CookieJar skips Secure cookies on plain HTTP
+        # in tests, so we bypass the jar).  No X-CSRF-Token header → 403.
+        resp = await client.post(
+            "/api/v1/settings/onboarding/complete",
+            cookies={"access_token": token},
+        )
+
+    assert resp.status_code == 403
+    assert "CSRF" in resp.json().get("detail", "")
 
 
 # ── Initial state ─────────────────────────────────────────────

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -79,6 +79,43 @@ def sent_emails() -> list[tuple[str, str]]:
     return []
 
 
+@pytest.fixture
+def enabled_limiter() -> Iterator[None]:
+    """Temporarily enable the module-level limiter with fresh in-memory storage.
+
+    The global limiter is disabled when TESTING=true so ordinary tests are not
+    affected by rate limits.  Swapping app.state.limiter with a new instance
+    does NOT work: the @limiter.limit() decorator captures self (the original
+    limiter instance) in its closure and calls self._check_request_limit() at
+    request time, so any new limiter put in app.state has no effect on the
+    per-route limit check.
+
+    Instead we mutate the original limiter: enable it and replace its storage
+    with a fresh MemoryStorage (no Redis dependency), then restore everything
+    after the test.
+    """
+    import app.core.limiter as limiter_mod
+    from limits.storage import MemoryStorage
+    from limits.strategies import STRATEGIES
+
+    lim = limiter_mod.limiter
+    saved_enabled = lim.enabled
+    saved_storage = lim._storage
+    saved_rate_limiter = lim._limiter
+
+    new_storage = MemoryStorage()
+    strategy = lim._strategy or "fixed-window"
+    lim.enabled = True
+    lim._storage = new_storage
+    lim._limiter = STRATEGIES[strategy](new_storage)
+
+    yield
+
+    lim.enabled = saved_enabled
+    lim._storage = saved_storage
+    lim._limiter = saved_rate_limiter
+
+
 @pytest.fixture(autouse=True)
 def override_dependencies(
     monkeypatch: pytest.MonkeyPatch,
@@ -232,29 +269,28 @@ async def test_email_rate_limit_allows_only_three_requests_per_hour(
     assert len(sent_emails) == 3
 
 
-@pytest.mark.skipif(
-    os.environ.get("TESTING", "").lower() == "true",
-    reason=(
-        "slowapi limiter is disabled globally when TESTING=true "
-        "(see app/core/limiter.py). The per-IP rate limit is enforced at "
-        "the slowapi layer, not inside our service, so it cannot be "
-        "exercised from this suite. Runtime behaviour is covered by the "
-        "limiter's own integration tests and manual smoke checks."
-    ),
-)
 @pytest.mark.asyncio
-async def test_ip_rate_limit_returns_429_on_sixth_call() -> None:
-    """6. Request is rate-limited per IP via slowapi: 5 per 15 minutes."""
-    headers, cookies = _csrf()
+async def test_ip_rate_limit_returns_429_on_sixth_call(enabled_limiter: None) -> None:
+    """IP rate-limited via slowapi: 5 per 15 minutes; 6th call → 429.
+
+    Uses an isolated in-memory limiter (enabled_limiter fixture) so the test
+    is not affected by the global TESTING=true bypass in app/core/limiter.py
+    and does not need a Redis instance.
+    """
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        for i in range(6):
-            response = await client.post(
+        for i in range(5):
+            resp = await client.post(
                 "/api/v1/auth/password-reset/request",
                 json={"email": f"ip{i}@example.com"},
-                headers=headers,
-                cookies=cookies,
             )
-    assert response.status_code == 429
+            assert resp.status_code == 202, f"call {i + 1} expected 202, got {resp.status_code}"
+
+        # 6th request from the same IP (test client host) exceeds 5/15min limit.
+        resp = await client.post(
+            "/api/v1/auth/password-reset/request",
+            json={"email": "ip5@example.com"},
+        )
+    assert resp.status_code == 429
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from collections.abc import AsyncIterator, Iterator
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlparse


### PR DESCRIPTION
## Summary

- **#160**: CSRF middleware was returning 403 for unauthenticated POSTs to `/api/v1/settings/onboarding/*` before the auth dependency could return 401. Fix: pass through requests with no `access_token` cookie — only active cookie sessions are CSRF targets. Added a regression test verifying cookie-auth POSTs without `X-CSRF-Token` still get 403.
- **#153**: `@limiter.limit()` captures the module-level `Limiter` instance in its closure. Swapping `app.state.limiter` with a new test limiter had no effect because the decorator still called `original_limiter._check_request_limit()` (which had `enabled=False`). Fix: mutate the original limiter — enable it and swap its `_storage`/`_limiter` with fresh `MemoryStorage` — so both the middleware and the decorator's closure see the correct enabled state.

## Files changed

| File | Change |
|------|--------|
| `backend/app/core/csrf.py` | Added `ACCESS_COOKIE_NAME` check: no cookie → pass through → auth dependency returns 401 |
| `backend/tests/test_onboarding.py` | Removed `xfail` from auth test; added CSRF regression test for cookie sessions |
| `backend/tests/test_password_reset.py` | Replaced `enabled_limiter` fixture to mutate original limiter instead of swapping it |

## Test plan

- [x] `tests/test_onboarding.py::test_onboarding_endpoints_require_auth` — unauthenticated POSTs return 401
- [x] `tests/test_onboarding.py::test_csrf_still_enforced_for_cookie_session` — cookie-auth without CSRF returns 403
- [x] All other 6 onboarding tests pass (complete/skip/reset cycle)
- [x] `tests/test_password_reset.py::test_ip_rate_limit_returns_429_on_sixth_call` — 5 calls pass, 6th returns 429
- [x] Other password-reset tests unaffected (email rate limit, token storage, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSRF protection now only triggers for requests with an active cookie-authenticated session, reducing incorrect CSRF blocks.

* **Tests**
  * Strengthened test coverage to ensure CSRF is enforced for cookie-authenticated sessions and to validate per-IP rate-limiting behavior during tests, improving reliability of auth and rate-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->