### PR TITLE
Localize transactional emails and clarify add-book location copy

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -59,6 +59,17 @@ router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 SETTINGS = get_settings()
 
 
+def _email_locale_from_request(request: Request) -> str:
+    """Best-effort email locale from the SPA language cookie or browser headers."""
+    cookie_locale = request.cookies.get("shelfy_language")
+    if cookie_locale:
+        return email_svc.normalize_locale(cookie_locale)
+
+    accept_language = request.headers.get("accept-language", "")
+    first_language = accept_language.split(",", maxsplit=1)[0].strip()
+    return email_svc.normalize_locale(first_language)
+
+
 # ── Standard auth ──────────────────────────────────────────────────────────────
 
 @router.post("/register", response_model=UserResponse, status_code=201)
@@ -72,7 +83,7 @@ async def register(
     user = await register_user(session, str(payload.email), payload.password)
     # Fire-and-forget welcome email — never blocks the response
     name = user.email.split("@")[0]
-    background_tasks.add_task(email_svc.send_welcome, user.email, name)
+    background_tasks.add_task(email_svc.send_welcome, user.email, name, locale=_email_locale_from_request(request))
     return UserResponse.model_validate(user)
 
 
@@ -185,7 +196,7 @@ async def request_password_reset(
         requested_user_agent=request.headers.get("user-agent"),
     )
     reset_url = f"{settings.app_url}/reset-password?token={plaintext_token}"
-    background_tasks.add_task(email_svc.send_password_reset, user.email, reset_url)
+    background_tasks.add_task(email_svc.send_password_reset, user.email, reset_url, locale=_email_locale_from_request(request))
     await session.commit()
     logger.info("password_reset_request", email_hash=email_hash, outcome="token_created")
     return {"status": "ok"}

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -76,10 +76,31 @@ async def _send(*, to: str, subject: str, html: str) -> None:
 
 # ── Email templates ────────────────────────────────────────────────────────────
 
-def _base(content: str) -> str:
+_SUPPORTED_LOCALES = {"cs", "en"}
+
+
+def normalize_locale(locale: str | None) -> str:
+    """Return a supported email locale, defaulting to English.
+
+    The frontend currently stores the UI language in a browser cookie rather
+    than on the user row. Email callers can pass that value directly; unknown
+    values intentionally fall back to English.
+    """
+    if not locale:
+        return "en"
+    normalized = locale.lower().split("-", maxsplit=1)[0]
+    return normalized if normalized in _SUPPORTED_LOCALES else "en"
+
+
+def _base(content: str, *, locale: str | None = None) -> str:
     """Minimal responsive wrapper so emails render well in any client."""
+    lang = normalize_locale(locale)
+    footer = {
+        "cs": "Shelfy · Tento e-mail dostáváš, protože máš účet na shelfy.cz",
+        "en": "Shelfy · You're receiving this because you have an account at shelfy.cz",
+    }[lang]
     return f"""<!DOCTYPE html>
-<html lang="en">
+<html lang="{lang}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -96,7 +117,7 @@ def _base(content: str) -> str:
             {content}
             <hr style="border:none;border-top:1px solid #eee;margin:32px 0">
             <p style="color:#888;font-size:12px;margin:0">
-              Shelfy · You're receiving this because you have an account at shelfy.cz
+              {footer}
             </p>
           </td></tr>
         </table>
@@ -107,10 +128,34 @@ def _base(content: str) -> str:
 </html>"""
 
 
-async def send_welcome(to: str, name: str) -> None:
+def _cta(url: str, label: str) -> str:
+    return f"""<a href="{url}"
+     style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;
+            text-decoration:none;display:inline-block;margin-top:8px">
+    {label}
+  </a>"""
+
+
+async def send_welcome(to: str, name: str, *, locale: str | None = None) -> None:
     """Welcome email sent immediately after registration."""
     settings = get_settings()
-    html = _base(f"""
+    lang = normalize_locale(locale)
+    if lang == "cs":
+        html = _base(f"""
+<p>Ahoj {name},</p>
+<p>Vítej v <strong>Shelfy</strong> — tvém osobním správci knihovny! 🎉</p>
+<p>Hned můžeš:</p>
+<ul>
+  <li>📷 naskenovat knihovnu pomocí AI skenu police,</li>
+  <li>🔍 doplnit obálky a metadata z Google Books,</li>
+  <li>📍 organizovat knihy podle umístění a stavu čtení.</li>
+</ul>
+<p>{_cta(f"{settings.app_url}/books", "Otevřít Shelfy →")}</p>
+<p style="color:#555">Příjemné čtení,<br>tým Shelfy</p>
+""", locale=lang)
+        subject = "Vítej v Shelfy 📚"
+    else:
+        html = _base(f"""
 <p>Hey {name},</p>
 <p>Welcome to <strong>Shelfy</strong> — your personal book library manager! 🎉</p>
 <p>Here's what you can do right away:</p>
@@ -119,41 +164,39 @@ async def send_welcome(to: str, name: str) -> None:
   <li>🔍 Auto-enrich books with cover images &amp; metadata from Google Books</li>
   <li>📍 Organise books by location and reading status</li>
 </ul>
-<p>
-  <a href="{settings.app_url}/books"
-     style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;
-            text-decoration:none;display:inline-block;margin-top:8px">
-    Open Shelfy →
-  </a>
-</p>
+<p>{_cta(f"{settings.app_url}/books", "Open Shelfy →")}</p>
 <p style="color:#555">Happy reading,<br>The Shelfy team</p>
-""")
-    await _send(to=to, subject="Welcome to Shelfy 📚", html=html)
+""", locale=lang)
+        subject = "Welcome to Shelfy 📚"
+    await _send(to=to, subject=subject, html=html)
 
 
-async def send_trial_ending(to: str, name: str, days_left: int) -> None:
+async def send_trial_ending(to: str, name: str, days_left: int, *, locale: str | None = None) -> None:
     """Sent on trial day 10 (4 days left) and day 13 (1 day left)."""
     settings = get_settings()
-    urgency = "your trial ends tomorrow" if days_left == 1 else f"your trial ends in {days_left} days"
-    html = _base(f"""
+    lang = normalize_locale(locale)
+    if lang == "cs":
+        urgency = "zkušební období končí zítra" if days_left == 1 else f"zkušební období končí za {days_left} dny"
+        html = _base(f"""
+<p>Ahoj {name},</p>
+<p>Jen připomínka — <strong>{urgency}</strong>.</p>
+<p>Pokud chceš dál používat neomezené obohacování, skeny polic a sdílené knihovny,
+   přejdi na placený tarif před koncem trialu.</p>
+<p>{_cta(f"{settings.app_url}/settings#billing", "Upgradovat →")}</p>
+<p style="color:#555">Díky, že zkoušíš Shelfy,<br>tým Shelfy</p>
+""", locale=lang)
+        subject = "Zkušební období Shelfy končí zítra ⏰" if days_left == 1 else f"Zkušební období Shelfy končí za {days_left} dny"
+    else:
+        urgency = "your trial ends tomorrow" if days_left == 1 else f"your trial ends in {days_left} days"
+        html = _base(f"""
 <p>Hey {name},</p>
 <p>Just a heads-up — <strong>{urgency}</strong>.</p>
 <p>To keep enjoying unlimited enrichments, shelf scans, and shared libraries,
    upgrade to a paid plan before your trial expires.</p>
-<p>
-  <a href="{settings.app_url}/settings#billing"
-     style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;
-            text-decoration:none;display:inline-block;margin-top:8px">
-    Upgrade now →
-  </a>
-</p>
+<p>{_cta(f"{settings.app_url}/settings#billing", "Upgrade now →")}</p>
 <p style="color:#555">Thanks for trying Shelfy,<br>The Shelfy team</p>
-""")
-    subject = (
-        "Your Shelfy trial ends tomorrow ⏰"
-        if days_left == 1
-        else f"Your Shelfy trial ends in {days_left} days"
-    )
+""", locale=lang)
+        subject = "Your Shelfy trial ends tomorrow ⏰" if days_left == 1 else f"Your Shelfy trial ends in {days_left} days"
     await _send(to=to, subject=subject, html=html)
 
 
@@ -163,47 +206,60 @@ async def send_limit_approaching(
     metric: str,
     used: int,
     limit: int,
+    *,
+    locale: str | None = None,
 ) -> None:
     """Sent when a user reaches ≥ 80 % of a monthly quota."""
     settings = get_settings()
+    lang = normalize_locale(locale)
     pct = int(used / limit * 100)
     metric_label = metric.replace("_", " ")
-    html = _base(f"""
+    if lang == "cs":
+        html = _base(f"""
+<p>Ahoj {name},</p>
+<p>Tento měsíc jsi využil/a <strong>{used} z {limit} ({metric_label})</strong> ({pct} %).</p>
+<p>Po dosažení limitu půjde funkce znovu použít až v dalším fakturačním období —
+   pokud nepřejdeš na vyšší tarif.</p>
+<p>{_cta(f"{settings.app_url}/settings#billing", "Zobrazit tarify →")}</p>
+<p style="color:#555">Tým Shelfy</p>
+""", locale=lang)
+        subject = f"Jsi na {pct} % limitu: {metric_label}"
+    else:
+        html = _base(f"""
 <p>Hey {name},</p>
 <p>You've used <strong>{used} of {limit} {metric_label}</strong> ({pct} %) this month.</p>
 <p>When you hit the limit you won't be able to use this feature until the next billing period
    — unless you upgrade.</p>
-<p>
-  <a href="{settings.app_url}/settings#billing"
-     style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;
-            text-decoration:none;display:inline-block;margin-top:8px">
-    View plans →
-  </a>
-</p>
+<p>{_cta(f"{settings.app_url}/settings#billing", "View plans →")}</p>
 <p style="color:#555">The Shelfy team</p>
-""")
-    await _send(
-        to=to,
-        subject=f"You're at {pct}% of your {metric_label} quota",
-        html=html,
-    )
+""", locale=lang)
+        subject = f"You're at {pct}% of your {metric_label} quota"
+    await _send(to=to, subject=subject, html=html)
 
 
-async def send_password_reset(to: str, reset_url: str) -> None:
+async def send_password_reset(to: str, reset_url: str, *, locale: str | None = None) -> None:
     """Sent when a user requests a password reset."""
-    html = _base(f"""
+    lang = normalize_locale(locale)
+    if lang == "cs":
+        html = _base(f"""
+<p>Ahoj,</p>
+<p>Dostali jsme žádost o reset hesla k tvému účtu Shelfy.</p>
+<p>{_cta(reset_url, "Resetovat heslo →")}</p>
+<p>Odkaz platí 60 minut a lze ho použít pouze jednou.
+   Pokud jsi o reset nežádal/a, můžeš tento e-mail bezpečně ignorovat —
+   heslo se nezměnilo.</p>
+<p style="color:#555">Tým Shelfy</p>
+""", locale=lang)
+        subject = "Reset hesla do Shelfy"
+    else:
+        html = _base(f"""
 <p>Hey,</p>
 <p>We received a request to reset the password for your Shelfy account.</p>
-<p>
-  <a href="{reset_url}"
-     style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;
-            text-decoration:none;display:inline-block;margin-top:8px">
-    Reset my password →
-  </a>
-</p>
+<p>{_cta(reset_url, "Reset my password →")}</p>
 <p>This link is valid for 60 minutes and can be used only once.
    If you did not request a reset, you can safely ignore this email —
    your password has not been changed.</p>
 <p style="color:#555">The Shelfy team</p>
-""")
-    await _send(to=to, subject="Reset your Shelfy password", html=html)
+""", locale=lang)
+        subject = "Reset your Shelfy password"
+    await _send(to=to, subject=subject, html=html)

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -21,8 +21,10 @@ from pytest import LogCaptureFixture
 
 from app.services.email import (
     _send,
+    normalize_locale,
     send_limit_approaching,
     send_password_reset,
+    send_welcome,
     send_trial_ending,
 )
 
@@ -78,6 +80,64 @@ def _make_resend_client_mocks(
     client_context.__aenter__ = AsyncMock(return_value=client)
     client_context.__aexit__ = AsyncMock(return_value=None)
     return client, response, client_context
+
+
+def test_normalize_locale_defaults_to_english() -> None:
+    assert normalize_locale(None) == "en"
+    assert normalize_locale("en-US") == "en"
+    assert normalize_locale("cs-CZ") == "cs"
+    assert normalize_locale("de-DE") == "en"
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_renders_czech_copy() -> None:
+    send_mock = AsyncMock()
+
+    with patch("app.services.email._send", send_mock):
+        await send_password_reset(
+            "user@example.com",
+            reset_url="https://shelfy.cz/reset-password?token=abc123",
+            locale="cs-CZ",
+        )
+
+    assert send_mock.await_args is not None
+    kwargs = send_mock.await_args.kwargs
+    assert kwargs["subject"] == "Reset hesla do Shelfy"
+    assert 'html lang="cs"' in kwargs["html"]
+    assert "Resetovat heslo" in kwargs["html"]
+    assert "https://shelfy.cz/reset-password?token=abc123" in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_falls_back_to_english_copy() -> None:
+    send_mock = AsyncMock()
+
+    with patch("app.services.email._send", send_mock):
+        await send_password_reset(
+            "user@example.com",
+            reset_url="https://shelfy.cz/reset-password?token=abc123",
+            locale="de-DE",
+        )
+
+    assert send_mock.await_args is not None
+    kwargs = send_mock.await_args.kwargs
+    assert kwargs["subject"] == "Reset your Shelfy password"
+    assert 'html lang="en"' in kwargs["html"]
+    assert "Reset my password" in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_send_welcome_renders_czech_copy() -> None:
+    send_mock = AsyncMock()
+
+    with patch("app.services.email._send", send_mock):
+        await send_welcome("user@example.com", "Alice", locale="cs")
+
+    assert send_mock.await_args is not None
+    kwargs = send_mock.await_args.kwargs
+    assert kwargs["subject"] == "Vítej v Shelfy 📚"
+    assert "Ahoj Alice" in kwargs["html"]
+    assert "Otevřít Shelfy" in kwargs["html"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -74,7 +74,7 @@ def fake_redis() -> FakeRedis:
 
 
 @pytest.fixture
-def sent_emails() -> list[tuple[str, str]]:
+def sent_emails() -> list[tuple[str, str, str | None]]:
     return []
 
 
@@ -121,7 +121,7 @@ def override_dependencies(
     test_session: async_sessionmaker[AsyncSession],
     test_settings: Settings,
     fake_redis: FakeRedis,
-    sent_emails: list[tuple[str, str]],
+    sent_emails: list[tuple[str, str, str | None]],
 ) -> Iterator[None]:
     async def _get_db() -> AsyncIterator[AsyncSession]:
         async with test_session() as session:
@@ -130,8 +130,8 @@ def override_dependencies(
     async def _get_redis() -> AsyncIterator[FakeRedis]:
         yield fake_redis
 
-    async def _fake_send_password_reset(to: str, reset_url: str) -> None:
-        sent_emails.append((to, reset_url))
+    async def _fake_send_password_reset(to: str, reset_url: str, *, locale: str | None = None) -> None:
+        sent_emails.append((to, reset_url, locale))
 
     monkeypatch.setattr("app.services.email.send_password_reset", _fake_send_password_reset)
     app.dependency_overrides[get_db_session] = _get_db
@@ -176,7 +176,7 @@ def _token_from_reset_url(url: str) -> str:
 @pytest.mark.asyncio
 async def test_request_returns_202_for_all_email_cases(
     test_session: async_sessionmaker[AsyncSession],
-    sent_emails: list[tuple[str, str]],
+    sent_emails: list[tuple[str, str, str | None]],
 ) -> None:
     """5. Request endpoint returns 202 regardless of whether email exists."""
     async with test_session() as session:
@@ -214,9 +214,32 @@ async def test_request_returns_202_for_all_email_cases(
 
 
 @pytest.mark.asyncio
+async def test_password_reset_uses_ui_language_cookie(
+    test_session: async_sessionmaker[AsyncSession],
+    sent_emails: list[tuple[str, str, str | None]],
+) -> None:
+    async with test_session() as session:
+        await _create_user(session, email="locale@example.com")
+
+    headers, cookies = _csrf()
+    cookies = {**cookies, "shelfy_language": "cs"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/auth/password-reset/request",
+            json={"email": "locale@example.com"},
+            headers=headers,
+            cookies=cookies,
+        )
+
+    assert response.status_code == 202
+    assert len(sent_emails) == 1
+    assert sent_emails[0][2] == "cs"
+
+
+@pytest.mark.asyncio
 async def test_token_not_stored_in_plaintext_and_ttl_is_60_minutes(
     test_session: async_sessionmaker[AsyncSession],
-    sent_emails: list[tuple[str, str]],
+    sent_emails: list[tuple[str, str, str | None]],
 ) -> None:
     """1. Token is never stored in plaintext."""
     async with test_session() as session:
@@ -245,7 +268,7 @@ async def test_token_not_stored_in_plaintext_and_ttl_is_60_minutes(
 @pytest.mark.asyncio
 async def test_email_rate_limit_allows_only_three_requests_per_hour(
     test_session: async_sessionmaker[AsyncSession],
-    sent_emails: list[tuple[str, str]],
+    sent_emails: list[tuple[str, str, str | None]],
 ) -> None:
     """7. Request is rate-limited per email via Redis: 3 req/hour."""
     async with test_session() as session:
@@ -295,7 +318,7 @@ async def test_ip_rate_limit_returns_429_on_sixth_call(enabled_limiter: None) ->
 @pytest.mark.asyncio
 async def test_confirm_success_single_use_and_sibling_invalidation(
     test_session: async_sessionmaker[AsyncSession],
-    sent_emails: list[tuple[str, str]],
+    sent_emails: list[tuple[str, str, str | None]],
 ) -> None:
     """10. On successful reset, all other outstanding reset tokens for that user are also consumed."""
     async with test_session() as session:
@@ -418,7 +441,7 @@ async def test_confirm_password_policy_failure_is_400() -> None:
 @pytest.mark.asyncio
 async def test_reset_invalidates_existing_refresh_tokens(
     test_session: async_sessionmaker[AsyncSession],
-    sent_emails: list[tuple[str, str]],
+    sent_emails: list[tuple[str, str, str | None]],
 ) -> None:
     """9. Successful reset invalidates all existing refresh sessions."""
     async with test_session() as session:

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -383,8 +383,15 @@
     "processing_label": "Zpracovávám obrázek…",
     "location_optional": "volitelné",
     "no_location_option": "Bez umístění",
-    "location_help": "Umístění je volitelné. Můžeš ho přidat i později.",
-    "add_location_cta": "Přidat umístění"
+    "location_help": "Chybí ti místnost nebo police? Vytvoř nové umístění a vrať se zpět.",
+    "add_location_cta": "Přidat umístění",
+    "title_placeholder": "např. Duna",
+    "author_placeholder": "např. Frank Herbert",
+    "isbn_placeholder": "978-80-…",
+    "location_optional_hint": "Nemusíš vybírat umístění hned. Kniha se uloží i bez něj a můžeš ji zařadit později v detailu knihy.",
+    "no_room_option": "Bez místnosti / zařadit později",
+    "no_furniture_option": "Bez knihovny / zařadit později",
+    "no_shelf_option": "Bez police / zařadit později"
   },
   "enrich": {
     "enriching": "Obohacuji…",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -434,8 +434,15 @@
     "processing_label": "Processing image…",
     "location_optional": "optional",
     "no_location_option": "No location",
-    "location_help": "Location is optional. You can set it later.",
-    "add_location_cta": "Add location"
+    "location_help": "Missing a room or shelf? Create a new location, then come back here.",
+    "add_location_cta": "Add location",
+    "title_placeholder": "e.g. Dune",
+    "author_placeholder": "e.g. Frank Herbert",
+    "isbn_placeholder": "978-…",
+    "location_optional_hint": "You do not have to pick a location now. The book will save without it and you can place it later from the book detail.",
+    "no_room_option": "No room / place later",
+    "no_furniture_option": "No bookshelf / place later",
+    "no_shelf_option": "No shelf / place later"
   },
   "enrich": {
     "enriching": "Enriching…",

--- a/frontend/src/pages/AddBookPage.tsx
+++ b/frontend/src/pages/AddBookPage.tsx
@@ -141,18 +141,19 @@ export function AddBookPage() {
         <div className="md-grid-2">
           <div>
             <label style={{ fontSize: 13, fontWeight: 600, color: 'var(--sh-text-main)', display: 'block', marginBottom: 8 }}>{t('add_book.title_label')} <span style={{ color: 'var(--sh-red)' }}>*</span></label>
-            <input className="sh-input" placeholder="např. Duna" value={title} onChange={e => setTitle(e.target.value)} required />
+            <input className="sh-input" placeholder={t('add_book.title_placeholder')} value={title} onChange={e => setTitle(e.target.value)} required />
           </div>
 
           <div>
             <label style={{ fontSize: 13, fontWeight: 600, color: 'var(--sh-text-main)', display: 'block', marginBottom: 8 }}>{t('add_book.author_label')}</label>
-            <input className="sh-input" placeholder="např. Frank Herbert" value={author} onChange={e => setAuthor(e.target.value)} />
+            <input className="sh-input" placeholder={t('add_book.author_placeholder')} value={author} onChange={e => setAuthor(e.target.value)} />
           </div>
         </div>
 
         {/* 3-level location */}
         <div style={{ background: 'var(--sh-surface)', padding: 16, borderRadius: 'var(--sh-radius-md)', border: '1px solid var(--sh-border)' }}>
           <label style={{ fontSize: 14, fontWeight: 600, color: 'var(--sh-text-main)', display: 'block', marginBottom: 12 }}>{t('add_book.location_label')} <span style={{ color: 'var(--sh-text-muted)', fontWeight: 400 }}>({t('add_book.location_optional')})</span></label>
+          <p style={{ margin: '-4px 0 12px', fontSize: 12, color: 'var(--sh-text-muted)' }}>{t('add_book.location_optional_hint')}</p>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
             <div>
               <label style={{ fontSize: 12, fontWeight: 500, color: 'var(--sh-text-muted)', display: 'block', marginBottom: 6 }}>{t('add_book.room_label')}</label>
@@ -162,7 +163,7 @@ export function AddBookPage() {
                 value={selRoom}
                 onChange={e => { setSelRoom(e.target.value); setSelFurniture(''); setSelShelf('') }}
               >
-                <option value="">{t('add_book.no_location_option')}</option>
+                <option value="">{t('add_book.no_room_option')}</option>
                 {rooms.map(r => <option key={r} value={r}>{r}</option>)}
               </select>
             </div>
@@ -175,7 +176,7 @@ export function AddBookPage() {
                 disabled={!selRoom}
                 onChange={e => { setSelFurniture(e.target.value); setSelShelf('') }}
               >
-                <option value="">{t('add_book.no_location_option')}</option>
+                <option value="">{t('add_book.no_furniture_option')}</option>
                 {furnitures.map(f => <option key={f} value={f}>{f}</option>)}
               </select>
             </div>
@@ -188,7 +189,7 @@ export function AddBookPage() {
                 disabled={!selFurniture}
                 onChange={e => setSelShelf(e.target.value)}
               >
-                <option value="">{t('add_book.no_location_option')}</option>
+                <option value="">{t('add_book.no_shelf_option')}</option>
                 {shelves.map(s => <option key={s} value={s}>{s}</option>)}
               </select>
             </div>
@@ -226,7 +227,7 @@ export function AddBookPage() {
 
           <div>
             <label style={{ fontSize: 13, fontWeight: 600, color: 'var(--sh-text-main)', display: 'block', marginBottom: 8 }}>{t('add_book.isbn_label')} <span style={{ color: 'var(--sh-text-muted)', fontWeight: 400 }}>{t('add_book.isbn_optional')}</span></label>
-            <input className="sh-input" placeholder="978-80-…" value={isbn} onChange={e => setIsbn(e.target.value)} />
+            <input className="sh-input" placeholder={t('add_book.isbn_placeholder')} value={isbn} onChange={e => setIsbn(e.target.value)} />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- localize transactional email templates for Czech and English
- pick the email locale from the SPA language cookie, with `Accept-Language` fallback and English default
- cover localized password reset/welcome rendering and request-locale forwarding in tests
- clarify Add book location microcopy so users know location is optional and can be filled later
- localize Add book placeholders/options instead of hardcoded Czech strings

Closes #173
Closes #135

## Verification
- backend container: `ruff check app tests`
- backend container: `python -m mypy app tests`
- backend container: `pytest tests/test_email_service.py tests/test_password_reset.py -q` (`23 passed`)
- frontend: `npm ci`
- frontend: `npm run lint` (passes with existing warnings)
- frontend: `npm run build` (passes with existing Node 18/Vite warning)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transactional emails (welcome, password reset, trial ending, limit approaching) now render in Czech or English based on user language preference.
  * Book addition form inputs (title, author, ISBN) and location labels now display in your preferred language.
  * Email language automatically detects from your browser settings or UI language selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->