### PR TITLE
fix(bookshelf): force-render highlighted shelf so scrollIntoView works

### DIFF
--- a/frontend/src/pages/BookshelfViewPage.tsx
+++ b/frontend/src/pages/BookshelfViewPage.tsx
@@ -403,9 +403,11 @@ export function BookshelfViewPage() {
                   {shelfLocations.map((loc) => {
                     const shelfBooks = localByLocation[loc.id] ?? []
                     const isHighlighted = preselectedLocationId === loc.id
+                    const hasHighlightBook = highlightBookId ? shelfBooks.some((b) => b.id === highlightBookId) : false
+                    const needsRender = isHighlighted || hasHighlightBook
 
                     return (
-                      <div key={loc.id} style={{ borderBottom: '1px solid var(--sh-border)', padding: isMobile ? '10px 12px' : '12px 16px', background: isHighlighted ? 'var(--sh-teal-bg)' : undefined, transition: 'background 0.3s', contentVisibility: 'auto', containIntrinsicSize: 'auto 80px' }}>
+                      <div key={loc.id} style={{ borderBottom: '1px solid var(--sh-border)', padding: isMobile ? '10px 12px' : '12px 16px', background: isHighlighted ? 'var(--sh-teal-bg)' : undefined, transition: 'background 0.3s', contentVisibility: needsRender ? 'visible' : 'auto', containIntrinsicSize: 'auto 80px' }}>
                         <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--sh-text-muted)', marginBottom: 8 }}>{loc.shelf}</div>
 
                         {shelfBooks.length === 0 ? (


### PR DESCRIPTION
## Problem

`content-visibility: auto` (from PR #210) skips layout for off-screen shelves. When navigating to a book's shelf position (e.g. from book detail "show in shelf"), `scrollIntoView` fails because the target shelf container has no computed layout — the browser cannot scroll to an element whose parent hasn't been rendered.

## Fix

Only apply `content-visibility: auto` to shelves that do NOT contain the highlighted book. The shelf with the highlighted/preselected book gets `content-visibility: visible`, forcing the browser to compute layout and allowing `scrollIntoView` to work.

## Testing

- Navigate to any book in shelfy (with 5,000 books distributed across 90+ shelves)
- Click "Show in shelf" — should scroll to and highlight the correct shelf
- No performance regression (only 1 shelf is force-rendered out of ~91)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized shelf container rendering and visibility handling in the Bookshelf view to improve performance when navigating between highlighted books.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->