### PR TITLE
Add public changelog page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Shelfy changelog
+
+Public source for notable Shelfy changes. Keep entries short, dated, and user-facing; avoid implementation noise unless it affects reliability, security, privacy, or product behavior.
+
+The public page at `/changelog` is generated from `frontend/src/content/changelog.ts`. When adding a release note, update both files in the same PR until a markdown-to-page generator exists.
+
+## 2026-04-29 — Spolehlivější backend a přísnější CI
+
+- Backend test coverage gate is back at 80%.
+- Strict Mypy is now a required CI gate instead of advisory-only.
+- Added/fixed type coverage across billing, OAuth, cookies, libraries, CSV import, scan API, and tests.
+
+## 2026-04-27 — Bezpečnější knihovny a member management
+
+- ISBN uniqueness is scoped per library.
+- Foreign `X-Library-Id` returns 403 instead of silently falling back.
+- Unauthenticated onboarding returns 401 consistently.
+
+## 2026-04-10 — Password reset a auth hardening
+
+- Added forgot/reset password flow.
+- Added reset-password transactional e-mails.
+- Improved auth rate-limiting and tests.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { PrivacyPage } from './pages/PrivacyPage'
 import { TermsPage } from './pages/TermsPage'
 import { ForgotPasswordPage } from './pages/ForgotPasswordPage'
 import { ResetPasswordPage } from './pages/ResetPasswordPage'
+import { ChangelogPage } from './pages/ChangelogPage'
 
 import { ROUTES } from './lib/routes'
 
@@ -60,6 +61,7 @@ const PUBLIC_PATHS = new Set([
   ROUTES.forgotPassword,
   ROUTES.resetPassword,
   ROUTES.pricing,
+  ROUTES.changelog,
   ROUTES.privacy,
   ROUTES.terms,
   ROUTES.oauthCallback,
@@ -94,6 +96,7 @@ function AppShell() {
           <Route path={ROUTES.privacy} element={<PrivacyPage />} />
           <Route path={ROUTES.terms} element={<TermsPage />} />
           <Route path={ROUTES.pricing} element={<PricingPage />} />
+          <Route path={ROUTES.changelog} element={<ChangelogPage />} />
 
           {/* ── Protected routes ── */}
           <Route element={<ProtectedRoute />}>

--- a/frontend/src/content/changelog.ts
+++ b/frontend/src/content/changelog.ts
@@ -1,49 +1,107 @@
+export type ChangelogLocale = 'cs' | 'en'
+
+type LocalizedText = Record<ChangelogLocale, string>
+type LocalizedList = Partial<Record<ChangelogLocale, string[]>>
+
 export type ChangelogEntry = {
   date: string
-  title: string
-  summary: string
-  added?: string[]
-  changed?: string[]
-  fixed?: string[]
+  title: LocalizedText
+  summary: LocalizedText
+  added?: LocalizedList
+  changed?: LocalizedList
+  fixed?: LocalizedList
 }
 
 export const changelogEntries: ChangelogEntry[] = [
   {
     date: '2026-04-29',
-    title: 'Spolehlivější backend a přísnější CI',
-    summary: 'Zpřísnili jsme backend quality gate: test coverage je zpět na 80 % a strict Mypy už není jen advisory kontrola.',
-    changed: [
-      'Backend test coverage gate je zvýšený zpět na 80 %.',
-      'Strict Mypy běží jako povinná kontrola v CI.',
-    ],
-    fixed: [
-      'Doplněné typové opravy napříč billingem, OAuth, knihovnami, cookies a testy.',
-      'Nové testy pokrývají rate limiter, e-maily, CSV import, joby a scan API.',
-    ],
+    title: {
+      cs: 'Spolehlivější backend a přísnější CI',
+      en: 'More reliable backend and stricter CI',
+    },
+    summary: {
+      cs: 'Zpřísnili jsme backend quality gate: test coverage je zpět na 80 % a strict Mypy už není jen advisory kontrola.',
+      en: 'We tightened the backend quality gate: test coverage is back at 80% and strict Mypy is now a required check.',
+    },
+    changed: {
+      cs: [
+        'Backend test coverage gate je zvýšený zpět na 80 %.',
+        'Strict Mypy běží jako povinná kontrola v CI.',
+      ],
+      en: [
+        'Backend test coverage gate is back at 80%.',
+        'Strict Mypy now runs as a required CI check.',
+      ],
+    },
+    fixed: {
+      cs: [
+        'Doplněné typové opravy napříč billingem, OAuth, knihovnami, cookies a testy.',
+        'Nové testy pokrývají rate limiter, e-maily, CSV import, joby a scan API.',
+      ],
+      en: [
+        'Type fixes landed across billing, OAuth, libraries, cookies, and tests.',
+        'New tests cover the rate limiter, emails, CSV import, jobs, and scan API.',
+      ],
+    },
   },
   {
     date: '2026-04-27',
-    title: 'Bezpečnější knihovny a member management',
-    summary: 'Dotažení izolace knihoven a přesnějších status kódů pro sdílené knihovny.',
-    changed: [
-      'ISBN unikátnost je vyhodnocovaná per knihovna.',
-      'Member-management testy lépe pokrývají očekávané chybové stavy.',
-    ],
-    fixed: [
-      'Cizí X-Library-Id už nepadá do tichého fallbacku a vrací 403.',
-      'Unauthenticated onboarding vrací konzistentně 401.',
-    ],
+    title: {
+      cs: 'Bezpečnější knihovny a member management',
+      en: 'Safer libraries and member management',
+    },
+    summary: {
+      cs: 'Dotažení izolace knihoven a přesnějších status kódů pro sdílené knihovny.',
+      en: 'Library isolation and shared-library status codes were tightened up.',
+    },
+    changed: {
+      cs: [
+        'ISBN unikátnost je vyhodnocovaná per knihovna.',
+        'Member-management testy lépe pokrývají očekávané chybové stavy.',
+      ],
+      en: [
+        'ISBN uniqueness is now scoped per library.',
+        'Member-management tests cover expected error states more clearly.',
+      ],
+    },
+    fixed: {
+      cs: [
+        'Cizí X-Library-Id už nepadá do tichého fallbacku a vrací 403.',
+        'Unauthenticated onboarding vrací konzistentně 401.',
+      ],
+      en: [
+        'Foreign X-Library-Id no longer silently falls back and returns 403 instead.',
+        'Unauthenticated onboarding now consistently returns 401.',
+      ],
+    },
   },
   {
     date: '2026-04-10',
-    title: 'Password reset a auth hardening',
-    summary: 'Přibyl reset hesla a několik bezpečnostních úprav kolem autentizace.',
-    added: [
-      'Forgot/reset password flow pro uživatele.',
-      'Transakční e-maily pro reset hesla.',
-    ],
-    fixed: [
-      'Lepší rate limiting a robustnější testy auth flow.',
-    ],
+    title: {
+      cs: 'Password reset a auth hardening',
+      en: 'Password reset and auth hardening',
+    },
+    summary: {
+      cs: 'Přibyl reset hesla a několik bezpečnostních úprav kolem autentizace.',
+      en: 'Password reset shipped together with several authentication hardening improvements.',
+    },
+    added: {
+      cs: [
+        'Forgot/reset password flow pro uživatele.',
+        'Transakční e-maily pro reset hesla.',
+      ],
+      en: [
+        'Forgot/reset password flow for users.',
+        'Transactional password-reset emails.',
+      ],
+    },
+    fixed: {
+      cs: [
+        'Lepší rate limiting a robustnější testy auth flow.',
+      ],
+      en: [
+        'Improved rate limiting and more robust auth-flow tests.',
+      ],
+    },
   },
 ]

--- a/frontend/src/content/changelog.ts
+++ b/frontend/src/content/changelog.ts
@@ -1,0 +1,49 @@
+export type ChangelogEntry = {
+  date: string
+  title: string
+  summary: string
+  added?: string[]
+  changed?: string[]
+  fixed?: string[]
+}
+
+export const changelogEntries: ChangelogEntry[] = [
+  {
+    date: '2026-04-29',
+    title: 'Spolehlivější backend a přísnější CI',
+    summary: 'Zpřísnili jsme backend quality gate: test coverage je zpět na 80 % a strict Mypy už není jen advisory kontrola.',
+    changed: [
+      'Backend test coverage gate je zvýšený zpět na 80 %.',
+      'Strict Mypy běží jako povinná kontrola v CI.',
+    ],
+    fixed: [
+      'Doplněné typové opravy napříč billingem, OAuth, knihovnami, cookies a testy.',
+      'Nové testy pokrývají rate limiter, e-maily, CSV import, joby a scan API.',
+    ],
+  },
+  {
+    date: '2026-04-27',
+    title: 'Bezpečnější knihovny a member management',
+    summary: 'Dotažení izolace knihoven a přesnějších status kódů pro sdílené knihovny.',
+    changed: [
+      'ISBN unikátnost je vyhodnocovaná per knihovna.',
+      'Member-management testy lépe pokrývají očekávané chybové stavy.',
+    ],
+    fixed: [
+      'Cizí X-Library-Id už nepadá do tichého fallbacku a vrací 403.',
+      'Unauthenticated onboarding vrací konzistentně 401.',
+    ],
+  },
+  {
+    date: '2026-04-10',
+    title: 'Password reset a auth hardening',
+    summary: 'Přibyl reset hesla a několik bezpečnostních úprav kolem autentizace.',
+    added: [
+      'Forgot/reset password flow pro uživatele.',
+      'Transakční e-maily pro reset hesla.',
+    ],
+    fixed: [
+      'Lepší rate limiting a robustnější testy auth flow.',
+    ],
+  },
+]

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -583,7 +583,8 @@
     "final_cta_button": "Vytvořit svůj katalog zdarma",
     "footer_privacy": "Zásady ochrany soukromí",
     "footer_terms": "Podmínky použití",
-    "hero_trust_summary": "Tvoje data patří tobě. Kdykoli je exportuješ a účet můžeš jednoduše smazat."
+    "hero_trust_summary": "Tvoje data patří tobě. Kdykoli je exportuješ a účet můžeš jednoduše smazat.",
+    "footer_changelog": "Changelog"
   },
   "csv": {
     "import_button": "Importovat CSV",
@@ -651,5 +652,12 @@
     "show_password": "Zobrazit",
     "hide_password": "Skrýt",
     "network_error_try_again": "Chyba připojení. Zkus to prosím znovu."
+  },
+  "changelog": {
+    "title": "Changelog",
+    "subtitle": "Přehled důležitých změn v Shelfy — hlavně věci, které mají dopad na stabilitu, bezpečnost nebo používání aplikace.",
+    "added": "Přidáno",
+    "changed": "Změněno",
+    "fixed": "Opraveno"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -289,7 +289,8 @@
     "final_cta_button": "Create your free library catalog",
     "footer_privacy": "Privacy Policy",
     "footer_terms": "Terms of Service",
-    "hero_trust_summary": "Your data stays yours. Export anytime and delete your account whenever you want."
+    "hero_trust_summary": "Your data stays yours. Export anytime and delete your account whenever you want.",
+    "footer_changelog": "Changelog"
   },
   "tabs": {
     "all": "All",
@@ -651,5 +652,12 @@
     "show_password": "Show",
     "hide_password": "Hide",
     "network_error_try_again": "Connection error. Please try again."
+  },
+  "changelog": {
+    "title": "Changelog",
+    "subtitle": "A short overview of notable Shelfy changes — especially updates that affect stability, security, or day-to-day use.",
+    "added": "Added",
+    "changed": "Changed",
+    "fixed": "Fixed"
   }
 }

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -10,6 +10,7 @@ export const ROUTES = {
   locations: '/locations',
   settings: '/settings',
   pricing: '/pricing',
+  changelog: '/changelog',
   privacy: '/privacy',
   terms: '/terms',
   oauthCallback: '/auth/callback',

--- a/frontend/src/pages/ChangelogPage.tsx
+++ b/frontend/src/pages/ChangelogPage.tsx
@@ -1,7 +1,8 @@
 import type { CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
-import { changelogEntries } from '../content/changelog'
+import { changelogEntries, type ChangelogLocale } from '../content/changelog'
 
 const P: CSSProperties = { margin: '0 0 10px', lineHeight: 1.7, color: 'var(--sh-text-secondary)' }
 const UL: CSSProperties = { paddingLeft: 20, color: 'var(--sh-text-secondary)', lineHeight: 1.7, margin: '8px 0 0' }
@@ -15,6 +16,10 @@ const BADGE: CSSProperties = {
   color: 'var(--sh-text-secondary)',
   fontSize: 12,
   fontWeight: 700,
+}
+
+function activeLocale(language: string | undefined): ChangelogLocale {
+  return language?.startsWith('en') ? 'en' : 'cs'
 }
 
 function ChangeGroup({ label, items }: { label: string; items?: string[] }) {
@@ -31,6 +36,8 @@ function ChangeGroup({ label, items }: { label: string; items?: string[] }) {
 
 export function ChangelogPage() {
   const navigate = useNavigate()
+  const { i18n, t } = useTranslation()
+  const locale = activeLocale(i18n.resolvedLanguage ?? i18n.language)
 
   return (
     <div style={{ minHeight: '100vh', background: 'var(--sh-bg)' }}>
@@ -54,15 +61,15 @@ export function ChangelogPage() {
       </header>
 
       <main style={{ maxWidth: 760, margin: '0 auto', padding: '48px 24px 80px' }}>
-        <h1 style={{ fontSize: 32, fontWeight: 900, margin: '0 0 8px' }}>Changelog</h1>
+        <h1 style={{ fontSize: 32, fontWeight: 900, margin: '0 0 8px' }}>{t('changelog.title')}</h1>
         <p style={{ ...P, fontSize: 16, marginBottom: 28 }}>
-          Přehled důležitých změn v Shelfy — hlavně věci, které mají dopad na stabilitu, bezpečnost nebo používání aplikace.
+          {t('changelog.subtitle')}
         </p>
 
         <div style={{ display: 'grid', gap: 18 }}>
           {changelogEntries.map((entry) => (
             <article
-              key={`${entry.date}-${entry.title}`}
+              key={`${entry.date}-${entry.title.en}`}
               style={{
                 background: 'var(--sh-surface)',
                 border: '1px solid var(--sh-border)',
@@ -72,11 +79,11 @@ export function ChangelogPage() {
               }}
             >
               <span style={BADGE}>{entry.date}</span>
-              <h2 style={{ fontSize: 21, fontWeight: 850, margin: '12px 0 8px' }}>{entry.title}</h2>
-              <p style={P}>{entry.summary}</p>
-              <ChangeGroup label='Přidáno' items={entry.added} />
-              <ChangeGroup label='Změněno' items={entry.changed} />
-              <ChangeGroup label='Opraveno' items={entry.fixed} />
+              <h2 style={{ fontSize: 21, fontWeight: 850, margin: '12px 0 8px' }}>{entry.title[locale]}</h2>
+              <p style={P}>{entry.summary[locale]}</p>
+              <ChangeGroup label={t('changelog.added')} items={entry.added?.[locale]} />
+              <ChangeGroup label={t('changelog.changed')} items={entry.changed?.[locale]} />
+              <ChangeGroup label={t('changelog.fixed')} items={entry.fixed?.[locale]} />
             </article>
           ))}
         </div>

--- a/frontend/src/pages/ChangelogPage.tsx
+++ b/frontend/src/pages/ChangelogPage.tsx
@@ -1,0 +1,86 @@
+import type { CSSProperties } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { changelogEntries } from '../content/changelog'
+
+const P: CSSProperties = { margin: '0 0 10px', lineHeight: 1.7, color: 'var(--sh-text-secondary)' }
+const UL: CSSProperties = { paddingLeft: 20, color: 'var(--sh-text-secondary)', lineHeight: 1.7, margin: '8px 0 0' }
+const BADGE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  borderRadius: 'var(--sh-radius-pill)',
+  padding: '4px 10px',
+  background: 'var(--sh-surface-elevated)',
+  border: '1px solid var(--sh-border)',
+  color: 'var(--sh-text-secondary)',
+  fontSize: 12,
+  fontWeight: 700,
+}
+
+function ChangeGroup({ label, items }: { label: string; items?: string[] }) {
+  if (!items?.length) return null
+  return (
+    <div style={{ marginTop: 14 }}>
+      <p style={{ margin: 0, fontSize: 13, fontWeight: 800, color: 'var(--sh-text-main)' }}>{label}</p>
+      <ul style={UL}>
+        {items.map((item) => <li key={item}>{item}</li>)}
+      </ul>
+    </div>
+  )
+}
+
+export function ChangelogPage() {
+  const navigate = useNavigate()
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--sh-bg)' }}>
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '14px 24px',
+          borderBottom: '1px solid var(--sh-border)',
+          background: 'var(--sh-surface)',
+        }}
+      >
+        <button
+          type='button'
+          style={{ background: 'none', border: 'none', cursor: 'pointer', fontWeight: 700, fontSize: 20 }}
+          onClick={() => navigate('/')}
+        >
+          📚 Shelfy
+        </button>
+      </header>
+
+      <main style={{ maxWidth: 760, margin: '0 auto', padding: '48px 24px 80px' }}>
+        <h1 style={{ fontSize: 32, fontWeight: 900, margin: '0 0 8px' }}>Changelog</h1>
+        <p style={{ ...P, fontSize: 16, marginBottom: 28 }}>
+          Přehled důležitých změn v Shelfy — hlavně věci, které mají dopad na stabilitu, bezpečnost nebo používání aplikace.
+        </p>
+
+        <div style={{ display: 'grid', gap: 18 }}>
+          {changelogEntries.map((entry) => (
+            <article
+              key={`${entry.date}-${entry.title}`}
+              style={{
+                background: 'var(--sh-surface)',
+                border: '1px solid var(--sh-border)',
+                borderRadius: 'var(--sh-radius-lg)',
+                padding: '22px 24px',
+                boxShadow: 'var(--sh-shadow-sm)',
+              }}
+            >
+              <span style={BADGE}>{entry.date}</span>
+              <h2 style={{ fontSize: 21, fontWeight: 850, margin: '12px 0 8px' }}>{entry.title}</h2>
+              <p style={P}>{entry.summary}</p>
+              <ChangeGroup label='Přidáno' items={entry.added} />
+              <ChangeGroup label='Změněno' items={entry.changed} />
+              <ChangeGroup label='Opraveno' items={entry.fixed} />
+            </article>
+          ))}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -419,6 +419,13 @@ export function LandingPage() {
         >
           {t('landing.footer_terms')}
         </button>
+        <button
+          type="button"
+          style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', fontSize: 'inherit' }}
+          onClick={() => navigate(ROUTES.changelog)}
+        >
+          Changelog
+        </button>
       </footer>
     </div>
   )

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -424,7 +424,7 @@ export function LandingPage() {
           style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', fontSize: 'inherit' }}
           onClick={() => navigate(ROUTES.changelog)}
         >
-          Changelog
+          {t('landing.footer_changelog')}
         </button>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- add a public /changelog route with user-facing Shelfy updates
- keep changelog entries in source control via docs/CHANGELOG.md and frontend/src/content/changelog.ts
- link the changelog from the landing page footer

## Verification
- npm run lint (passes with existing warnings)
- npm run build (passes; Vite warns host Node 18 is below recommended 20.19+ and bundle size warning is pre-existing)

Notes: I chose a public changelog because it gives users visibility into reliability/security/product changes. The docs file is the lightweight canonical process note for future entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated changelog page displaying Shelfy's release history with dated entries.
  * Changelog is accessible from a new footer link on the landing page and via site navigation.
  * Localized UI for the changelog (English and Czech) with categorized entries (Added / Changed / Fixed).

* **Documentation**
  * Added a public changelog document summarizing recent notable releases and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->