### PR TITLE
feat(safety): unify destructive-action confirmation UX (#138)

### DIFF
--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -37,6 +37,7 @@
     "moved": "Přesunuto {{count}} knih",
     "status_updated": "Stav upraven pro {{count}} knih",
     "confirm_delete": "Opravdu smazat {{count}} knih? Tato akce je nevratná.",
+    "delete_confirm_title": "Smazat {{count}} knih?",
     "move_to": "Přesunout na…",
     "no_location": "Bez umístění",
     "status_label": "Nový stav",
@@ -355,7 +356,10 @@
     "tip_count": "Do jedné fotky 5–10 knih pro nejlepší čitelnost nápisů.",
     "tip_segments": "Fotografuj zleva doprava po úsecích — pro dlouhé police použij 'Přidat další fotku'.",
     "tips_dismiss": "Zavřít tipy",
-    "tips_show": "? Tipy"
+    "tips_show": "? Tipy",
+    "remove_segment_title": "Odebrat tuto fotku?",
+    "remove_segment_body": "Tím se zahodí všechny knihy rozpoznané v této fotce. Tuto akci nelze vrátit.",
+    "remove_segment_confirm": "Odebrat fotku"
   },
   "add_book": {
     "page_title": "Přidat knihu",
@@ -452,6 +456,8 @@
     "add_error_404": "Uživatel s tímto e-mailem nebyl nalezen.",
     "add_error": "Přidání člena selhalo.",
     "remove": "Odebrat",
+    "remove_title": "Odebrat člena",
+    "remove_body": "Odebrat {{email}} z této knihovny? Přístup ztratí okamžitě. Tuto akci nelze vrátit.",
     "remove_confirm": "Odebrat {{email}} z této knihovny?",
     "remove_success": "Člen odebrán.",
     "remove_error_400": "Nelze odebrat posledního vlastníka.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -37,6 +37,7 @@
     "moved": "Moved {{count}} books",
     "status_updated": "Status updated for {{count}} books",
     "confirm_delete": "Really delete {{count}} books? This cannot be undone.",
+    "delete_confirm_title": "Delete {{count}} books?",
     "move_to": "Move to…",
     "no_location": "No location",
     "status_label": "New status",
@@ -405,7 +406,10 @@
     "tip_count": "Fit 5–10 books per photo for the clearest spine detail.",
     "tip_segments": "Photograph in sections from left to right — use 'Add another photo' for long shelves.",
     "tips_dismiss": "Dismiss tips",
-    "tips_show": "? Tips"
+    "tips_show": "? Tips",
+    "remove_segment_title": "Remove this photo?",
+    "remove_segment_body": "This will discard all books detected in this photo. This cannot be undone.",
+    "remove_segment_confirm": "Remove photo"
   },
   "add_book": {
     "page_title": "Add book",
@@ -502,6 +506,8 @@
     "add_error_404": "No user with that email address found.",
     "add_error": "Failed to add member.",
     "remove": "Remove",
+    "remove_title": "Remove member",
+    "remove_body": "Remove {{email}} from this library? They will lose access immediately. This cannot be undone.",
     "remove_confirm": "Remove {{email}} from this library?",
     "remove_success": "Member removed.",
     "remove_error_400": "Cannot remove the last owner.",

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -535,8 +535,8 @@ export function BooksPage() {
       )}
 
       {/* ── Bulk delete confirm ── */}
-      <Modal open={bulkDeleteConfirmOpen} onClose={() => setBulkDeleteConfirmOpen(false)} size="sm" label={t('books.delete_confirm_title')}>
-        <h3 className="text-h3" style={{ marginTop: 0 }}>{t('books.delete_confirm_title')}</h3>
+      <Modal open={bulkDeleteConfirmOpen} onClose={() => setBulkDeleteConfirmOpen(false)} size="sm" label={t('bulk.delete_confirm_title', { count: selectedIds.size })}>
+        <h3 className="text-h3" style={{ marginTop: 0 }}>{t('bulk.delete_confirm_title', { count: selectedIds.size })}</h3>
         <p className="text-p" style={{ marginBottom: 24 }}>{t('bulk.confirm_delete', { count: selectedIds.size })}</p>
         <div style={{ display: 'flex', gap: 12, justifyContent: 'flex-end' }}>
           <button onClick={() => setBulkDeleteConfirmOpen(false)} className="sh-btn-secondary">{t('books.delete_cancel')}</button>

--- a/frontend/src/pages/ScanShelfPage.tsx
+++ b/frontend/src/pages/ScanShelfPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
 import { BookshelfInlineIcon, CameraIcon, ProcessingIcon } from '../components/EmptyStateIcons'
+import { Modal } from '../components/Modal'
 import { useLocations, useCreateLocation } from '../hooks/useLocations'
 import { useBooksByLocation, useConfirmShelfScan, useScanShelf, useShelfScanResult } from '../hooks/useScan'
 import { useToastStore } from '../lib/toast-store'
@@ -87,6 +88,7 @@ export function ScanShelfPage() {
   const [appendAfterBookId, setAppendAfterBookId] = useState<string | null>(null)
   const [pendingDraft, setPendingDraft] = useState<ScanDraft | null>(null)
   const [tipsDismissed, setTipsDismissed] = useState(() => localStorage.getItem('shelfy_scan_tips_dismissed') === '1')
+  const [confirmRemoveSegmentIdx, setConfirmRemoveSegmentIdx] = useState<number | null>(null)
 
   const { data: booksAtLocation = [] } = useBooksByLocation(locationId)
   const existingShelfBooks = [...booksAtLocation].sort((a, b) => (a.shelf_position ?? 99999) - (b.shelf_position ?? 99999))
@@ -702,7 +704,7 @@ export function ScanShelfPage() {
                     </div>
                     {seg.status !== 'processing' && (
                       <button
-                        onClick={() => removeSegment(idx)}
+                        onClick={() => setConfirmRemoveSegmentIdx(idx)}
                         aria-label={t('scan.remove_item')}
                         className="sh-touch-target"
                         style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--sh-text-muted)', fontSize: 16 }}
@@ -875,6 +877,21 @@ export function ScanShelfPage() {
           <div style={{ height: 32 }} />
         </div>
       )}
+
+      <Modal open={confirmRemoveSegmentIdx !== null} onClose={() => setConfirmRemoveSegmentIdx(null)} label={t('scan.remove_segment_title')} size="sm">
+        <h3 className="text-h3" style={{ marginTop: 0 }}>{t('scan.remove_segment_title')}</h3>
+        <p className="text-p" style={{ marginBottom: 24 }}>{t('scan.remove_segment_body')}</p>
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'flex-end' }}>
+          <button type="button" className="sh-btn-secondary" onClick={() => setConfirmRemoveSegmentIdx(null)}>{t('common.cancel')}</button>
+          <button
+            type="button"
+            className="sh-btn-danger"
+            onClick={() => { if (confirmRemoveSegmentIdx !== null) removeSegment(confirmRemoveSegmentIdx); setConfirmRemoveSegmentIdx(null) }}
+          >
+            {t('scan.remove_segment_confirm')}
+          </button>
+        </div>
+      </Modal>
     </div>
   )
 }

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -421,13 +421,16 @@ describe('SettingsPage – library management', () => {
 
   it('calls removeLibraryMember after confirming remove', async () => {
     vi.mocked(removeLibraryMember).mockResolvedValue(undefined)
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
     const user = userEvent.setup()
     renderWithProviders(<SettingsPage />)
     await screen.findByText('editor@example.com')
 
     const removeBtn = screen.getByLabelText('remove-user-editor')
     await user.click(removeBtn)
+
+    // Modal should appear
+    expect(screen.getByRole('dialog', { name: 'library.remove_title' })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'library.remove' }))
 
     await waitFor(() => {
       expect(removeLibraryMember).toHaveBeenCalledWith('lib-1', 'user-editor')
@@ -435,7 +438,6 @@ describe('SettingsPage – library management', () => {
   })
 
   it('does not call removeLibraryMember when confirm is cancelled', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(false)
     const user = userEvent.setup()
     renderWithProviders(<SettingsPage />)
     await screen.findByText('editor@example.com')
@@ -443,9 +445,10 @@ describe('SettingsPage – library management', () => {
     const removeBtn = screen.getByLabelText('remove-user-editor')
     await user.click(removeBtn)
 
-    await waitFor(() => {
-      expect(removeLibraryMember).not.toHaveBeenCalled()
-    })
+    expect(screen.getByRole('dialog', { name: 'library.remove_title' })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'common.cancel' }))
+
+    expect(removeLibraryMember).not.toHaveBeenCalled()
   })
 
   it('shows read-only role badge for non-owner user', async () => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom'
 
 import { deleteAccount, exportBooksCsv, exportUserData, formatApiError, purgeLibrary } from '../lib/api'
 import { ImportCsvModal } from '../components/ImportCsvModal'
+import { Modal } from '../components/Modal'
 import { useEnrichAll } from '../hooks/useEnrich'
 import { useBillingStatus, useCreateCheckout, useCreatePortal } from '../hooks/useBilling'
 import { useAddMember, useLibraries, useLibraryMembers, useRemoveMember, useUpdateMember } from '../hooks/useLibrary'
@@ -48,6 +49,7 @@ function LibraryManagement() {
   const { user } = useAuth()
   const showSuccess = useToastStore((s) => s.showSuccess)
   const showError = useToastStore((s) => s.showError)
+  const [confirmRemove, setConfirmRemove] = useState<{ userId: string; email: string } | null>(null)
 
   const activeLibraryId = useLibraryStore((s) => s.activeLibraryId)
   const setActiveLibraryId = useLibraryStore((s) => s.setActiveLibraryId)
@@ -111,10 +113,15 @@ function LibraryManagement() {
   }
 
   function handleRemove(userId: string, email: string) {
-    if (!window.confirm(t('library.remove_confirm', { email }))) return
-    removeMemberMutation.mutate(userId, {
-      onSuccess: () => showSuccess(t('library.remove_success')),
+    setConfirmRemove({ userId, email })
+  }
+
+  function confirmRemoveMember() {
+    if (!confirmRemove) return
+    removeMemberMutation.mutate(confirmRemove.userId, {
+      onSuccess: () => { setConfirmRemove(null); showSuccess(t('library.remove_success')) },
       onError: (err) => {
+        setConfirmRemove(null)
         const status = extractStatusCode(err)
         if (status === 400) showError(t('library.remove_error_400'))
         else showError(formatApiError(err) || t('library.remove_error'))
@@ -266,6 +273,15 @@ function LibraryManagement() {
           )}
         </div>
       )}
+
+      <Modal open={!!confirmRemove} onClose={() => setConfirmRemove(null)} label={t('library.remove_title')} size="sm">
+        <h3 className="text-h3" style={{ marginTop: 0 }}>{t('library.remove_title')}</h3>
+        <p className="text-p" style={{ marginBottom: 24 }}>{t('library.remove_body', { email: confirmRemove?.email ?? '' })}</p>
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'flex-end' }}>
+          <button type="button" className="sh-btn-secondary" onClick={() => setConfirmRemove(null)}>{t('common.cancel')}</button>
+          <button type="button" className="sh-btn-danger" onClick={confirmRemoveMember}>{t('library.remove')}</button>
+        </div>
+      </Modal>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Library member removal**: replaced `window.confirm()` with a proper `<Modal>` dialog — now consistent with delete-book and delete-location flows
- **Scan segment removal**: tapping ✕ on a processed photo now shows a confirmation modal before discarding all detected books from that photo
- **Bulk delete title**: fixed modal heading from singular "Delete this book?" to "Delete {{count}} books?" (new `bulk.delete_confirm_title` key)
- Updated `SettingsPage.test.tsx` to assert on the modal dialog instead of `window.confirm` spy

## What's still out of scope

- Purge library and delete account intentionally keep the typed-"DELETE" / password pattern — appropriate for nuclear actions
- Scan draft discard is already gated by an explicit "restore vs discard" choice prompt

## Test plan

- [ ] Settings → Library: clicking Remove opens modal; Cancel leaves member; confirm removes member
- [ ] Scan page: clicking ✕ on a processed photo shows modal; Cancel keeps it; confirm removes it
- [ ] Bulk select books → Delete (N) → modal title says "Delete N books?"
- [ ] All 101 tests pass (`npx vitest run`)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialogs for destructive actions: bulk book deletion, photo segment removal from scans, and library member removal.
  * Enhanced user experience with consistent modal confirmation dialogs providing clear action details before proceeding.

* **Localization**
  * Added Czech language support for all confirmation dialogs and related UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->