### PR TITLE
feat(scan): add photography tips panel in scan step (#132)

### DIFF
--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -348,7 +348,14 @@
     "move_left": "Posun doleva",
     "move_right": "Posun doprava",
     "positions_saved": "Pozice uloženy",
-    "start_scan_here": "Skenovat odtud"
+    "start_scan_here": "Skenovat odtud",
+    "tips_title": "Tipy pro nejlepší výsledky",
+    "tip_lighting": "Dobré osvětlení — vyhni se stínům nebo odleskům na hřbetech knih.",
+    "tip_framing": "Drž telefon vodorovně a zachyť hřbety v jedné řadě.",
+    "tip_count": "Do jedné fotky 5–10 knih pro nejlepší čitelnost nápisů.",
+    "tip_segments": "Fotografuj zleva doprava po úsecích — pro dlouhé police použij 'Přidat další fotku'.",
+    "tips_dismiss": "Zavřít tipy",
+    "tips_show": "? Tipy"
   },
   "add_book": {
     "page_title": "Přidat knihu",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -398,7 +398,14 @@
     "move_left": "Move left",
     "move_right": "Move right",
     "positions_saved": "Positions saved",
-    "start_scan_here": "Scan from here"
+    "start_scan_here": "Scan from here",
+    "tips_title": "Tips for best results",
+    "tip_lighting": "Good lighting — avoid shadows or glare on book spines.",
+    "tip_framing": "Hold phone horizontally and capture spines in a single row.",
+    "tip_count": "Fit 5–10 books per photo for the clearest spine detail.",
+    "tip_segments": "Photograph in sections from left to right — use 'Add another photo' for long shelves.",
+    "tips_dismiss": "Dismiss tips",
+    "tips_show": "? Tips"
   },
   "add_book": {
     "page_title": "Add book",

--- a/frontend/src/pages/ScanShelfPage.tsx
+++ b/frontend/src/pages/ScanShelfPage.tsx
@@ -86,6 +86,7 @@ export function ScanShelfPage() {
   const [scanMode, setScanMode] = useState<ScanMode>('replace')
   const [appendAfterBookId, setAppendAfterBookId] = useState<string | null>(null)
   const [pendingDraft, setPendingDraft] = useState<ScanDraft | null>(null)
+  const [tipsDismissed, setTipsDismissed] = useState(() => localStorage.getItem('shelfy_scan_tips_dismissed') === '1')
 
   const { data: booksAtLocation = [] } = useBooksByLocation(locationId)
   const existingShelfBooks = [...booksAtLocation].sort((a, b) => (a.shelf_position ?? 99999) - (b.shelf_position ?? 99999))
@@ -601,6 +602,37 @@ export function ScanShelfPage() {
               </div>
             )}
           </div>
+
+          {/* Tips panel */}
+          {!tipsDismissed ? (
+            <div className="sh-card-panel" style={{ padding: '12px 16px', marginBottom: 16, background: 'var(--sh-surface-elevated)' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+                <span style={{ fontWeight: 600, fontSize: 14 }}>{t('scan.tips_title')}</span>
+                <button
+                  type="button"
+                  onClick={() => { localStorage.setItem('shelfy_scan_tips_dismissed', '1'); setTipsDismissed(true) }}
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--sh-text-muted)', fontSize: 18, lineHeight: 1, padding: '0 2px' }}
+                  aria-label={t('scan.tips_dismiss')}
+                >
+                  ✕
+                </button>
+              </div>
+              <ul style={{ margin: 0, paddingLeft: 18, color: 'var(--sh-text-secondary)', fontSize: 13, lineHeight: 1.7 }}>
+                <li>{t('scan.tip_lighting')}</li>
+                <li>{t('scan.tip_framing')}</li>
+                <li>{t('scan.tip_count')}</li>
+                <li>{t('scan.tip_segments')}</li>
+              </ul>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setTipsDismissed(false)}
+              style={{ background: 'none', border: '1px solid var(--sh-border)', borderRadius: 'var(--sh-radius-sm)', cursor: 'pointer', color: 'var(--sh-text-muted)', fontSize: 12, padding: '2px 10px', marginBottom: 12 }}
+            >
+              {t('scan.tips_show')}
+            </button>
+          )}
 
           {/* Upload area */}
           <div


### PR DESCRIPTION
## Summary

- Adds a collapsible **Tips for best results** panel in the scan wizard's photograph step, between the mode selector and the upload area
- 4 concrete tips: good lighting, horizontal framing, 5–10 books per photo, left-to-right segments
- Dismissed state stored in `localStorage` (`shelfy_scan_tips_dismissed`) — returning users see a small `? Tips` toggle instead of the full panel
- Full CZ + EN i18n (`scan.tips_title`, `scan.tip_*`, `scan.tips_dismiss`, `scan.tips_show`)

## Test plan

- [ ] On first visit to the scan step, the tips panel is visible
- [ ] Clicking ✕ collapses the panel and shows the `? Tips` button; state survives page refresh
- [ ] Clicking `? Tips` re-opens the panel
- [ ] Tips text appears in both English and Czech depending on the active locale
- [ ] All 101 existing tests pass (`npx vitest run`)

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismissible tips panel on the Scan page with guidance on optimal lighting, framing, and capture techniques for best results. The panel visibility preference is persisted across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->