### PR TITLE
feat(e2e): scan failure segment UI and auth callback fallback tests (Closes #190, #191)

### DIFF
--- a/backend/tests/test_entitlements.py
+++ b/backend/tests/test_entitlements.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections.abc import AsyncIterator
-from datetime import date, timedelta
+from datetime import timedelta
 
 import pytest
 from typing import cast, Any

--- a/backend/tests/test_entitlements.py
+++ b/backend/tests/test_entitlements.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections.abc import AsyncIterator
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 from typing import cast, Any
@@ -194,16 +194,16 @@ class TestPlanDowngrade:
 class TestMonthRollover:
     async def test_new_period_starts_at_zero(self, session: AsyncSession) -> None:
         user = await _make_user(session)
-        last_month = date(2026, 3, 1)
-        this_month = date(2026, 4, 1)
-        # Exhaust scans in last month
+        this_month = entitlements.current_period_start()
+        last_month = (this_month - timedelta(days=1)).replace(day=1)
+        # Exhaust scans this month
         for _ in range(5):
             await entitlements.consume(session, user.id, UsageMetric.scans, )
         # Directly check a different period — should be 0
         usage = await entitlements.get_current_usage(
             session, user.id, UsageMetric.scans, period_start=last_month
         )
-        assert usage == 0  # nothing was counted for last_month
+        assert usage == 0  # nothing counted for a different period
         current = await entitlements.get_current_usage(
             session, user.id, UsageMetric.scans, period_start=this_month
         )

--- a/e2e/tests/scan-regressions.spec.ts
+++ b/e2e/tests/scan-regressions.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { login } from './helpers'
+import { getE2EAccessToken, login } from './helpers'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -8,10 +8,33 @@ const FIXTURE_IMAGE = process.env.E2E_SCAN_IMAGE_PATH ?? path.resolve(__dirname,
 
 test.describe('scan regressions', () => {
   test('@regression @slow scan job failure shows recoverable segment UI', async ({ page }) => {
-    // Login and navigate to scan page
+    // Login
     await login(page)
+
+    // Create a location via API so the scan dropdown has something to select
+    const token = getE2EAccessToken(page)
+    expect(token, 'login() did not capture an access token').toBeTruthy()
+    const api = process.env.E2E_API_BASE_URL ?? 'http://localhost:8000'
+    const suffix = Date.now()
+    const room = `E2E Scan Fail ${suffix}`
+
+    const locRes = await page.request.post(`${api}/api/v1/locations`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { room, furniture: 'Shelf', shelf: 'Shelf 1', display_order: 0 },
+    })
+    expect(locRes.ok(), `location fixture: ${locRes.status()}`).toBeTruthy()
+
+    // Navigate to scan page via SPA
     await page.getByRole('button', { name: /^Sken$|^Scan$/i }).click()
     await page.waitForURL(/\/scan$/)
+
+    // Select the location we just created (room → furniture → shelf dropdowns)
+    await page.locator('select').first().selectOption({ label: room })
+    await page.locator('select').nth(1).selectOption({ label: 'Shelf' })
+    await page.locator('select').nth(2).selectOption({ label: 'Shelf 1' })
+
+    // Advance to the scan/photo step
+    await page.getByRole('button', { name: /Continue to scanning|Pokračovat ke skenování/i }).click()
 
     // Intercept the job-status poll to return 'failed'
     await page.route('**/api/v1/scan/shelf/**', async (route, request) => {
@@ -31,6 +54,6 @@ test.describe('scan regressions', () => {
 
     // Wait for the segment to show failure state
     // scan.segment_failed: cs="Zpracování selhalo", en="Processing failed"
-    await expect(page.getByText(/Zpracování selhalo|Processing failed/i)).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByText(/Zpracování selhalo|Processing failed/i)).toBeVisible({ timeout: 45_000 })
   })
 })

--- a/e2e/tests/scan-regressions.spec.ts
+++ b/e2e/tests/scan-regressions.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test'
+import { login } from './helpers'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURE_IMAGE = process.env.E2E_SCAN_IMAGE_PATH ?? path.resolve(__dirname, '../fixtures/scan-flow-shelf.jpg')
+
+test.describe('scan regressions', () => {
+  test('@regression @slow scan job failure shows recoverable segment UI', async ({ page }) => {
+    // Login and navigate to scan page
+    await login(page)
+    await page.getByRole('button', { name: /^Sken$|^Scan$/i }).click()
+    await page.waitForURL(/\/scan$/)
+
+    // Intercept the job-status poll to return 'failed'
+    await page.route('**/api/v1/scan/shelf/**', async (route, request) => {
+      if (request.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'failed', error_message: null }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    // Upload the fixture image via the hidden file input
+    await page.locator('input[type="file"]').setInputFiles(FIXTURE_IMAGE)
+
+    // Wait for the segment to show failure state
+    // scan.segment_failed: cs="Zpracování selhalo", en="Processing failed"
+    await expect(page.getByText(/Zpracování selhalo|Processing failed/i)).toBeVisible({ timeout: 30_000 })
+  })
+})

--- a/e2e/tests/smoke-regressions.spec.ts
+++ b/e2e/tests/smoke-regressions.spec.ts
@@ -17,7 +17,7 @@
  *   This matches the pattern documented and used in p0-release-gate.spec.ts.
  */
 import { expect, test, type Page } from '@playwright/test'
-import { createLocatedBook, createManualBook, getE2EAccessToken, login } from './helpers'
+import { login } from './helpers'
 
 // ── SPA navigation helpers ────────────────────────────────────────────────────
 // Click the sidebar/bottom-nav button and wait for the URL to settle.
@@ -34,49 +34,6 @@ async function clickNavScan(page: Page): Promise<void> {
   // nav.scan i18n: en='Scan', cs='Sken'
   await page.getByRole('button', { name: /^Sken$|^Scan$/i }).click()
   await page.waitForURL(/\/scan$/)
-}
-
-
-function getApiAuthHeaders(page: Page): Record<string, string> {
-  // APIRequestContext does not reliably mirror the browser's CSRF double-submit
-  // state in CI. Reuse the access token captured by login() and use the
-  // backend's Bearer-token path for test fixture setup.
-  const accessToken = getE2EAccessToken(page)
-  expect(accessToken, 'login() did not capture an access token for fixture setup').toBeTruthy()
-  return { Authorization: `Bearer ${accessToken}` }
-}
-
-async function createLocatedBook(page: Page, title: string, author = 'E2E Autor'): Promise<void> {
-  const headers = getApiAuthHeaders(page)
-  const suffix = Date.now()
-  const api = process.env.E2E_API_BASE_URL ?? 'http://localhost:8000'
-
-  const locationResponse = await page.request.post(`${api}/api/v1/locations`, {
-    headers,
-    data: {
-      room: `E2E Room ${suffix}`,
-      furniture: 'E2E Bookshelf',
-      shelf: 'Shelf 1',
-      display_order: 0,
-    },
-  })
-  if (!locationResponse.ok()) {
-    throw new Error(`location fixture failed: ${locationResponse.status()} ${await locationResponse.text()}`)
-  }
-  const location = await locationResponse.json() as { id: string }
-
-  const bookResponse = await page.request.post(`${api}/api/v1/books`, {
-    headers,
-    data: {
-      title,
-      author,
-      location_id: location.id,
-      shelf_position: 0,
-    },
-  })
-  if (!bookResponse.ok()) {
-    throw new Error(`book fixture failed: ${bookResponse.status()} ${await bookResponse.text()}`)
-  }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/e2e/tests/smoke-regressions.spec.ts
+++ b/e2e/tests/smoke-regressions.spec.ts
@@ -126,3 +126,8 @@ test('scan page renders main sections', async ({ page }) => {
   await clickNavScan(page)
   await expect(page.getByRole('heading', { name: /Skenovat polici|Scan shelf/i })).toBeVisible()
 })
+test('auth callback with missing parameters shows safe fallback', async ({ page }) => {
+  await page.goto('/auth/callback')
+  await expect(page.getByText(/Missing OAuth parameters/i)).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByRole('button', { name: /Back to sign in/i })).toBeVisible()
+})


### PR DESCRIPTION
## Summary

Implements two new E2E tests from the risk-based testing strategy (PR #184).

### Test 1: Scan job failure — recoverable segment UI (#190)
- **File:** `e2e/tests/scan-regressions.spec.ts`
- **Tags:** `@regression @slow`
- Logs in, navigates to scan page, intercepts job-status poll to return `failed`
- Uploads fixture image via file input, asserts segment shows failure text
- Avoids real Gemini dependency by route-level simulation post-upload

### Test 2: Auth callback — safe fallback on missing params (#191)
- **File:** `e2e/tests/smoke-regressions.spec.ts`
- Visits `/auth/callback` without parameters
- Asserts error message and `Back to sign in` button are visible
- Deterministic (public route, no auth needed)

Closes #190, #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end regression test for shelf scan failure recovery, verifying upload flow, polling failure handling, and localized “processing failed” messaging.
  * Added a smoke regression covering OAuth callback with missing parameters, verifying the “Missing OAuth parameters” message and a “Back to sign in” recovery action.
  * Updated entitlement tests to use dynamic period calculations for more robust month-boundary verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->