### PR TITLE
feat(landing): add Features and Pricing quick links to top nav

### DIFF
--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -557,6 +557,8 @@
   "landing": {
     "hero_title": "Celá tvoje knihovna, katalogizovaná během minut.",
     "hero_subtitle": "Pro domácí čtenáře, čtenářské kluby, školy a malé knihovny. Vyfoť police a Shelfy přečte každý hřbet — vytvoří prohledatelný katalog podle názvu, autora i ISBN.",
+    "nav_features": "Funkce",
+    "nav_pricing": "Ceník",
     "hero_cta_signup": "Vyzkoušet zdarma",
     "hero_cta_login": "Přihlásit se",
     "hero_cta_watch_demo": "Jak to funguje",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -244,6 +244,8 @@
   "landing": {
     "hero_title": "Your entire book collection, catalogued in minutes.",
     "hero_subtitle": "For home readers, book clubs, schools, and small libraries. Photograph your shelves and Shelfy's AI reads every spine — building a searchable catalog by title, author, and ISBN.",
+    "nav_features": "Features",
+    "nav_pricing": "Pricing",
     "hero_cta_signup": "Try it free",
     "hero_cta_login": "Sign in",
     "hero_cta_watch_demo": "How it works",

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -112,17 +112,33 @@ export function LandingPage() {
       {/* ── Header ── */}
       <header className="lp-header">
         <span style={{ fontWeight: 700, fontSize: 20, letterSpacing: '-0.02em' }}>Shelfy</span>
-        <button
-          type="button"
-          className="sh-btn-ghost"
-          style={{ fontSize: 14 }}
-          onClick={() => {
-            trackSupportingCtaClick(t('landing.hero_cta_login'), 'header')
-            navigate(ROUTES.login)
-          }}
-        >
-          {t('landing.hero_cta_login')}
-        </button>
+        <nav className="lp-header-nav">
+          <button
+            type="button"
+            className="lp-header-nav-link"
+            onClick={() => howItWorksRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+          >
+            {t('landing.nav_features')}
+          </button>
+          <button
+            type="button"
+            className="lp-header-nav-link"
+            onClick={() => navigate(ROUTES.pricing)}
+          >
+            {t('landing.nav_pricing')}
+          </button>
+          <button
+            type="button"
+            className="sh-btn-ghost"
+            style={{ fontSize: 14 }}
+            onClick={() => {
+              trackSupportingCtaClick(t('landing.hero_cta_login'), 'header')
+              navigate(ROUTES.login)
+            }}
+          >
+            {t('landing.hero_cta_login')}
+          </button>
+        </nav>
       </header>
 
       <main style={{ flex: 1 }}>

--- a/frontend/src/styles/shelfy.css
+++ b/frontend/src/styles/shelfy.css
@@ -1574,6 +1574,34 @@ html.dark .sh-onboarding-checkmark {
   z-index: 10;
 }
 
+.lp-header-nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.lp-header-nav-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--sh-text-muted);
+  font-size: 14px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.lp-header-nav-link:hover {
+  color: var(--sh-text);
+  background: var(--sh-hover);
+}
+
+@media (max-width: 480px) {
+  .lp-header-nav-link {
+    display: none;
+  }
+}
+
 .lp-section {
   max-width: 720px;
   margin: 0 auto;


### PR DESCRIPTION
Closes #149

## Summary
- Added **Features** and **Pricing** nav links to the landing page header, between the logo and Sign in button
- Features scrolls smoothly to the "How it works" section on the landing page
- Pricing navigates to `/pricing`
- Nav links hidden on mobile (≤480px) to keep the header clean on small screens
- Translation keys added for both EN and CS

## Test plan
- [ ] Visit landing page — header shows Features · Pricing · Sign in
- [ ] Click Features → smooth scroll to "How it works" section
- [ ] Click Pricing → navigates to `/pricing`
- [ ] Resize to mobile (≤480px) → Features and Pricing links disappear, Sign in remains
- [ ] Switch language to CS → links show "Funkce" / "Ceník"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a header navigation bar with quick-access links to Features, Pricing, and Login sections on the landing page.
  * Implemented responsive navigation design that adapts to mobile devices.
  * Extended translation support for navigation elements in Czech and English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->