### PR TITLE
perf(bookshelf): ETag caching + content-visibility for 5k+ book libraries

### DIFF
--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -2,7 +2,7 @@ import asyncio
 import uuid
 
 import redis.asyncio as aioredis
-from fastapi import APIRouter, Depends, File, HTTPException, Query, Response, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -73,6 +73,8 @@ async def read_books(
 
 @router.get("/shelf", response_model=list[BookResponse])
 async def read_books_for_shelf(
+    request: Request,
+    response: Response,
     session: AsyncSession = Depends(get_db_session),
     library_id: uuid.UUID = Depends(get_library_id),
 ) -> list[BookResponse]:
@@ -86,8 +88,27 @@ async def read_books_for_shelf(
     NOTE: This route MUST be registered before the ``/{book_id}`` dynamic
     path (FastAPI matches in declaration order — otherwise "shelf" would be
     parsed as a book id).
+
+    Supports ETag / If-None-Match: the ETag is derived from the library's
+    latest book ``updated_at`` so clients can skip the 2+ MB download when
+    nothing changed.
     """
     books = await list_all_books_for_shelf(session, library_id=library_id)
+
+    # ── ETag from max(updated_at) ─────────────────────────────────────────
+    if books:
+        max_updated = max(b.updated_at for b in books).timestamp()
+    else:
+        max_updated = 0.0
+    etag = f'W/"{library_id}-{max_updated:.6f}"'
+    response.headers["ETag"] = etag
+    response.headers["Cache-Control"] = "private, no-cache"
+
+    if_none_match = request.headers.get("If-None-Match", "")
+    if if_none_match == etag:
+        response.status_code = 304
+        return []  # FastAPI discards body on 304
+
     return [BookResponse.model_validate(book) for book in books]
 
 

--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -23,8 +23,8 @@ from app.schemas.book import (
 from app.schemas.job import UploadResponse
 from app.services.book import (
     bulk_delete_books, bulk_move_books, bulk_reorder_books, bulk_update_status,
-    create_book, delete_book, get_book_or_404, list_all_books_for_shelf,
-    list_books, update_book,
+    create_book, delete_book, get_book_or_404, get_shelf_etag_metadata,
+    list_all_books_for_shelf, list_books, update_book,
 )
 from app.services.csv_import import build_books_export_csv, confirm_csv_import, preview_csv_import
 from app.services.job import create_upload_job
@@ -89,18 +89,17 @@ async def read_books_for_shelf(
     path (FastAPI matches in declaration order — otherwise "shelf" would be
     parsed as a book id).
 
-    Supports ETag / If-None-Match: the ETag is derived from the library's
-    latest book ``updated_at`` so clients can skip the 2+ MB download when
-    nothing changed.
+    Supports ETag / If-None-Match: a lightweight metadata query runs first
+    (book count + location count + max updated timestamps).  If the client's
+    ``If-None-Match`` matches, the endpoint returns 304 *without* loading the
+    full 2+ MB book payload.
     """
-    books = await list_all_books_for_shelf(session, library_id=library_id)
+    # ── Lightweight ETag from metadata (no book payload yet) ──────────────
+    book_cnt, max_book_ts, loc_cnt, max_loc_ts = await get_shelf_etag_metadata(
+        session, library_id=library_id
+    )
+    etag = f'W/"{library_id}-{book_cnt}-{max_book_ts:.6f}-{loc_cnt}-{max_loc_ts:.6f}"'
 
-    # ── ETag from max(updated_at) ─────────────────────────────────────────
-    if books:
-        max_updated = max(b.updated_at for b in books).timestamp()
-    else:
-        max_updated = 0.0
-    etag = f'W/"{library_id}-{max_updated:.6f}"'
     response.headers["ETag"] = etag
     response.headers["Cache-Control"] = "private, no-cache"
 
@@ -109,6 +108,8 @@ async def read_books_for_shelf(
         response.status_code = 304
         return []  # FastAPI discards body on 304
 
+    # ── ETag didn't match → load full payload ────────────────────────────
+    books = await list_all_books_for_shelf(session, library_id=library_id)
     return [BookResponse.model_validate(book) for book in books]
 
 

--- a/backend/app/services/book.py
+++ b/backend/app/services/book.py
@@ -94,12 +94,15 @@ async def get_shelf_etag_metadata(
     Returns (book_count, max_book_updated, location_count, max_location_updated)
     so the endpoint can build a weak ETag and return 304 without touching
     the full 2+ MB book payload.
+
+    For empty libraries max(updated_at) is NULL — we use 0.0 in Python so
+    the ETag is stable across requests (``func.now()`` would drift).
     """
     book_row = (
         await session.execute(
             select(
                 func.count(Book.id),
-                func.coalesce(func.max(Book.updated_at), func.now()),
+                func.max(Book.updated_at),
             ).where(Book.library_id == library_id)
         )
     ).one()
@@ -107,15 +110,18 @@ async def get_shelf_etag_metadata(
         await session.execute(
             select(
                 func.count(Location.id),
-                func.coalesce(func.max(Location.updated_at), func.now()),
+                func.max(Location.updated_at),
             ).where(Location.library_id == library_id)
         )
     ).one()
+
+    max_book_ts = book_row[1]
+    max_loc_ts = loc_row[1]
     return (
         int(book_row[0]),
-        float(book_row[1].timestamp()),
+        max_book_ts.timestamp() if max_book_ts is not None else 0.0,
         int(loc_row[0]),
-        float(loc_row[1].timestamp()),
+        max_loc_ts.timestamp() if max_loc_ts is not None else 0.0,
     )
 
 

--- a/backend/app/services/book.py
+++ b/backend/app/services/book.py
@@ -84,6 +84,41 @@ async def list_books(
     return books, total
 
 
+async def get_shelf_etag_metadata(
+    session: AsyncSession,
+    *,
+    library_id: uuid.UUID,
+) -> tuple[int, float, int, float]:
+    """Lightweight query for shelf ETag — runs before loading all books.
+
+    Returns (book_count, max_book_updated, location_count, max_location_updated)
+    so the endpoint can build a weak ETag and return 304 without touching
+    the full 2+ MB book payload.
+    """
+    book_row = (
+        await session.execute(
+            select(
+                func.count(Book.id),
+                func.coalesce(func.max(Book.updated_at), func.now()),
+            ).where(Book.library_id == library_id)
+        )
+    ).one()
+    loc_row = (
+        await session.execute(
+            select(
+                func.count(Location.id),
+                func.coalesce(func.max(Location.updated_at), func.now()),
+            ).where(Location.library_id == library_id)
+        )
+    ).one()
+    return (
+        int(book_row[0]),
+        float(book_row[1].timestamp()),
+        int(loc_row[0]),
+        float(loc_row[1].timestamp()),
+    )
+
+
 async def list_all_books_for_shelf(
     session: AsyncSession,
     *,

--- a/backend/tests/test_book_service.py
+++ b/backend/tests/test_book_service.py
@@ -20,6 +20,7 @@ from app.services.book import (
     create_book,
     delete_book,
     get_book_or_404,
+    get_shelf_etag_metadata,
     list_all_books_for_shelf,
     list_books,
     update_book,
@@ -657,3 +658,38 @@ async def test_bulk_reorder_partial_coverage_raises_409(test_session: AsyncSessi
         )
     assert exc.value.status_code == 409
     _ = outsider  # prevent unused-variable warning
+
+
+# ── Shelf ETag metadata ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_shelf_etag_metadata_empty_library(test_session: AsyncSession) -> None:
+    """Empty library returns all zeros and 0.0 timestamps."""
+    _, lib_id = await _make_library(test_session)
+    book_cnt, max_book_ts, loc_cnt, max_loc_ts = await get_shelf_etag_metadata(
+        test_session, library_id=lib_id
+    )
+    assert book_cnt == 0
+    assert max_book_ts == 0.0
+    assert loc_cnt == 0
+    assert max_loc_ts == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_shelf_etag_metadata_with_data(test_session: AsyncSession) -> None:
+    """Library with books and locations returns counts > 0 and real timestamps."""
+    _, lib_id = await _make_library(test_session)
+    await _make_location(test_session, lib_id)
+    await _make_location(test_session, lib_id)
+    await _make_book(test_session, lib_id, title="Book 1")
+    await _make_book(test_session, lib_id, title="Book 2")
+    await _make_book(test_session, lib_id, title="Book 3")
+
+    book_cnt, max_book_ts, loc_cnt, max_loc_ts = await get_shelf_etag_metadata(
+        test_session, library_id=lib_id
+    )
+    assert book_cnt == 3
+    assert max_book_ts > 0.0
+    assert loc_cnt == 2
+    assert max_loc_ts > 0.0

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -527,6 +527,137 @@ async def test_shelf_endpoint_requires_authentication() -> None:
         assert (await client.get("/api/v1/books/shelf")).status_code == 401
 
 
+# ── Shelf ETag / If-None-Match ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shelf_etag_200_includes_etag_header(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """First request to /books/shelf returns 200 with ETag header."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        response = await client.get("/api/v1/books/shelf", headers=headers)
+        assert response.status_code == 200
+        assert "etag" in response.headers
+        assert response.headers["etag"].startswith('W/')
+        assert "Cache-Control" in response.headers
+
+
+@pytest.mark.asyncio
+async def test_shelf_etag_304_on_unchanged_data(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """Second request with If-None-Match returns 304 when data is unchanged."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        response1 = await client.get("/api/v1/books/shelf", headers=headers)
+        assert response1.status_code == 200
+        etag = response1.headers["etag"]
+
+        # Second request with matching ETag
+        headers["If-None-Match"] = etag
+        response2 = await client.get("/api/v1/books/shelf", headers=headers)
+        assert response2.status_code == 304
+
+
+@pytest.mark.asyncio
+async def test_shelf_etag_changes_on_book_create(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """Creating a book changes the ETag — old ETag no longer returns 304."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+            user, library = await _seed_user_with_library(session)
+
+        response1 = await client.get("/api/v1/books/shelf", headers=headers)
+        assert response1.status_code == 200
+        old_etag = response1.headers["etag"]
+
+        # Create a book — must change the ETag
+        await client.post(
+            "/api/v1/books",
+            json={"title": "New Book"},
+            headers=headers,
+        )
+
+        response2 = await client.get(
+            "/api/v1/books/shelf",
+            headers={**headers, "If-None-Match": old_etag},
+        )
+        assert response2.status_code == 200, (
+            f"Expected 200 (ETag should have changed), got {response2.status_code}"
+        )
+        assert response2.headers["etag"] != old_etag
+
+
+@pytest.mark.asyncio
+async def test_shelf_etag_changes_on_book_delete(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """Deleting a book changes the ETag — count is part of the ETag."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+            user, library = await _seed_user_with_library(session)
+
+        # Create a book first
+        create = await client.post(
+            "/api/v1/books",
+            json={"title": "To Delete"},
+            headers=headers,
+        )
+        book_id = create.json()["id"]
+
+        response1 = await client.get("/api/v1/books/shelf", headers=headers)
+        old_etag = response1.headers["etag"]
+
+        # Delete it
+        await client.delete(f"/api/v1/books/{book_id}", headers=headers)
+
+        response2 = await client.get(
+            "/api/v1/books/shelf",
+            headers={**headers, "If-None-Match": old_etag},
+        )
+        assert response2.status_code == 200, (
+            f"Expected 200 (ETag should have changed after delete), got {response2.status_code}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_shelf_etag_changes_on_location_change(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """Creating a location changes the ETag — location metadata is included."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+            user, library = await _seed_user_with_library(session)
+
+        response1 = await client.get("/api/v1/books/shelf", headers=headers)
+        old_etag = response1.headers["etag"]
+
+        # Create a location — should change ETag because location count is included
+        await client.post(
+            "/api/v1/locations",
+            json={"room": "office", "furniture": "desk", "shelf": "top"},
+            headers=headers,
+        )
+
+        response2 = await client.get(
+            "/api/v1/books/shelf",
+            headers={**headers, "If-None-Match": old_etag},
+        )
+        assert response2.status_code == 200, (
+            f"Expected 200 (ETag should have changed after location create), got {response2.status_code}"
+        )
+
+
 @pytest.mark.asyncio
 async def test_bulk_reorder_rejects_partial_payload_with_409(
     test_session: async_sessionmaker[AsyncSession],

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1003,7 +1003,7 @@
           "books"
         ],
         "summary": "Read Books For Shelf",
-        "description": "Return every book in the library, ordered for bookshelf rendering.\n\nThe bookshelf UI needs a complete per-location dataset or its reorder\nflow builds payloads that collide with books hidden by pagination (see\nissue #128). This endpoint returns the full library without pagination;\ncallers should not use it for generic browsing.\n\nNOTE: This route MUST be registered before the ``/{book_id}`` dynamic\npath (FastAPI matches in declaration order — otherwise \"shelf\" would be\nparsed as a book id).",
+        "description": "Return every book in the library, ordered for bookshelf rendering.\n\nThe bookshelf UI needs a complete per-location dataset or its reorder\nflow builds payloads that collide with books hidden by pagination (see\nissue #128). This endpoint returns the full library without pagination;\ncallers should not use it for generic browsing.\n\nNOTE: This route MUST be registered before the ``/{book_id}`` dynamic\npath (FastAPI matches in declaration order — otherwise \"shelf\" would be\nparsed as a book id).\n\nSupports ETag / If-None-Match: a lightweight metadata query runs first\n(book count + location count + max updated timestamps).  If the client's\n``If-None-Match`` matches, the endpoint returns 304 *without* loading the\nfull 2+ MB book payload.",
         "operationId": "read_books_for_shelf_api_v1_books_shelf_get",
         "security": [
           {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,3 +1,4 @@
+{"environment": "production", "event": "sentry_initialized", "service": "backend", "level": "info", "timestamp": "2026-05-05T10:15:58.066572Z"}
 {
   "openapi": "3.1.0",
   "info": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,4 +1,3 @@
-{"environment": "production", "event": "sentry_initialized", "service": "backend", "level": "info", "timestamp": "2026-05-05T10:15:58.066572Z"}
 {
   "openapi": "3.1.0",
   "info": {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -366,8 +366,43 @@ export async function deleteLocation(id: string): Promise<void> {
  * hidden by pagination (issue #128). Do not use this for generic browsing;
  * the payload can be large for sizable libraries.
  */
+// ── ETag cache for /books/shelf ────────────────────────────────────────────
+// Keyed by libraryId so multi-library users get correct isolation.
+const _shelfEtagCache = new Map<string, { etag: string; data: Book[] }>()
+
 export async function listBooksForShelf(): Promise<Book[]> {
-  const response = await apiClient.get<Book[]>('/api/v1/books/shelf')
+  const libraryId = getActiveLibraryId()
+  const cached = libraryId ? _shelfEtagCache.get(libraryId) : undefined
+
+  const headers: Record<string, string> = {}
+  if (cached?.etag) {
+    headers['If-None-Match'] = cached.etag
+  }
+
+  const response = await apiClient.get<Book[]>('/api/v1/books/shelf', {
+    headers,
+    // Axios throws on 304 by default; allow it so we can handle cache hits
+    validateStatus: (status) => status === 200 || status === 304,
+  })
+
+  if (response.status === 304) {
+    if (cached) {
+      return cached.data
+    }
+    // No cached payload and a 304 — should not happen, but refetch safely
+    const refetch = await apiClient.get<Book[]>('/api/v1/books/shelf')
+    const etag = refetch.headers['etag'] ?? ''
+    if (libraryId && etag) {
+      _shelfEtagCache.set(libraryId, { etag, data: refetch.data })
+    }
+    return refetch.data
+  }
+
+  // 200 — store or update cache
+  const etag = response.headers['etag'] ?? ''
+  if (libraryId && etag) {
+    _shelfEtagCache.set(libraryId, { etag, data: response.data })
+  }
   return response.data
 }
 

--- a/frontend/src/pages/BookshelfViewPage.tsx
+++ b/frontend/src/pages/BookshelfViewPage.tsx
@@ -405,7 +405,7 @@ export function BookshelfViewPage() {
                     const isHighlighted = preselectedLocationId === loc.id
 
                     return (
-                      <div key={loc.id} style={{ borderBottom: '1px solid var(--sh-border)', padding: isMobile ? '10px 12px' : '12px 16px', background: isHighlighted ? 'var(--sh-teal-bg)' : undefined, transition: 'background 0.3s' }}>
+                      <div key={loc.id} style={{ borderBottom: '1px solid var(--sh-border)', padding: isMobile ? '10px 12px' : '12px 16px', background: isHighlighted ? 'var(--sh-teal-bg)' : undefined, transition: 'background 0.3s', contentVisibility: 'auto', containIntrinsicSize: 'auto 80px' }}>
                         <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--sh-text-muted)', marginBottom: 8 }}>{loc.shelf}</div>
 
                         {shelfBooks.length === 0 ? (


### PR DESCRIPTION
## Problem

BookshelfViewPage freezes for 20+ seconds with 5,000 books across ~100 shelves:
- Downloads 2.3 MB JSON every time (no caching)
- Renders all 5,000 book spines in the DOM
- Mobile browser hangs, desktop is sluggish

## Fix

### Backend: ETag caching
- Add `ETag` header derived from `max(updated_at)` of library books
- Support `If-None-Match` — returns `304 Not Modified` when nothing changed
- Subsequent loads skip the 2+ MB download entirely

### Frontend: CSS content-visibility
- Add `content-visibility: auto` + `contain-intrinsic-size: 80px` to each shelf row
- Browser skips layout/paint for off-screen shelves
- Only first ~5 visible shelves are rendered initially
- No new npm dependency, no scroll virtualization library needed

## Testing

- Manual: load loadtest@shelfy.cz with 5,000 books -> BookshelfView
- E2E: existing tests should pass (no DOM structure change, only CSS)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client and server now use ETag-based caching for bookshelf data so unchanged shelf contents return 304 and are not re-downloaded.

* **Performance**
  * Improved shelf row rendering for better responsiveness and reduced browser overhead.

* **Tests**
  * Added integration and service tests verifying ETag/cache behavior and that tags update when shelf data changes.

* **Documentation**
  * API docs updated to describe ETag/If-None-Match caching for the bookshelf endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->