### PR TITLE
Brand transactional email and fix password reset confirm

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,18 @@ MINIO_REGION=us-east-1
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
 GEMINI_API_KEY=
+
+# Transactional email (Resend) — optional in local dev.
+# Leave RESEND_API_KEY empty to disable outbound mail (the service no-ops
+# silently). Set in production via the deployment secret store; never commit.
+# EMAIL_FROM_ADDRESS must be a sender on a Resend-verified domain (SPF/DKIM/DMARC
+# pointing at Resend) — otherwise the API call returns 403.
+# EMAIL_REPLY_TO_ADDRESS sets the Reply-To header so user replies route to a
+# monitored mailbox; leave empty to omit the header entirely.
+RESEND_API_KEY=
+EMAIL_FROM_ADDRESS=Shelfy <noreply@shelfy.cz>
+EMAIL_REPLY_TO_ADDRESS=support@shelfy.cz
+
 # Frontend app configuration
 VITE_API_BASE_URL=http://localhost:8000
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -207,8 +207,8 @@ async def confirm_password_reset(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    user = await consume_reset_token(session, payload.token, payload.new_password)
-    logger.info("password_reset_completed", user_id=str(user.id))
+    user_id = await consume_reset_token(session, payload.token, payload.new_password)
+    logger.info("password_reset_completed", user_id=user_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,8 +38,15 @@ class Settings(BaseSettings):
 
     # Transactional email (Resend)
     # Set RESEND_API_KEY in .env to enable email notifications.
+    # The from address must be a verified sender on the Resend account, and the
+    # domain (shelfy.cz) must have SPF/DKIM/DMARC records pointing at Resend
+    # before mail will deliver — see docs/runbooks/email.md.
     resend_api_key: str | None = None
-    email_from_address: str = "Shelfy <noreply@shelfy.app>"
+    email_from_address: str = "Shelfy <noreply@shelfy.cz>"
+    # Reply-To header: where users land when they hit "Reply" on a transactional
+    # email.  Set to a monitored mailbox (we forward shelfy.cz support to a real
+    # inbox).  Set to ``None`` to omit the header entirely.
+    email_reply_to_address: str | None = "support@shelfy.cz"
 
     # Billing / Stripe
     # Set these in .env once you create products in the Stripe dashboard.

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -34,11 +34,25 @@ async def _send(*, to: str, subject: str, html: str) -> None:
     No-ops silently when RESEND_API_KEY is absent.
     Network / API errors are logged but never re-raised so that email failures
     never crash the main request path.
+
+    The Authorization header is the only place the API key appears; it is
+    never logged (only ``to`` / ``subject`` / ``status`` make it into log
+    records).  ``reply_to`` is included only when ``email_reply_to_address``
+    is set so deployments without a support inbox don't claim one.
     """
     settings = get_settings()
     if not settings.resend_api_key:
         logger.debug("email.skipped (no RESEND_API_KEY)", extra={"to": to, "subject": subject})
         return
+
+    payload: dict[str, object] = {
+        "from": settings.email_from_address,
+        "to": [to],
+        "subject": subject,
+        "html": html,
+    }
+    if settings.email_reply_to_address:
+        payload["reply_to"] = settings.email_reply_to_address
 
     # Retry up to 3 times on network-level errors (connection reset, DNS failure, etc.).
     # 5xx responses are not automatically retried here — Resend's own delivery retries
@@ -52,12 +66,7 @@ async def _send(*, to: str, subject: str, html: str) -> None:
                     "Authorization": f"Bearer {settings.resend_api_key}",
                     "Content-Type": "application/json",
                 },
-                json={
-                    "from": settings.email_from_address,
-                    "to": [to],
-                    "subject": subject,
-                    "html": html,
-                },
+                json=payload,
             )
             response.raise_for_status()
             logger.info("email.sent", extra={"to": to, "subject": subject, "status": response.status_code})
@@ -87,7 +96,7 @@ def _base(content: str) -> str:
             {content}
             <hr style="border:none;border-top:1px solid #eee;margin:32px 0">
             <p style="color:#888;font-size:12px;margin:0">
-              Shelfy · You're receiving this because you have an account at shelfy.app
+              Shelfy · You're receiving this because you have an account at shelfy.cz
             </p>
           </td></tr>
         </table>

--- a/backend/app/services/password_reset.py
+++ b/backend/app/services/password_reset.py
@@ -65,7 +65,7 @@ async def create_reset_token(
 
 async def consume_reset_token(
     session: AsyncSession, plaintext_token: str, new_password: str
-) -> User:
+) -> str:
     """Verify + consume reset token and rotate password atomically.
 
     Uses ``SELECT ... FOR UPDATE`` to serialise concurrent confirms on
@@ -81,16 +81,31 @@ async def consume_reset_token(
     token = result.scalar_one_or_none()
 
     now = datetime.now(timezone.utc)
-    if token is None or token.used_at is not None or token.expires_at < now:
+    if token is None or token.used_at is not None:
+        raise HTTPException(status_code=400, detail="Invalid or expired reset token")
+
+    expires_at = token.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if expires_at < now:
         raise HTTPException(status_code=400, detail="Invalid or expired reset token")
 
     user = await session.get(User, token.user_id)
     if user is None or not user.has_local_password:
         raise HTTPException(status_code=400, detail="Invalid or expired reset token")
 
+    user_id = str(user.id)
+
+    consume_result = await session.execute(
+        update(PasswordResetToken)
+        .where(PasswordResetToken.id == token.id, PasswordResetToken.used_at.is_(None))
+        .values(used_at=now)
+    )
+    if consume_result.rowcount != 1:
+        raise HTTPException(status_code=400, detail="Invalid or expired reset token")
+
     user.hashed_password = get_password_hash(new_password)
     user.password_changed_at = now
-    token.used_at = now
 
     # Invalidate any other outstanding reset tokens for this user — once a
     # successful reset happens, older pending links must not keep working.
@@ -105,4 +120,4 @@ async def consume_reset_token(
     )
 
     await session.commit()
-    return user
+    return user_id

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pytest import LogCaptureFixture
 
 from app.services.email import (
     _send,
@@ -168,7 +169,7 @@ async def test_send_password_reset_uses_branded_sender_and_reply_to() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_does_not_log_authorization_header_on_failure(caplog) -> None:
+async def test_send_does_not_log_authorization_header_on_failure(caplog: LogCaptureFixture) -> None:
     """When Resend fails, the warning log carries to/subject/error — never the API key.
 
     Defence-in-depth: a regression that started logging request headers would

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -60,23 +60,36 @@ async def test_send_password_reset() -> None:
     )
 
 
+def _make_resend_client_mocks(
+    *, raise_for_status_side_effect: Exception | None = None,
+) -> tuple[AsyncMock, MagicMock, MagicMock]:
+    """Build a (client, response, context-manager) trio for httpx.AsyncClient patching."""
+    response = MagicMock(status_code=202)
+    if raise_for_status_side_effect is not None:
+        response.raise_for_status = MagicMock(side_effect=raise_for_status_side_effect)
+    else:
+        response.raise_for_status = MagicMock()
+
+    client = AsyncMock()
+    client.post.return_value = response
+
+    client_context = MagicMock()
+    client_context.__aenter__ = AsyncMock(return_value=client)
+    client_context.__aexit__ = AsyncMock(return_value=None)
+    return client, response, client_context
+
+
 @pytest.mark.asyncio
-async def test_send_posts_to_resend_when_api_key_configured() -> None:
-    """Configured RESEND_API_KEY: _send posts the expected payload."""
+async def test_send_posts_to_resend_with_branded_sender_and_reply_to() -> None:
+    """Configured RESEND_API_KEY: payload includes shelfy.cz sender + reply_to."""
     from app.core.config import Settings
 
     settings = Settings(
         resend_api_key="re_test_key",
-        email_from_address="Shelfy <noreply@example.com>",
+        email_from_address="Shelfy <noreply@shelfy.cz>",
+        email_reply_to_address="support@shelfy.cz",
     )
-    response = MagicMock(status_code=202)
-    response.raise_for_status = MagicMock()
-
-    client = AsyncMock()
-    client.post.return_value = response
-    client_context = MagicMock()
-    client_context.__aenter__ = AsyncMock(return_value=client)
-    client_context.__aexit__ = AsyncMock(return_value=None)
+    client, response, client_context = _make_resend_client_mocks()
 
     with (
         patch("app.services.email.get_settings", return_value=settings),
@@ -91,13 +104,99 @@ async def test_send_posts_to_resend_when_api_key_configured() -> None:
             "Content-Type": "application/json",
         },
         json={
-            "from": "Shelfy <noreply@example.com>",
+            "from": "Shelfy <noreply@shelfy.cz>",
             "to": ["user@example.com"],
             "subject": "Hello",
             "html": "<p>Hi</p>",
+            "reply_to": "support@shelfy.cz",
         },
     )
     response.raise_for_status.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_send_omits_reply_to_when_unset() -> None:
+    """email_reply_to_address=None → no reply_to key in the JSON payload."""
+    from app.core.config import Settings
+
+    settings = Settings(
+        resend_api_key="re_test_key",
+        email_from_address="Shelfy <noreply@shelfy.cz>",
+        email_reply_to_address=None,
+    )
+    client, _, client_context = _make_resend_client_mocks()
+
+    with (
+        patch("app.services.email.get_settings", return_value=settings),
+        patch("app.services.email.httpx.AsyncClient", return_value=client_context),
+    ):
+        await _send(to="user@example.com", subject="Hi", html="<p>Hi</p>")
+
+    posted = client.post.await_args.kwargs["json"]
+    assert "reply_to" not in posted
+    assert posted["from"] == "Shelfy <noreply@shelfy.cz>"
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_uses_branded_sender_and_reply_to() -> None:
+    """End-to-end: send_password_reset → _send → Resend payload carries shelfy.cz From + Reply-To."""
+    from app.core.config import Settings
+
+    settings = Settings(
+        resend_api_key="re_test_key",
+        email_from_address="Shelfy <noreply@shelfy.cz>",
+        email_reply_to_address="support@shelfy.cz",
+    )
+    client, _, client_context = _make_resend_client_mocks()
+
+    with (
+        patch("app.services.email.get_settings", return_value=settings),
+        patch("app.services.email.httpx.AsyncClient", return_value=client_context),
+    ):
+        await send_password_reset(
+            "user@example.com",
+            reset_url="https://shelfy.cz/reset/abc123token",
+        )
+
+    posted = client.post.await_args.kwargs["json"]
+    assert posted["from"] == "Shelfy <noreply@shelfy.cz>"
+    assert posted["reply_to"] == "support@shelfy.cz"
+    assert posted["to"] == ["user@example.com"]
+    assert "Reset your Shelfy password" in posted["subject"]
+    # Reset URL is rendered into the HTML so the user can click through.
+    assert "https://shelfy.cz/reset/abc123token" in posted["html"]
+
+
+@pytest.mark.asyncio
+async def test_send_does_not_log_authorization_header_on_failure(caplog) -> None:
+    """When Resend fails, the warning log carries to/subject/error — never the API key.
+
+    Defence-in-depth: a regression that started logging request headers would
+    leak the bearer token.  We assert the secret never appears anywhere in the
+    captured log records.
+    """
+    from app.core.config import Settings
+
+    secret = "re_super_secret_key_ABC123"
+    settings = Settings(resend_api_key=secret, email_from_address="Shelfy <noreply@shelfy.cz>")
+    _, _, client_context = _make_resend_client_mocks(
+        raise_for_status_side_effect=RuntimeError("resend down"),
+    )
+
+    import logging
+    with (
+        patch("app.services.email.get_settings", return_value=settings),
+        patch("app.services.email.httpx.AsyncClient", return_value=client_context),
+        caplog.at_level(logging.WARNING, logger="app.services.email"),
+    ):
+        await _send(to="user@example.com", subject="Boom", html="<p>Hi</p>")
+
+    # Error path was taken (logged a warning) and the API key never appeared.
+    assert any("email.failed" in rec.getMessage() for rec in caplog.records)
+    for rec in caplog.records:
+        assert secret not in rec.getMessage()
+        # Also check structured fields — extra={...} attributes get attached as record attrs.
+        assert secret not in str(rec.__dict__)
 
 
 @pytest.mark.asyncio
@@ -106,14 +205,9 @@ async def test_send_swallows_resend_errors() -> None:
     from app.core.config import Settings
 
     settings = Settings(resend_api_key="re_test_key")
-    response = MagicMock(status_code=500)
-    response.raise_for_status.side_effect = RuntimeError("resend down")
-
-    client = AsyncMock()
-    client.post.return_value = response
-    client_context = MagicMock()
-    client_context.__aenter__ = AsyncMock(return_value=client)
-    client_context.__aexit__ = AsyncMock(return_value=None)
+    _, response, client_context = _make_resend_client_mocks(
+        raise_for_status_side_effect=RuntimeError("resend down"),
+    )
 
     with (
         patch("app.services.email.get_settings", return_value=settings),
@@ -121,5 +215,4 @@ async def test_send_swallows_resend_errors() -> None:
     ):
         await _send(to="user@example.com", subject="Boom", html="<p>Hi</p>")
 
-    client.post.assert_awaited_once()
     response.raise_for_status.assert_called_once_with()

--- a/docs/runbooks/email.md
+++ b/docs/runbooks/email.md
@@ -1,0 +1,96 @@
+# Transactional email (Resend) — setup & operations
+
+Shelfy sends transactional email through [Resend](https://resend.com).  Mail
+flows from two places:
+
+| Sender | Path | Triggers |
+|---|---|---|
+| `backend/app/services/email.py` | FastAPI request handlers | `send_welcome` (registration), `send_password_reset` (forgot-password) |
+| `worker/email_tasks.py` | Celery beat | `send_trial_ending` (day 10/13), `send_limit_approaching` (≥ 80 % of free quota) |
+
+Both call the Resend HTTP API at `https://api.resend.com/emails`.  When
+`RESEND_API_KEY` is unset both modules **silently no-op** so local dev and CI
+work without a real key.
+
+## Sender identity
+
+The default identity is:
+
+```
+From:     Shelfy <noreply@shelfy.cz>
+Reply-To: support@shelfy.cz
+```
+
+Set per environment via:
+
+| Env var | Default | Notes |
+|---|---|---|
+| `RESEND_API_KEY` | _(none)_ | `re_…` from [resend.com/api-keys](https://resend.com/api-keys); never commit, never log. |
+| `EMAIL_FROM_ADDRESS` | `Shelfy <noreply@shelfy.cz>` | Must be a sender on a Resend-verified domain. |
+| `EMAIL_REPLY_TO_ADDRESS` | `support@shelfy.cz` | Empty / unset → no `Reply-To` header. |
+
+## DNS prerequisites (one-time, per domain)
+
+Before mail will deliver from `shelfy.cz`:
+
+1. In Resend: **Domains → Add domain → `shelfy.cz`**.
+2. Add the records Resend lists at the registrar (Wedos):
+   - `_resend.shelfy.cz` TXT (domain verification)
+   - `resend._domainkey.shelfy.cz` TXT (DKIM)
+   - `_dmarc.shelfy.cz` TXT (DMARC, recommend `p=none` initially, tighten to
+     `p=quarantine` once delivery is stable)
+   - SPF: ensure `v=spf1 include:_spf.resend.com ~all` is on the `shelfy.cz`
+     TXT record (merge with any existing SPF — only one SPF record allowed).
+3. Wait for Resend to mark the domain ✅ verified (usually < 10 min).
+
+The Wedos mailboxes (`admin@`, `billing@`, `noreply@`, `support@`) are
+**inbox-side** — they receive replies / bounces but do not change Resend's
+sending verification.  `support@shelfy.cz` is configured to forward to a
+real ops mailbox at Wedos.
+
+## Local development
+
+```bash
+# .env (gitignored — never commit)
+RESEND_API_KEY=re_…
+EMAIL_FROM_ADDRESS=Shelfy <noreply@shelfy.cz>
+EMAIL_REPLY_TO_ADDRESS=support@shelfy.cz
+```
+
+Smoke-test the password-reset path:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/auth/password-reset/request \
+  -H 'Content-Type: application/json' \
+  -d '{"email": "you@your-real-inbox.example"}'
+```
+
+Backend logs should show `email.sent status=200` (or `email.failed` with the
+HTTP error if Resend rejects).
+
+## Production deployment
+
+`RESEND_API_KEY` lives in the deployment secret store (`docker secret`,
+GitHub Actions environment secret, or `--env-file` chmod-600).  It must
+**not** appear in:
+
+- the git index (`.env` and `infra/.env.prod.local` are gitignored)
+- application logs (`_send` only logs `to`, `subject`, `status` — see the
+  defence-in-depth test `test_send_does_not_log_authorization_header_on_failure`)
+- the frontend bundle (`RESEND_API_KEY` is server-only; no `VITE_` mirror)
+
+## Rotation
+
+1. Resend dashboard → **API keys → Create new** (mark `Sending access` only).
+2. Update the production secret store; redeploy backend + worker.
+3. Confirm a `email.sent` log line appears with the new key in production.
+4. Resend dashboard → **delete the old key**.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `email.failed` with HTTP 403 | Domain not verified in Resend, or `EMAIL_FROM_ADDRESS` not on the verified domain. |
+| `email.failed` with HTTP 422 | Malformed `from`/`reply_to` (Resend rejects bare addresses without display names sometimes — keep `Name <addr@domain>` form). |
+| `email.skipped (no RESEND_API_KEY)` in dev | Expected — set the key in `.env` to enable. |
+| Replies bounce at Wedos | Check `support@shelfy.cz` mailbox / forwarder still exists at Wedos. |

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -58,8 +58,19 @@ STRIPE_PORTAL_RETURN_URL=                   # https://your-domain.example.com/se
 APP_URL=https://your-domain.example.com
 
 # ── Email (Resend) ────────────────────────────────────
-RESEND_API_KEY=                             # re_...
-EMAIL_FROM_ADDRESS=Shelfy <noreply@your-domain.example.com>
+# RESEND_API_KEY: create at https://resend.com/api-keys → "Sending access" only.
+#   Inject via the deployment secret store (Docker Swarm secret, GH Action env,
+#   or `--env-file` from a chmod-600 file).  Never commit, never log.
+# EMAIL_FROM_ADDRESS: must be a sender on a Resend-verified domain.  Verify at
+#   https://resend.com/domains by adding the SPF, DKIM and DMARC DNS records
+#   for shelfy.cz; mail will not deliver until Resend marks the domain green.
+# EMAIL_REPLY_TO_ADDRESS: monitored inbox where user replies land (Wedos
+#   forwarding from support@shelfy.cz → ops mailbox).  Leave empty to omit.
+# Example: RESEND_API_KEY=re_...
+# Keep the real value in a chmod-600 env file or secret store; never commit it.
+RESEND_API_KEY=
+EMAIL_FROM_ADDRESS=Shelfy <noreply@shelfy.cz>
+EMAIL_REPLY_TO_ADDRESS=support@shelfy.cz
 
 # ── Housekeeping ──────────────────────────────────────
 BACKUP_KEEP_DAYS=30

--- a/worker/email_tasks.py
+++ b/worker/email_tasks.py
@@ -37,8 +37,10 @@ _DATABASE_URL = os.environ.get(
 
 _REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
 _RESEND_API_KEY = os.environ.get("RESEND_API_KEY", "")
-_EMAIL_FROM = os.environ.get("EMAIL_FROM_ADDRESS", "Shelfy <noreply@shelfy.app>")
-_APP_URL = os.environ.get("APP_URL", "https://shelfy.app")
+_EMAIL_FROM = os.environ.get("EMAIL_FROM_ADDRESS", "Shelfy <noreply@shelfy.cz>")
+# Reply-To target for transactional mail (set empty to omit the header).
+_EMAIL_REPLY_TO = os.environ.get("EMAIL_REPLY_TO_ADDRESS", "support@shelfy.cz") or ""
+_APP_URL = os.environ.get("APP_URL", "https://shelfy.cz")
 
 _LIMIT_THRESHOLD = 0.80   # notify when ≥ 80 % used
 _RESEND_URL = "https://api.resend.com/emails"
@@ -68,10 +70,23 @@ def _mark_sent(r, key: str) -> None:
 
 
 def _send_email(to: str, subject: str, html: str) -> bool:
-    """POST to Resend API. Returns True on success, False otherwise."""
+    """POST to Resend API. Returns True on success, False otherwise.
+
+    Mirrors backend/app/services/email.py — same payload shape, same logging
+    discipline (the API key never enters log records).  ``reply_to`` is
+    omitted when EMAIL_REPLY_TO_ADDRESS is unset.
+    """
     if not _RESEND_API_KEY:
         log.debug("email.skipped_no_api_key", extra={"to": to})
         return False
+    payload: dict[str, object] = {
+        "from": _EMAIL_FROM,
+        "to": [to],
+        "subject": subject,
+        "html": html,
+    }
+    if _EMAIL_REPLY_TO:
+        payload["reply_to"] = _EMAIL_REPLY_TO
     try:
         resp = httpx.post(
             _RESEND_URL,
@@ -79,7 +94,7 @@ def _send_email(to: str, subject: str, html: str) -> bool:
                 "Authorization": f"Bearer {_RESEND_API_KEY}",
                 "Content-Type": "application/json",
             },
-            json={"from": _EMAIL_FROM, "to": [to], "subject": subject, "html": html},
+            json=payload,
             timeout=15,
         )
         resp.raise_for_status()


### PR DESCRIPTION
## Summary
- configure Shelfy transactional mail to use the branded `Shelfy <noreply@shelfy.cz>` sender and `support@shelfy.cz` reply-to
- document the Resend production setup and env variables without exposing secrets
- fix the password-reset confirm success path so the browser receives 204 instead of a backend 500 after the password is changed

## Verification
- `ruff check app/api/auth.py app/services/password_reset.py`
- `mypy app/api/auth.py app/services/password_reset.py`
- `pytest tests/test_email_service.py -q`
- `pytest tests/test_password_reset.py -q`
- production smoke: created a temporary reset token against the deployed backend, confirmed it via `/api/v1/auth/password-reset/confirm`, received HTTP 204, then removed the temporary user

## Notes
- Resend API key remains deployment-only and is not committed.
- Deployed on homelab2 for manual review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Reply-To header for transactional emails.
  * Local development: leaving the API key empty disables outbound mail.

* **Chores**
  * Migrated branded sender and email footer from shelfy.app to shelfy.cz.
  * Added RESEND_API_KEY and EMAIL_* examples and defaults to env templates.
  * Published a comprehensive transactional email runbook (setup, DNS, dev, troubleshooting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->