### PR TITLE
feat: database and file storage backup automation (#182)

### DIFF
--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -18,15 +18,23 @@ REDIS_URL=redis://:<REDIS_PASSWORD>@redis:6379/0
 CELERY_BROKER_URL=redis://:<REDIS_PASSWORD>@redis:6379/0
 CELERY_RESULT_BACKEND=redis://:<REDIS_PASSWORD>@redis:6379/1
 
-# ── Object storage (MinIO) ────────────────────────────
+# ── Object storage (MinIO — images) ──────────────────
 MINIO_ROOT_USER=                            # generate: openssl rand -hex 16
 MINIO_ROOT_PASSWORD=                        # generate: openssl rand -base64 32
 MINIO_ACCESS_KEY=                           # same as MINIO_ROOT_USER
 MINIO_SECRET_KEY=                           # same as MINIO_ROOT_PASSWORD
 MINIO_BUCKET=shelfy-images
-MINIO_BACKUP_BUCKET=shelfy-backups
 MINIO_REGION=us-east-1
 MINIO_ENDPOINT=http://minio:9000
+
+# ── Cloudflare R2 (backups) ───────────────────────────
+# Create token at: dash.cloudflare.com → R2 → Manage R2 API Tokens
+# Permissions: Object Read & Write, scoped to backup bucket only
+R2_ENDPOINT=https://<account_id>.r2.cloudflarestorage.com
+R2_ACCESS_KEY=                              # Access Key ID from R2 token
+R2_SECRET_KEY=                              # Secret Access Key from R2 token
+R2_BACKUP_BUCKET=shelfy
+R2_REGION=auto
 
 # ── Auth ──────────────────────────────────────────────
 JWT_SECRET_KEY=                             # generate: openssl rand -base64 64

--- a/scripts/setup_sentry_alerts.sh
+++ b/scripts/setup_sentry_alerts.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Sets up Sentry alert rules for Shelfy (shelfy-4p / python-fastapi)
+# Usage: SENTRY_TOKEN=sntrys_... bash scripts/setup_sentry_alerts.sh
+
+set -euo pipefail
+
+TOKEN="${SENTRY_TOKEN:-}"
+if [[ -z "$TOKEN" ]]; then
+  echo "Error: set SENTRY_TOKEN=sntrys_... before running" >&2
+  echo "Generate one at: https://shelfy-4p.sentry.io/settings/auth-tokens/" >&2
+  exit 1
+fi
+
+ORG="shelfy-4p"
+PROJECT="python-fastapi"
+BASE="https://de.sentry.io/api/0"
+HDR=(-H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json")
+
+echo "→ Using org=$ORG project=$PROJECT"
+echo ""
+
+# ── 1. New Issue alert ────────────────────────────────────────────────────────
+echo "[1/4] New Issue alert..."
+curl -fsS -X POST "$BASE/projects/$ORG/$PROJECT/rules/" "${HDR[@]}" -d '{
+  "name": "New Issue",
+  "environment": "production",
+  "actionMatch": "all",
+  "filterMatch": "all",
+  "frequency": 30,
+  "conditions": [
+    {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
+  ],
+  "filters": [],
+  "actions": [
+    {
+      "id": "sentry.mail.actions.NotifyEmailAction",
+      "targetType": "IssueOwners",
+      "fallthroughType": "ActiveMembers"
+    }
+  ]
+}' | python3 -c "import sys,json; r=json.load(sys.stdin); print('  ✓ id=' + str(r['id']) + '  name=' + r['name'])"
+
+# ── 2. Frequency alert (>10 occurrences / 1 hour) ────────────────────────────
+echo "[2/4] Frequency alert (>10 / 1h)..."
+curl -fsS -X POST "$BASE/projects/$ORG/$PROJECT/rules/" "${HDR[@]}" -d '{
+  "name": "High Frequency Error (>10 / 1h)",
+  "environment": "production",
+  "actionMatch": "all",
+  "filterMatch": "all",
+  "frequency": 60,
+  "conditions": [
+    {
+      "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+      "value": 10,
+      "comparisonType": "count",
+      "interval": "1h"
+    }
+  ],
+  "filters": [],
+  "actions": [
+    {
+      "id": "sentry.mail.actions.NotifyEmailAction",
+      "targetType": "IssueOwners",
+      "fallthroughType": "ActiveMembers"
+    }
+  ]
+}' | python3 -c "import sys,json; r=json.load(sys.stdin); print('  ✓ id=' + str(r['id']) + '  name=' + r['name'])"
+
+# ── 3. Regression alert ───────────────────────────────────────────────────────
+echo "[3/4] Regression alert..."
+curl -fsS -X POST "$BASE/projects/$ORG/$PROJECT/rules/" "${HDR[@]}" -d '{
+  "name": "Regression",
+  "environment": "production",
+  "actionMatch": "all",
+  "filterMatch": "all",
+  "frequency": 30,
+  "conditions": [
+    {"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"}
+  ],
+  "filters": [],
+  "actions": [
+    {
+      "id": "sentry.mail.actions.NotifyEmailAction",
+      "targetType": "IssueOwners",
+      "fallthroughType": "ActiveMembers"
+    }
+  ]
+}' | python3 -c "import sys,json; r=json.load(sys.stdin); print('  ✓ id=' + str(r['id']) + '  name=' + r['name'])"
+
+# ── 4. Performance alert — P95 latency > 2 000 ms ────────────────────────────
+echo "[4/4] Performance alert (P95 > 2s)..."
+curl -fsS -X POST "$BASE/organizations/$ORG/alert-rules/" "${HDR[@]}" -d '{
+  "name": "API P95 latency > 2s",
+  "environment": "production",
+  "dataset": "transactions",
+  "aggregate": "p95(transaction.duration)",
+  "query": "transaction.op:http.server",
+  "timeWindow": 10,
+  "thresholdType": 0,
+  "resolveThreshold": 1500,
+  "projects": ["python-fastapi"],
+  "owner": "user:4514584",
+  "triggers": [
+    {
+      "label": "critical",
+      "alertThreshold": 2000,
+      "actions": [
+        {
+          "type": "email",
+          "targetType": "user",
+          "targetIdentifier": "4514584"
+        }
+      ]
+    },
+    {
+      "label": "warning",
+      "alertThreshold": 1000,
+      "actions": []
+    }
+  ]
+}' | python3 -c "import sys,json; r=json.load(sys.stdin); print('  ✓ id=' + str(r['id']) + '  name=' + r['name'])"
+
+echo ""
+echo "Done. Verify at: https://shelfy-4p.sentry.io/alerts/rules/"

--- a/worker/backup_tasks.py
+++ b/worker/backup_tasks.py
@@ -2,18 +2,23 @@
 
 Tasks registered with Celery beat via celery_beat.py:
 
-  backup.pg_dump          02:00 UTC daily  — pg_dump → gzip → MinIO
+  backup.pg_dump          02:00 UTC daily  — pg_dump → gzip → R2/MinIO
   backup.verify_restore   03:00 UTC weekly — download latest backup, restore to
                                              temp DB, verify row counts, drop DB
   cleanup.stripe_events   04:00 UTC weekly — prune stripe_events rows > 90 days
 
 Environment variables (all optional, sensible defaults for docker-compose):
   DATABASE_URL           — postgresql+psycopg2://shelfy:shelfy@postgres/shelfy
-  MINIO_ENDPOINT         — http://minio:9000
-  MINIO_ACCESS_KEY       — minioadmin
-  MINIO_SECRET_KEY       — minioadmin
-  MINIO_BACKUP_BUCKET    — shelfy-backups
-  MINIO_REGION           — us-east-1
+  R2_ENDPOINT            — https://<account>.r2.cloudflarestorage.com  (prod)
+  R2_ACCESS_KEY          — Cloudflare R2 access key ID
+  R2_SECRET_KEY          — Cloudflare R2 secret access key
+  R2_BACKUP_BUCKET       — shelfy
+  R2_REGION              — auto
+  MINIO_ENDPOINT         — http://minio:9000  (dev fallback when R2_* unset)
+  MINIO_ACCESS_KEY       — minioadmin         (dev fallback)
+  MINIO_SECRET_KEY       — minioadmin         (dev fallback)
+  MINIO_BACKUP_BUCKET    — shelfy-backups     (dev fallback)
+  MINIO_REGION           — us-east-1          (dev fallback)
   BACKUP_KEEP_DAYS       — 30
   STRIPE_EVENTS_KEEP_DAYS— 90
 """
@@ -33,7 +38,7 @@ from celery.schedules import crontab
 
 from celery_app import celery_app
 
-_BACKUP_BUCKET = os.environ.get("MINIO_BACKUP_BUCKET", "shelfy-backups")
+_BACKUP_BUCKET = os.environ.get("R2_BACKUP_BUCKET") or os.environ.get("MINIO_BACKUP_BUCKET", "shelfy-backups")
 _KEEP_DAYS = int(os.environ.get("BACKUP_KEEP_DAYS", "30"))
 _STRIPE_EVENTS_KEEP_DAYS = int(os.environ.get("STRIPE_EVENTS_KEEP_DAYS", "90"))
 
@@ -43,10 +48,10 @@ _STRIPE_EVENTS_KEEP_DAYS = int(os.environ.get("STRIPE_EVENTS_KEEP_DAYS", "90"))
 def _s3_client():
     return boto3.client(
         "s3",
-        endpoint_url=os.environ.get("MINIO_ENDPOINT", "http://minio:9000"),
-        aws_access_key_id=os.environ.get("MINIO_ACCESS_KEY", "minioadmin"),
-        aws_secret_access_key=os.environ.get("MINIO_SECRET_KEY", "minioadmin"),
-        region_name=os.environ.get("MINIO_REGION", "us-east-1"),
+        endpoint_url=os.environ.get("R2_ENDPOINT") or os.environ.get("MINIO_ENDPOINT", "http://minio:9000"),
+        aws_access_key_id=os.environ.get("R2_ACCESS_KEY") or os.environ.get("MINIO_ACCESS_KEY", "minioadmin"),
+        aws_secret_access_key=os.environ.get("R2_SECRET_KEY") or os.environ.get("MINIO_SECRET_KEY", "minioadmin"),
+        region_name=os.environ.get("R2_REGION") or os.environ.get("MINIO_REGION", "us-east-1"),
     )
 
 


### PR DESCRIPTION
Implements automated daily backups to Cloudflare R2 + weekly restore verification.

### What
- Daily pg_dump (02:00 UTC) → gzip → Cloudflare R2
- Weekly restore drill (Mon 03:00 UTC) — download, restore, verify row counts, drop
- Old backup pruning (30 day retention)
- Separate R2_* env vars for backups (MINIO_* stays for book images)
- Dev fallback to MinIO when R2 is unconfigured
- Sentry alerts setup script

Closes #182