### PR TITLE
fix(deploy): use single quotes in if condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   deploy:
     # Only proceed if CI succeeded (workflow_run) or manual trigger (workflow_dispatch)
-    if: github.event_name == "workflow_dispatch" || github.event.workflow_run.conclusion == "success"
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, shelfy-prod]
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Fixes YAML parsing error in if: condition.
  
Double quotes \(open\) in the expression caused:


Changed to single quotes: 
