### PR TITLE
feat(scan): allow inserting and reordering book cards before save

### DIFF
--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -357,6 +357,10 @@
     "tip_segments": "Fotografuj zleva doprava po úsecích — pro dlouhé police použij 'Přidat další fotku'.",
     "tips_dismiss": "Zavřít tipy",
     "tips_show": "? Tipy",
+    "move_up": "Posunout nahoru",
+    "move_down": "Posunout dolů",
+    "add_book_here": "Přidat knihu zde",
+    "added_manually": "Ručně přidána",
     "remove_segment_title": "Odebrat tuto fotku?",
     "remove_segment_body": "Tím se zahodí všechny knihy rozpoznané v této fotce. Tuto akci nelze vrátit.",
     "remove_segment_confirm": "Odebrat fotku"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -408,6 +408,10 @@
     "tip_segments": "Photograph in sections from left to right — use 'Add another photo' for long shelves.",
     "tips_dismiss": "Dismiss tips",
     "tips_show": "? Tips",
+    "move_up": "Move up",
+    "move_down": "Move down",
+    "add_book_here": "Add book here",
+    "added_manually": "Manual",
     "remove_segment_title": "Remove this photo?",
     "remove_segment_body": "This will discard all books detected in this photo. This cannot be undone.",
     "remove_segment_confirm": "Remove photo"

--- a/frontend/src/pages/ScanShelfPage.test.tsx
+++ b/frontend/src/pages/ScanShelfPage.test.tsx
@@ -1,0 +1,338 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { type ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ScanShelfPage } from './ScanShelfPage'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const confirmMutateSpy = vi.fn()
+
+vi.mock('../hooks/useScan', () => ({
+  useScanShelf: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useShelfScanResult: vi.fn(() => ({ data: null })),
+  useConfirmShelfScan: vi.fn(() => ({ mutate: confirmMutateSpy, isPending: false })),
+  useBooksByLocation: vi.fn(() => ({ data: [] })),
+}))
+
+vi.mock('../hooks/useLocations', () => ({
+  useLocations: vi.fn(() => ({
+    data: [
+      {
+        id: 'loc-1',
+        room: 'Living Room',
+        furniture: 'Bookshelf',
+        shelf: 'Shelf 1',
+        display_order: 0,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ],
+  })),
+  useCreateLocation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}))
+
+vi.mock('../lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: vi.fn((selector: (s: { showError: () => void }) => unknown) =>
+    selector({ showError: vi.fn() }),
+  ),
+}))
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const SCAN_DRAFT_KEY = 'shelfy:scan-shelf-draft:v1'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+function makeReviewBook(overrides: {
+  localId: string
+  position: number
+  title: string
+  author?: string | null
+  isbn?: string | null
+  isManual?: boolean
+}) {
+  return {
+    localId: overrides.localId,
+    position: overrides.position,
+    title: overrides.title,
+    author: overrides.author ?? null,
+    isbn: overrides.isbn ?? null,
+    observedText: null,
+    confidence: null,
+    isManual: overrides.isManual ?? false,
+  }
+}
+
+function setReviewDraft(books: ReturnType<typeof makeReviewBook>[]) {
+  const draft = {
+    version: 1,
+    step: 'review',
+    selRoom: 'Living Room',
+    selFurniture: 'Bookshelf',
+    selShelf: 'Shelf 1',
+    newRoom: '',
+    newFurniture: '',
+    newShelf: '',
+    showNewLocation: false,
+    segments: [],
+    editableBooks: books,
+    locationId: 'loc-1',
+    scanMode: 'replace',
+    appendAfterBookId: null,
+    savedAt: new Date().toISOString(),
+  }
+  localStorage.setItem(SCAN_DRAFT_KEY, JSON.stringify(draft))
+}
+
+async function restoreDraft() {
+  await userEvent.click(screen.getByText('scan.restore_draft'))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ScanShelfPage – review step', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it('inserts a manual card between two existing scanned cards', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'Book A' }),
+      makeReviewBook({ localId: 'b', position: 1, title: 'Book B' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    // There should be 3 insert buttons: top, after A, after B
+    const insertButtons = screen.getAllByRole('button', { name: 'scan.add_book_here' })
+    expect(insertButtons).toHaveLength(3)
+
+    // Click the second insert button (after Book A, before Book B)
+    await userEvent.click(insertButtons[1])
+
+    // Now 3 cards: Book A, new manual, Book B
+    const titleInputs = screen.getAllByPlaceholderText('scan.book_title_placeholder')
+    expect(titleInputs).toHaveLength(3)
+    expect(titleInputs[0]).toHaveValue('Book A')
+    expect(titleInputs[1]).toHaveValue('')
+    expect(titleInputs[2]).toHaveValue('Book B')
+  })
+
+  it('inserts a manual card at the top when clicking the first insert button', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'Only Book' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    const insertButtons = screen.getAllByRole('button', { name: 'scan.add_book_here' })
+    // First button = insert at top
+    await userEvent.click(insertButtons[0])
+
+    const titleInputs = screen.getAllByPlaceholderText('scan.book_title_placeholder')
+    expect(titleInputs).toHaveLength(2)
+    expect(titleInputs[0]).toHaveValue('')       // new manual card at top
+    expect(titleInputs[1]).toHaveValue('Only Book')
+  })
+
+  it('moves a card up when clicking the move-up button', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'First' }),
+      makeReviewBook({ localId: 'b', position: 1, title: 'Second' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    const titleInputs = screen.getAllByPlaceholderText('scan.book_title_placeholder')
+    expect(titleInputs[0]).toHaveValue('First')
+    expect(titleInputs[1]).toHaveValue('Second')
+
+    // Move "Second" up — it's the second card, so its move-up button is index 1
+    const moveUpButtons = screen.getAllByRole('button', { name: 'scan.move_up' })
+    await userEvent.click(moveUpButtons[1])
+
+    const updatedInputs = screen.getAllByPlaceholderText('scan.book_title_placeholder')
+    expect(updatedInputs[0]).toHaveValue('Second')
+    expect(updatedInputs[1]).toHaveValue('First')
+  })
+
+  it('moves a card down when clicking the move-down button', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'Alpha' }),
+      makeReviewBook({ localId: 'b', position: 1, title: 'Beta' }),
+      makeReviewBook({ localId: 'c', position: 2, title: 'Gamma' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    // Move "Alpha" (first card) down
+    const moveDownButtons = screen.getAllByRole('button', { name: 'scan.move_down' })
+    await userEvent.click(moveDownButtons[0])
+
+    const inputs = screen.getAllByPlaceholderText('scan.book_title_placeholder')
+    expect(inputs[0]).toHaveValue('Beta')
+    expect(inputs[1]).toHaveValue('Alpha')
+    expect(inputs[2]).toHaveValue('Gamma')
+  })
+
+  it('sends books in display order with normalized positions on save', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'Alpha' }),
+      makeReviewBook({ localId: 'b', position: 1, title: 'Beta' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    // Swap: move Beta up to position 0
+    const moveUpButtons = screen.getAllByRole('button', { name: 'scan.move_up' })
+    await userEvent.click(moveUpButtons[1]) // Beta's move-up button
+
+    // Save
+    await userEvent.click(screen.getByRole('button', { name: 'scan.confirm_books' }))
+
+    expect(confirmMutateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location_id: 'loc-1',
+        books: [
+          { position: 0, title: 'Beta', author: null, isbn: null },
+          { position: 1, title: 'Alpha', author: null, isbn: null },
+        ],
+      }),
+      expect.any(Object),
+    )
+  })
+
+  it('includes manually inserted cards in the save payload', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'Existing' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    // Insert a new card at the top
+    const insertButtons = screen.getAllByRole('button', { name: 'scan.add_book_here' })
+    await userEvent.click(insertButtons[0])
+
+    // Type a title in the new empty card (first input after insert)
+    const titleInputs = screen.getAllByPlaceholderText('scan.book_title_placeholder')
+    await userEvent.type(titleInputs[0], 'New Manual Book')
+
+    // Save
+    await userEvent.click(screen.getByRole('button', { name: 'scan.confirm_books' }))
+
+    expect(confirmMutateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        books: expect.arrayContaining([
+          expect.objectContaining({ title: 'New Manual Book', position: 0 }),
+          expect.objectContaining({ title: 'Existing', position: 1 }),
+        ]),
+      }),
+      expect.any(Object),
+    )
+  })
+
+  it('move-up button is disabled for the first card', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'Only' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    const moveUpButtons = screen.getAllByRole('button', { name: 'scan.move_up' })
+    expect(moveUpButtons[0]).toBeDisabled()
+  })
+
+  it('move-down button is disabled for the last card', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'Only' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    const moveDownButtons = screen.getAllByRole('button', { name: 'scan.move_down' })
+    expect(moveDownButtons[0]).toBeDisabled()
+  })
+
+  it('renders the added_manually badge for inserted cards', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'AI Book' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    // Insert at top
+    const insertButtons = screen.getAllByRole('button', { name: 'scan.add_book_here' })
+    await userEvent.click(insertButtons[0])
+
+    // The new card should show the "added_manually" badge
+    expect(screen.getByText('scan.added_manually')).toBeInTheDocument()
+  })
+
+  it('shows within a card context', async () => {
+    setReviewDraft([
+      makeReviewBook({ localId: 'a', position: 0, title: 'Alpha' }),
+      makeReviewBook({ localId: 'b', position: 1, title: 'Beta' }),
+      makeReviewBook({ localId: 'c', position: 2, title: 'Gamma' }),
+    ])
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    // Insert between Beta and Gamma
+    const insertButtons = screen.getAllByRole('button', { name: 'scan.add_book_here' })
+    // Buttons: [top, after Alpha, after Beta, after Gamma]
+    await userEvent.click(insertButtons[2]) // after Beta
+
+    const inputs = screen.getAllByPlaceholderText('scan.book_title_placeholder')
+    expect(inputs).toHaveLength(4)
+    expect(inputs[0]).toHaveValue('Alpha')
+    expect(inputs[1]).toHaveValue('Beta')
+    expect(inputs[2]).toHaveValue('')      // new manual card
+    expect(inputs[3]).toHaveValue('Gamma')
+
+    // The new card's position badge should read #3
+    const cards = screen.getAllByText(/^#\d+$/)
+    // cards: #1 Alpha, #2 Beta, #3 manual, #4 Gamma
+    expect(cards.map(el => el.textContent)).toEqual(['#1', '#2', '#3', '#4'])
+
+    // Edit the new card title
+    await userEvent.type(inputs[2], 'Inserted')
+
+    // Verify positions are correct in payload
+    await userEvent.click(screen.getByRole('button', { name: 'scan.confirm_books' }))
+    const [[payload]] = confirmMutateSpy.mock.calls
+    expect(payload.books).toEqual([
+      { position: 0, title: 'Alpha', author: null, isbn: null },
+      { position: 1, title: 'Beta', author: null, isbn: null },
+      { position: 2, title: 'Inserted', author: null, isbn: null },
+      { position: 3, title: 'Gamma', author: null, isbn: null },
+    ])
+  })
+})

--- a/frontend/src/pages/ScanShelfPage.tsx
+++ b/frontend/src/pages/ScanShelfPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react'
+import { Fragment, useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
@@ -18,6 +18,7 @@ interface ReviewBookItem extends ConfirmBookItem {
   localId: string
   observedText: string | null
   confidence: ScannedBookItem['confidence'] | null
+  isManual?: boolean
 }
 
 interface ScanSegment {
@@ -305,6 +306,50 @@ export function ScanShelfPage() {
       .map((b, i) => ({ ...b, position: i })))
   }
 
+  function insertBook(afterLocalId: string | null) {
+    const newBook: ReviewBookItem = {
+      localId: `manual:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+      position: 0,
+      title: '',
+      author: null,
+      isbn: null,
+      observedText: null,
+      confidence: null,
+      isManual: true,
+    }
+    setEditableBooks(prev => {
+      let next: ReviewBookItem[]
+      if (afterLocalId === null) {
+        next = [newBook, ...prev]
+      } else {
+        const idx = prev.findIndex(b => b.localId === afterLocalId)
+        next = idx === -1
+          ? [...prev, newBook]
+          : [...prev.slice(0, idx + 1), newBook, ...prev.slice(idx + 1)]
+      }
+      return next.map((b, i) => ({ ...b, position: i }))
+    })
+  }
+
+  function moveBookUp(localId: string) {
+    setEditableBooks(prev => {
+      const idx = prev.findIndex(b => b.localId === localId)
+      if (idx <= 0) return prev
+      const next = [...prev]
+      ;[next[idx - 1], next[idx]] = [next[idx], next[idx - 1]]
+      return next.map((b, i) => ({ ...b, position: i }))
+    })
+  }
+
+  function moveBookDown(localId: string) {
+    setEditableBooks(prev => {
+      const idx = prev.findIndex(b => b.localId === localId)
+      if (idx === -1 || idx >= prev.length - 1) return prev
+      const next = [...prev]
+      ;[next[idx], next[idx + 1]] = [next[idx + 1], next[idx]]
+      return next.map((b, i) => ({ ...b, position: i }))
+    })
+  }
 
   function clearDraft() {
     localStorage.removeItem(SCAN_DRAFT_KEY)
@@ -337,7 +382,7 @@ export function ScanShelfPage() {
     }
     const validBooks = editableBooks
       .filter(b => b.title.trim())
-      .map(({ position, title, author, isbn }) => ({ position, title, author, isbn }))
+      .map(({ title, author, isbn }, i) => ({ position: i, title, author, isbn }))
     if (validBooks.length === 0) {
       showError(t('scan.no_books'))
       return
@@ -765,86 +810,160 @@ export function ScanShelfPage() {
             {t('scan.step_review_desc', { count: editableBooks.length })}
           </p>
 
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 24 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', marginBottom: 24 }}>
+            {/* Insert at top */}
+            <button
+              type="button"
+              aria-label={t('scan.add_book_here')}
+              onClick={() => insertBook(null)}
+              style={{
+                width: '100%', padding: '5px 8px',
+                background: 'none', border: '1px dashed var(--sh-border)',
+                borderRadius: 'var(--sh-radius-sm)', cursor: 'pointer',
+                color: 'var(--sh-teal)', fontSize: 12, fontWeight: 500,
+                marginBottom: 4,
+              }}
+            >
+              + {t('scan.add_book_here')}
+            </button>
+
+            {editableBooks.length === 0 && (
+              <div className="sh-empty-state" style={{ padding: 40 }}>
+                <p>{t('scan.no_books_found')}</p>
+              </div>
+            )}
+
             {editableBooks.map((book) => {
-              const isLowConfidence = book.confidence === 'needs_review' || book.confidence === 'low' || !book.title
+              const isLowConfidence = !book.isManual && (book.confidence === 'needs_review' || !book.title)
 
               return (
-                <div
-                  key={book.localId}
-                  className={`sh-review-card${isLowConfidence ? ' sh-review-card--warn' : ''}`}
-                >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-                    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                      <span style={{
-                        fontSize: 11, fontWeight: 600, textTransform: 'uppercase',
-                        color: isLowConfidence ? 'var(--sh-amber-text)' : 'var(--sh-teal)',
-                        background: isLowConfidence ? 'var(--sh-amber-bg)' : 'var(--sh-teal-bg)',
-                        padding: '2px 8px', borderRadius: 'var(--sh-radius-sm)',
-                      }}>
-                        #{book.position + 1}
-                      </span>
-                      {isLowConfidence && (
-                        <span style={{ fontSize: 11, color: 'var(--sh-amber-text)', fontWeight: 500 }}>
-                          {t('scan.needs_review')}
+                <Fragment key={book.localId}>
+                  <div
+                    className={`sh-review-card${isLowConfidence ? ' sh-review-card--warn' : ''}`}
+                    style={{ marginBottom: 4 }}
+                  >
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+                      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                        <span style={{
+                          fontSize: 11, fontWeight: 600, textTransform: 'uppercase',
+                          color: isLowConfidence ? 'var(--sh-amber-text)' : 'var(--sh-teal)',
+                          background: isLowConfidence ? 'var(--sh-amber-bg)' : 'var(--sh-teal-bg)',
+                          padding: '2px 8px', borderRadius: 'var(--sh-radius-sm)',
+                        }}>
+                          #{book.position + 1}
                         </span>
-                      )}
-                      {book.observedText && book.observedText !== book.title && (
-                        <span style={{ fontSize: 10, color: 'var(--sh-text-muted)', fontStyle: 'italic' }}>
-                          {t('scan.observed')}: &ldquo;{book.observedText.slice(0, 40)}{book.observedText.length > 40 ? '…' : ''}&rdquo;
-                        </span>
-                      )}
+                        {book.isManual && (
+                          <span style={{
+                            fontSize: 11, fontWeight: 600, textTransform: 'uppercase',
+                            color: 'var(--sh-teal)', background: 'var(--sh-teal-bg)',
+                            padding: '2px 8px', borderRadius: 'var(--sh-radius-sm)',
+                          }}>
+                            {t('scan.added_manually')}
+                          </span>
+                        )}
+                        {!book.isManual && isLowConfidence && (
+                          <span style={{ fontSize: 11, color: 'var(--sh-amber-text)', fontWeight: 500 }}>
+                            {t('scan.needs_review')}
+                          </span>
+                        )}
+                        {!book.isManual && book.observedText && book.observedText !== book.title && (
+                          <span style={{ fontSize: 10, color: 'var(--sh-text-muted)', fontStyle: 'italic' }}>
+                            {t('scan.observed')}: &ldquo;{book.observedText.slice(0, 40)}{book.observedText.length > 40 ? '…' : ''}&rdquo;
+                          </span>
+                        )}
+                      </div>
+                      <div style={{ display: 'flex', gap: 2, alignItems: 'center', flexShrink: 0 }}>
+                        <button
+                          type="button"
+                          aria-label={t('scan.move_up')}
+                          title={t('scan.move_up')}
+                          onClick={() => moveBookUp(book.localId)}
+                          disabled={book.position === 0}
+                          className="sh-touch-target"
+                          style={{
+                            background: 'none', border: 'none', cursor: 'pointer',
+                            color: 'var(--sh-text-muted)', fontSize: 14,
+                            opacity: book.position === 0 ? 0.3 : 1,
+                          }}
+                        >
+                          ↑
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={t('scan.move_down')}
+                          title={t('scan.move_down')}
+                          onClick={() => moveBookDown(book.localId)}
+                          disabled={book.position === editableBooks.length - 1}
+                          className="sh-touch-target"
+                          style={{
+                            background: 'none', border: 'none', cursor: 'pointer',
+                            color: 'var(--sh-text-muted)', fontSize: 14,
+                            opacity: book.position === editableBooks.length - 1 ? 0.3 : 1,
+                          }}
+                        >
+                          ↓
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={t('scan.remove_item')}
+                          title={t('scan.remove_item')}
+                          onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            removeBook(book.localId)
+                          }}
+                          className="sh-touch-target"
+                          style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--sh-red)', fontSize: 16 }}
+                        >
+                          ✕
+                        </button>
+                      </div>
                     </div>
-                    <button
-                      type="button"
-                      aria-label={t('scan.remove_item')}
-                      title={t('scan.remove_item')}
-                      onClick={(e) => {
-                        e.preventDefault()
-                        e.stopPropagation()
-                        removeBook(book.localId)
-                      }}
-                      className="sh-touch-target"
-                      style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--sh-red)', fontSize: 16 }}
-                    >
-                      ✕
-                    </button>
+                    <div className="sh-review-fields">
+                      <div>
+                        <label className="sh-form-label--sm" style={{ fontSize: 11, marginBottom: 4 }}>{t('scan.book_title')}</label>
+                        <input
+                          className="sh-input"
+                          value={book.title}
+                          onChange={e => updateBook(book.localId, 'title', e.target.value)}
+                          placeholder={t('scan.book_title_placeholder')}
+                          style={{
+                            fontSize: 14,
+                            borderColor: isLowConfidence ? 'var(--sh-amber-text)' : undefined,
+                          }}
+                        />
+                      </div>
+                      <div>
+                        <label className="sh-form-label--sm" style={{ fontSize: 11, marginBottom: 4 }}>{t('scan.book_author')}</label>
+                        <input
+                          className="sh-input"
+                          value={book.author ?? ''}
+                          onChange={e => updateBook(book.localId, 'author', e.target.value || null)}
+                          placeholder={t('scan.book_author_placeholder')}
+                          style={{ fontSize: 14 }}
+                        />
+                      </div>
+                    </div>
                   </div>
-                  <div className="sh-review-fields">
-                    <div>
-                      <label className="sh-form-label--sm" style={{ fontSize: 11, marginBottom: 4 }}>{t('scan.book_title')}</label>
-                      <input
-                        className="sh-input"
-                        value={book.title}
-                        onChange={e => updateBook(book.localId, 'title', e.target.value)}
-                        placeholder={t('scan.book_title_placeholder')}
-                        style={{
-                          fontSize: 14,
-                          borderColor: isLowConfidence ? 'var(--sh-amber-text)' : undefined,
-                        }}
-                      />
-                    </div>
-                    <div>
-                      <label className="sh-form-label--sm" style={{ fontSize: 11, marginBottom: 4 }}>{t('scan.book_author')}</label>
-                      <input
-                        className="sh-input"
-                        value={book.author ?? ''}
-                        onChange={e => updateBook(book.localId, 'author', e.target.value || null)}
-                        placeholder={t('scan.book_author_placeholder')}
-                        style={{ fontSize: 14 }}
-                      />
-                    </div>
-                  </div>
-                </div>
+                  {/* Insert after this card */}
+                  <button
+                    type="button"
+                    aria-label={t('scan.add_book_here')}
+                    onClick={() => insertBook(book.localId)}
+                    style={{
+                      width: '100%', padding: '5px 8px',
+                      background: 'none', border: '1px dashed var(--sh-border)',
+                      borderRadius: 'var(--sh-radius-sm)', cursor: 'pointer',
+                      color: 'var(--sh-teal)', fontSize: 12, fontWeight: 500,
+                      marginBottom: 4,
+                    }}
+                  >
+                    + {t('scan.add_book_here')}
+                  </button>
+                </Fragment>
               )
             })}
           </div>
-
-          {editableBooks.length === 0 && (
-            <div className="sh-empty-state" style={{ padding: 40 }}>
-              <p>{t('scan.no_books_found')}</p>
-            </div>
-          )}
 
           <div style={{ display: 'flex', gap: 12 }}>
             <button


### PR DESCRIPTION
## Summary

- Users can now insert a manual (blank) book card **between** existing scanned cards using "+ Add book here" dashed buttons that appear between every pair of cards and at the top of the list.
- Each card has **↑ / ↓ move buttons** in its header to reorder before saving.
- Inserted cards show a **"Manual"** badge so they are clearly distinguishable from AI-detected cards.
- The save payload always sends positions as `0, 1, 2, …` matching the display order, so saved shelf positions correctly reflect the reviewed sequence.
- No backend changes were needed — the existing `position` field in `ConfirmBookItem` already drives shelf order.

## UX changes

| Before | After |
|---|---|
| Review step: static list, delete only | Review step: insert between cards, move up/down, delete |
| No way to add a missing book without rescanning | "+ Add book here" inserts an editable blank card at any position |
| Order fixed from scan result | ↑/↓ buttons allow full reordering before confirming |

Controls are explicit button presses (no drag/drop), keeping the flow mobile-friendly.

## Testing performed

- **10 new unit tests** in `ScanShelfPage.test.tsx` covering:
  - Insert between two cards
  - Insert at top
  - Move card up
  - Move card down
  - Disabled state for move-up on first card, move-down on last card
  - Manual badge rendered on inserted cards
  - Save payload order after reordering
  - Save payload includes manually inserted cards
  - Full 4-card insert-and-confirm scenario
- All 111 frontend tests pass (`npx vitest run`)
- ESLint clean on changed files (pre-existing `react-hooks/exhaustive-deps` warning on line 118 of `ScanShelfPage.tsx` is unchanged from before this PR)
- Backend untouched — no backend tests needed

## Known limitations / tradeoffs

- No drag-and-drop (by design per issue guidance — up/down buttons preferred for mobile)
- "Add book here" buttons are always visible between every card; on a very long list this adds visual density. A future improvement could collapse them until hover/focus.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to insert and manually reorder books in the scan review interface.
  * Users can now insert blank books at the top or between existing entries and move items up/down.
  * Manually added items are now clearly marked in the interface.

* **Localization**
  * Added Czech and English translations for new review controls (move up/down, add book, manual indicator).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->