### PR TITLE
feat(landing): add audience positioning and trust layer

### DIFF
--- a/e2e/tests/smoke-regressions.spec.ts
+++ b/e2e/tests/smoke-regressions.spec.ts
@@ -81,6 +81,20 @@ async function createLocatedBook(page: Page, title: string, author = 'E2E Autor'
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
+test('public landing communicates audience and trust positioning', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('heading', { name: /Najdi plán podle toho, kdo knihovnu používá|Pick the plan by who shares the shelves/i })).toBeVisible()
+  await expect(page.getByText(/škola|classroom|school/i).first()).toBeVisible()
+  await expect(page.getByRole('heading', { name: /Důvěra bez marketingové mlhy|Trust without marketing fog/i })).toBeVisible()
+  await expect(page.getByText(/Export|account deletion|smazání účtu/i).first()).toBeVisible()
+})
+
+test('public pricing communicates intended audience per plan', async ({ page }) => {
+  await page.goto('/pricing')
+  await expect(page.getByTestId('plan-card-free')).toContainText(/menší domácí sbírky|small home collections/i)
+  await expect(page.getByTestId('plan-card-library')).toContainText(/školy, spolky a malé knihovny|schools, associations, and small libraries/i)
+})
+
 test('books route renders (no blank screen)', async ({ page }) => {
   const errors: string[] = []
   page.on('pageerror', (e) => errors.push(String(e)))

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -544,7 +544,15 @@
     "feature_library_members": "15 členů na knihovnu",
     "feature_library_books": "30 000 knih na knihovnu",
     "feature_includes_pro": "Vše z plánu Pro",
-    "feature_priority_support": "Prioritní podpora"
+    "feature_priority_support": "Prioritní podpora",
+    "plan_free_audience": "Pro jednotlivce a menší domácí sbírky",
+    "plan_free_use_case": "Vyzkoušej skenování polic a získej přehled o knihách doma bez platební karty.",
+    "plan_home_audience": "Pro rodiny a sdílenou domácí knihovnu",
+    "plan_home_use_case": "Vhodné, když katalog spravuje víc lidí a sbírka roste přes základní limit.",
+    "plan_pro_audience": "Pro sběratele, kluby a malé týmy",
+    "plan_pro_use_case": "Více knihoven, větší katalogy a dost skenů pro pravidelné přidávání nových polic.",
+    "plan_library_audience": "Pro školy, spolky a malé knihovny",
+    "plan_library_use_case": "Pro třídní, klubové nebo místní knihovny, kde katalog spravuje více členů."
   },
   "landing": {
     "hero_title": "Celá tvoje knihovna, katalogizovaná během minut.",
@@ -595,7 +603,25 @@
     "footer_privacy": "Zásady ochrany soukromí",
     "footer_terms": "Podmínky použití",
     "hero_trust_summary": "Tvoje data patří tobě. Kdykoli je exportuješ a účet můžeš jednoduše smazat.",
-    "footer_changelog": "Changelog"
+    "footer_changelog": "Changelog",
+    "audience_title": "Najdi plán podle toho, kdo knihovnu používá",
+    "audience_subtitle": "Shelfy není jen pro jednu sbírku doma. Stejný workflow funguje pro rodinu, klub, školní kabinet i malou veřejnou knihovnu.",
+    "audience_home_title": "Domácnost a rodina",
+    "audience_home_desc": "Rychle zjistíš, co už máte doma, a sdílíš katalog s partnerem nebo dětmi.",
+    "audience_club_title": "Čtenářský klub nebo spolek",
+    "audience_club_desc": "Jedna sdílená evidence pro komunitní polici, zápůjčky a společné spravování knih.",
+    "audience_school_title": "Škola nebo třída",
+    "audience_school_desc": "Přehled učebních a třídních knih bez tabulek, které po měsíci nikdo neaktualizuje.",
+    "audience_library_title": "Malá knihovna",
+    "audience_library_desc": "Katalog pro místní knihovnu, klubovnu nebo firemní bookshelf, kde je důležitý jednoduchý provoz.",
+    "trust_title": "Důvěra bez marketingové mlhy",
+    "trust_subtitle": "Shelfy zatím nestaví na vymyšlených logách ani nafouknutých číslech. Staví na jasných pravidlech, transparentnosti a praktickém použití.",
+    "trust_data_kicker": "Data máš pod kontrolou",
+    "trust_data_copy": "Export, smazání účtu a soukromí jsou přímo v produktu. Katalog knih neprodáváme třetím stranám.",
+    "trust_builder_kicker": "Postavené v Česku",
+    "trust_builder_copy": "Projekt vzniká otevřeně a průběžně se ladí podle reálné domácí, klubové a školní knihovní praxe.",
+    "trust_pilot_kicker": "Pravdivý social proof",
+    "trust_pilot_copy": "První uživatelé a pilotní knihovny pomáhají ověřit workflow skenování polic — bez falešných testimonialů."
   },
   "csv": {
     "import_button": "Importovat CSV",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -290,7 +290,25 @@
     "footer_privacy": "Privacy Policy",
     "footer_terms": "Terms of Service",
     "hero_trust_summary": "Your data stays yours. Export anytime and delete your account whenever you want.",
-    "footer_changelog": "Changelog"
+    "footer_changelog": "Changelog",
+    "audience_title": "Pick the plan by who shares the shelves",
+    "audience_subtitle": "Shelfy is not only for one home collection. The same workflow fits families, clubs, classrooms, and small community libraries.",
+    "audience_home_title": "Home and family",
+    "audience_home_desc": "Know what you already own and share the catalog with your partner, kids, or housemates.",
+    "audience_club_title": "Book club or association",
+    "audience_club_desc": "One shared record for a community shelf, lending, and collaborative book management.",
+    "audience_school_title": "School or classroom",
+    "audience_school_desc": "Track classroom and teaching books without spreadsheets nobody updates after a month.",
+    "audience_library_title": "Small library",
+    "audience_library_desc": "A catalog for a local library, club room, or office bookshelf where simple operations matter.",
+    "trust_title": "Trust without marketing fog",
+    "trust_subtitle": "Shelfy does not rely on invented logos or inflated numbers. It relies on clear controls, transparency, and practical use.",
+    "trust_data_kicker": "You control your data",
+    "trust_data_copy": "Export, account deletion, and privacy controls are built into the product. We do not sell your book catalog to third parties.",
+    "trust_builder_kicker": "Built in Czechia",
+    "trust_builder_copy": "The project is being shaped openly around real home, club, and school library workflows.",
+    "trust_pilot_kicker": "Honest social proof",
+    "trust_pilot_copy": "Early users and pilot libraries help validate the shelf-scanning workflow — no fake testimonials."
   },
   "tabs": {
     "all": "All",
@@ -595,7 +613,15 @@
     "feature_library_members": "15 members per library",
     "feature_library_books": "30,000 books per library",
     "feature_includes_pro": "Everything in Pro",
-    "feature_priority_support": "Priority support"
+    "feature_priority_support": "Priority support",
+    "plan_free_audience": "For individuals and small home collections",
+    "plan_free_use_case": "Try shelf scanning and catalog your books at home without a credit card.",
+    "plan_home_audience": "For families and shared home libraries",
+    "plan_home_use_case": "Best when several people manage one growing collection beyond the free limits.",
+    "plan_pro_audience": "For collectors, clubs, and small teams",
+    "plan_pro_use_case": "More libraries, larger catalogs, and enough scans for regularly adding new shelves.",
+    "plan_library_audience": "For schools, associations, and small libraries",
+    "plan_library_use_case": "For classroom, club, or local libraries managed by multiple members."
   },
   "csv": {
     "import_button": "Import CSV",

--- a/frontend/src/pages/LandingPage.test.tsx
+++ b/frontend/src/pages/LandingPage.test.tsx
@@ -31,8 +31,25 @@ describe('LandingPage', () => {
     expect(screen.getByText('landing.how_title')).toBeInTheDocument()
     expect(screen.getByText('landing.visual_proof_title')).toBeInTheDocument()
     expect(screen.getByText('landing.pricing_teaser_title')).toBeInTheDocument()
+    expect(screen.getByText('landing.audience_title')).toBeInTheDocument()
+    expect(screen.getByText('landing.trust_title')).toBeInTheDocument()
     expect(screen.getByText('landing.faq_title')).toBeInTheDocument()
     expect(screen.getByText('landing.final_cta_title')).toBeInTheDocument()
+  })
+
+  it('renders audience positioning and trust blocks', () => {
+    render(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId('audience-positioning')).toBeInTheDocument()
+    expect(screen.getByText('landing.audience_school_title')).toBeInTheDocument()
+    expect(screen.getByText('landing.audience_library_title')).toBeInTheDocument()
+    expect(screen.getByTestId('trust-layer')).toBeInTheDocument()
+    expect(screen.getByText('landing.trust_data_kicker')).toBeInTheDocument()
+    expect(screen.getByText('landing.trust_pilot_kicker')).toBeInTheDocument()
   })
 
   it('renders visual proof showcase with poster image', () => {

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -31,6 +31,10 @@ import { ROUTES } from '../lib/routes'
 /** Set to a real URL (e.g. YouTube embed) when demo video is ready. */
 const DEMO_VIDEO_URL = ''
 
+const AUDIENCE_ITEMS = ['home', 'club', 'school', 'library'] as const
+
+const TRUST_ITEMS = ['data', 'builder', 'pilot'] as const
+
 const FAQ_ITEMS = [
   { id: 'scanning', topic: 'how_scanning_works' },
   { id: 'privacy', topic: 'data_privacy' },
@@ -323,6 +327,20 @@ export function LandingPage() {
           </div>
         )}
 
+        {/* ── Audience positioning ── */}
+        <section className="lp-section" data-testid="audience-positioning">
+          <h2 className="lp-section-title">{t('landing.audience_title')}</h2>
+          <p className="lp-section-subtitle">{t('landing.audience_subtitle')}</p>
+          <div className="lp-audience-grid">
+            {AUDIENCE_ITEMS.map((item) => (
+              <article key={item} className="lp-audience-card">
+                <h3 className="lp-audience-title">{t(`landing.audience_${item}_title`)}</h3>
+                <p className="lp-audience-desc">{t(`landing.audience_${item}_desc`)}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
         {/* ── Pricing teaser ── */}
         <section className="lp-section">
           <h2 className="lp-section-title">{t('landing.pricing_teaser_title')}</h2>
@@ -339,6 +357,20 @@ export function LandingPage() {
             >
               {t('landing.pricing_teaser_cta')}
             </button>
+          </div>
+        </section>
+
+        {/* ── Trust layer ── */}
+        <section className="lp-section" data-testid="trust-layer">
+          <h2 className="lp-section-title">{t('landing.trust_title')}</h2>
+          <p className="lp-section-subtitle">{t('landing.trust_subtitle')}</p>
+          <div className="lp-trust-grid">
+            {TRUST_ITEMS.map((item) => (
+              <article key={item} className="lp-trust-card">
+                <strong className="lp-trust-kicker">{t(`landing.trust_${item}_kicker`)}</strong>
+                <p className="lp-trust-copy">{t(`landing.trust_${item}_copy`)}</p>
+              </article>
+            ))}
           </div>
         </section>
 

--- a/frontend/src/pages/PricingPage.test.tsx
+++ b/frontend/src/pages/PricingPage.test.tsx
@@ -151,6 +151,11 @@ describe('PricingPage — unauthenticated visitor', () => {
     expect(screen.getByTestId('plan-card-home')).toBeInTheDocument()
     expect(screen.getByTestId('plan-card-pro')).toBeInTheDocument()
     expect(screen.getByTestId('plan-card-library')).toBeInTheDocument()
+    expect(screen.getByText('billing.plan_free_audience')).toBeInTheDocument()
+    expect(screen.getByText('billing.plan_home_audience')).toBeInTheDocument()
+    expect(screen.getByText('billing.plan_pro_audience')).toBeInTheDocument()
+    expect(screen.getByText('billing.plan_library_audience')).toBeInTheDocument()
+    expect(screen.getByText('billing.plan_library_use_case')).toBeInTheDocument()
 
     // Non-negotiable outcome: logged-out users browse without the app
     // pretending they're signed in. Concretely that means we do NOT fire

--- a/frontend/src/pages/PricingPage.tsx
+++ b/frontend/src/pages/PricingPage.tsx
@@ -17,6 +17,8 @@ interface PlanDef {
   /** CZK prices per interval — match the Stripe test-mode prices. */
   priceCzk: { monthly: number; yearly: number } | null
   featureKeys: string[]
+  audienceKey: string
+  useCaseKey: string
   highlighted?: boolean
   checkoutPlan?: PaidPlan
 }
@@ -30,6 +32,8 @@ const PLANS: PlanDef[] = [
   {
     key: 'free',
     nameKey: 'billing.plan_free',
+    audienceKey: 'billing.plan_free_audience',
+    useCaseKey: 'billing.plan_free_use_case',
     priceCzk: null,
     featureKeys: [
       'billing.feature_free_scans',
@@ -44,6 +48,8 @@ const PLANS: PlanDef[] = [
   {
     key: 'home',
     nameKey: 'billing.plan_home',
+    audienceKey: 'billing.plan_home_audience',
+    useCaseKey: 'billing.plan_home_use_case',
     priceCzk: { monthly: 59, yearly: 590 },
     featureKeys: [
       'billing.feature_home_scans',
@@ -58,6 +64,8 @@ const PLANS: PlanDef[] = [
   {
     key: 'pro',
     nameKey: 'billing.plan_pro',
+    audienceKey: 'billing.plan_pro_audience',
+    useCaseKey: 'billing.plan_pro_use_case',
     priceCzk: { monthly: 129, yearly: 1290 },
     featureKeys: [
       'billing.feature_pro_scans',
@@ -73,6 +81,8 @@ const PLANS: PlanDef[] = [
   {
     key: 'library',
     nameKey: 'billing.plan_library',
+    audienceKey: 'billing.plan_library_audience',
+    useCaseKey: 'billing.plan_library_use_case',
     priceCzk: { monthly: 299, yearly: 2990 },
     featureKeys: [
       'billing.feature_library_scans',
@@ -304,7 +314,13 @@ export function PricingPage() {
 
               <div>
                 <h3 className='text-h3' style={{ margin: 0 }}>{t(plan.nameKey)}</h3>
-                <p style={{ margin: '6px 0 0', fontWeight: 700, fontSize: 24, color: 'var(--sh-primary)' }}>
+                <p className='text-small' style={{ margin: '4px 0 0', color: 'var(--sh-text-secondary)' }}>
+                  {t(plan.audienceKey)}
+                </p>
+                <p className='text-small' style={{ margin: '6px 0 0', color: 'var(--sh-text-muted)', lineHeight: 1.45 }}>
+                  {t(plan.useCaseKey)}
+                </p>
+                <p style={{ margin: '10px 0 0', fontWeight: 700, fontSize: 24, color: 'var(--sh-primary)' }}>
                   {priceDisplay.amount}
                   <span style={{
                     display: 'block', fontSize: 12, fontWeight: 400,

--- a/frontend/src/styles/shelfy.css
+++ b/frontend/src/styles/shelfy.css
@@ -2194,6 +2194,37 @@ html.dark .sh-onboarding-checkmark {
   color: var(--sh-danger);
 }
 
+
+/* ── Audience positioning ── */
+.lp-audience-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  max-width: 760px;
+}
+
+.lp-audience-card {
+  padding: 18px;
+  border: 1px solid var(--sh-border);
+  border-radius: var(--sh-radius-lg);
+  background: var(--sh-surface);
+  box-shadow: var(--sh-shadow-sm);
+}
+
+.lp-audience-title {
+  margin: 0 0 6px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--sh-text-main);
+}
+
+.lp-audience-desc {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--sh-text-muted);
+}
+
 /* ── Pricing teaser ── */
 .lp-pricing-body {
   max-width: 560px;
@@ -2213,6 +2244,38 @@ html.dark .sh-onboarding-checkmark {
   margin: 0 0 24px;
   padding-left: 16px;
   border-left: 3px solid var(--sh-primary-bg);
+}
+
+
+/* ── Trust layer ── */
+.lp-trust-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  max-width: 860px;
+}
+
+.lp-trust-card {
+  padding: 18px;
+  border-radius: var(--sh-radius-lg);
+  border: 1px solid color-mix(in srgb, var(--sh-primary) 18%, var(--sh-border));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--sh-primary-bg) 28%, transparent), var(--sh-surface));
+}
+
+.lp-trust-kicker {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: var(--sh-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.lp-trust-copy {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--sh-text-muted);
 }
 
 /* ── FAQ ── */
@@ -2342,6 +2405,11 @@ html.dark .sh-onboarding-checkmark {
     display: none;
   }
 
+  .lp-audience-grid,
+  .lp-trust-grid {
+    grid-template-columns: 1fr;
+  }
+
   .lp-lightbox {
     max-width: calc(100vw - 24px);
     max-height: calc(100dvh - 24px);
@@ -2365,6 +2433,10 @@ html.dark .sh-onboarding-checkmark {
   html:not(.light) .lp-pricing-trust {
     border-left-color: rgba(45, 122, 95, 0.2);
   }
+  html:not(.light) .lp-trust-card {
+    background: linear-gradient(180deg, rgba(45, 122, 95, 0.08), var(--sh-surface));
+    border-color: rgba(45, 122, 95, 0.16);
+  }
   html:not(.light) .lp-final-cta {
     background: linear-gradient(
       160deg,
@@ -2379,6 +2451,10 @@ html.dark .lp-step-number {
 }
 html.dark .lp-pricing-trust {
   border-left-color: rgba(45, 122, 95, 0.2);
+}
+html.dark .lp-trust-card {
+  background: linear-gradient(180deg, rgba(45, 122, 95, 0.08), var(--sh-surface));
+  border-color: rgba(45, 122, 95, 0.16);
 }
 html.dark .lp-final-cta {
   background: linear-gradient(


### PR DESCRIPTION
## Summary
- add a landing audience-positioning block for home/family, clubs, schools, and small libraries
- add a truthful trust/social-proof layer before FAQ/final CTA
- add audience/use-case subtitles to pricing plan cards without changing billing plan keys
- cover the new landing/pricing copy in unit tests and E2E smoke checks

Closes #143
Closes #146

## Tests
- `npm --prefix frontend test` ✅
- `npm --prefix frontend run lint` ✅ (existing warnings only)
- `docker run --rm -u $(id -u suslik):$(id -g suslik) -v /home/suslik/shelfy/frontend:/app -w /app node:20 npm run build` ✅
- `frontend/node_modules/.bin/tsc -p frontend/tsconfig.json --noEmit` ❌ existing unrelated TS errors in BooksPage/BookshelfViewPage/LocationsPage.test/ScanShelfPage
- `E2E_BASE_URL=http://127.0.0.1:4174 npx playwright test tests/smoke-regressions.spec.ts --grep "public landing|public pricing" --project=chromium` ❌ local browser binary missing (`chromium_headless_shell-1208`); test definitions list correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added audience positioning section to landing page with messaging for different user types (home/family, clubs, schools, libraries)
  * Introduced trust messaging section highlighting data control and privacy commitments
  * Enhanced pricing page to display audience and use-case information for each plan tier

* **Localization**
  * Added Czech translations for landing page and billing sections

* **Tests**
  * Added smoke tests and component tests validating new landing page sections and pricing page content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->