### PR TITLE
fix(bookshelf): retry scrollIntoView + nearest alignment for edge-position books

### DIFF
--- a/e2e/tests/reorder-and-bulk-regressions.spec.ts
+++ b/e2e/tests/reorder-and-bulk-regressions.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
-import { createLocatedBook, createManualBook, login, navigateProtected } from './helpers'
+import { createLocatedBook, createManualBook, getE2EAccessToken, login, navigateProtected } from './helpers'
 
 // SPA nav to bookshelf — no page reload, auth state stays intact.
 async function clickNavBookshelf(page: Page): Promise<void> {
@@ -65,17 +65,25 @@ test('"show on shelf" highlights book at shelf position 0', async ({ page }) => 
   await page.waitForURL(/\/books\//)
   const bookId = page.url().split('/').pop()!
 
-  // Create a location and assign the book to position 0
-  const locRes = await page.request.post('/api/v1/locations', {
+  // Create a location and assign the book to position 0 via API
+  const token = getE2EAccessToken(page)
+  const headers = token ? { Authorization: 'Bearer ' + token } : {}
+  const apiBase = process.env.E2E_API_BASE_URL ?? 'http://localhost:8000'
+  const locRes = await page.request.post(apiBase + '/api/v1/locations', {
+    headers,
     data: { room: 'E2E Room', furniture: 'Bookshelf', shelf: 'Shelf 1', display_order: 0 },
   })
   const { id: locationId } = await locRes.json() as { id: string }
-  await page.request.patch('/api/v1/books/' + bookId, {
+  await page.request.patch(apiBase + '/api/v1/books/' + bookId, {
+    headers,
     data: { location_id: locationId, shelf_position: 0 },
   })
 
-  // Refresh the detail page to see the location, then click Show on shelf
-  await page.reload()
+  // Go back to /books then re-enter the detail page to see the location.
+  // (Avoids page.reload which re-bootstraps auth in CI.)
+  await page.goBack()
+  await page.waitForURL(/\/books$/)
+  await page.locator('.sh-card-enter').filter({ hasText: title }).first().click()
   await page.waitForURL(/\/books\//)
   await page.waitForURL(/\/books\//)
 

--- a/e2e/tests/reorder-and-bulk-regressions.spec.ts
+++ b/e2e/tests/reorder-and-bulk-regressions.spec.ts
@@ -51,3 +51,29 @@ test('bookshelf route and reorder toggle render on mobile', async ({ page }) => 
   await reorderButton.click()
   await expect(page.getByText(/Drag books to reorder|long-press/i)).toBeVisible()
 })
+
+test('"show on shelf" highlights book at shelf position 0', async ({ page }) => {
+  await login(page)
+  const title = `E2E Shelf Highlight ${Date.now()}`
+  await createLocatedBook(page, title)
+  // createLocatedBook ends on /books — no extra navigation needed.
+
+  // Navigate to the book detail page by clicking the book card
+  await page.locator('.sh-card-enter').filter({ hasText: title }).click()
+  await page.waitForURL(/\/books\//)
+
+  // Click "Show on shelf" / "Ukázat v polici"
+  await page.getByRole('button', { name: /Ukázat v polici|Show on shelf/i }).click()
+  await page.waitForURL(/\/bookshelf\?/)
+
+  // Verify URL params
+  const url = page.url()
+  expect(url).toContain('location_id=')
+  expect(url).toContain('highlight_book_id=')
+
+  // Verify the book spine is highlighted (data-highlighted attribute present)
+  await expect(page.locator('[data-highlighted]').first()).toBeVisible({ timeout: 8000 })
+
+  // Verify the highlighted spine has the correct book title
+  await expect(page.locator('[data-highlighted]').first()).toContainText(title.substring(0, 10), { ignoreCase: true })
+})

--- a/e2e/tests/reorder-and-bulk-regressions.spec.ts
+++ b/e2e/tests/reorder-and-bulk-regressions.spec.ts
@@ -53,13 +53,30 @@ test('bookshelf route and reorder toggle render on mobile', async ({ page }) => 
 })
 
 test('"show on shelf" highlights book at shelf position 0', async ({ page }) => {
+  // Use createManualBook for proper SPA nav that lands on /books.
+  // Then assign a location via the API and navigate to show-on-shelf.
   await login(page)
   const title = `E2E Shelf Highlight ${Date.now()}`
-  await createLocatedBook(page, title)
-  // createLocatedBook ends on /books — no extra navigation needed.
+  await createManualBook(page, title)
+  await expect(page).toHaveURL(/\/books$/)
 
-  // Navigate to the book detail page by clicking the book card
-  await page.locator('.sh-card-enter').filter({ hasText: title }).click()
+  // Find the book card and extract its ID
+  await page.locator('.sh-card-enter').filter({ hasText: title }).first().click()
+  await page.waitForURL(/\/books\//)
+  const bookId = page.url().split('/').pop()!
+
+  // Create a location and assign the book to position 0
+  const locRes = await page.request.post('/api/v1/locations', {
+    data: { room: 'E2E Room', furniture: 'Bookshelf', shelf: 'Shelf 1', display_order: 0 },
+  })
+  const { id: locationId } = await locRes.json() as { id: string }
+  await page.request.patch('/api/v1/books/' + bookId, {
+    data: { location_id: locationId, shelf_position: 0 },
+  })
+
+  // Refresh the detail page to see the location, then click Show on shelf
+  await page.reload()
+  await page.waitForURL(/\/books\//)
   await page.waitForURL(/\/books\//)
 
   // Click "Show on shelf" / "Ukázat v polici"

--- a/frontend/src/pages/BookshelfViewPage.tsx
+++ b/frontend/src/pages/BookshelfViewPage.tsx
@@ -152,9 +152,25 @@ export function BookshelfViewPage() {
 
   useEffect(() => {
     if (!highlightBookId || activeTab !== 'shelves') return
-    const timer = setTimeout(() => {
-      highlightSpineRef.current?.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' })
-    }, 80)
+    // The highlighted shelf gets ``content-visibility: visible`` above, but
+    // the spine DOM (dnd-kit wrappers + 55 spines) needs layout time.
+    // ``inline: nearest`` avoids the edge case where ``center`` fails for
+    // books at position 0 (nothing to scroll left of the first spine).
+    let attempts = 0
+    const maxAttempts = 4
+    const tryScroll = () => {
+      attempts += 1
+      if (highlightSpineRef.current) {
+        highlightSpineRef.current.scrollIntoView({
+          behavior: 'smooth',
+          inline: 'nearest',
+          block: 'center',
+        })
+      } else if (attempts < maxAttempts) {
+        setTimeout(tryScroll, 150)
+      }
+    }
+    const timer = setTimeout(tryScroll, 100)
     return () => clearTimeout(timer)
   }, [highlightBookId, activeTab, filteredTree])
 


### PR DESCRIPTION
## Problem

content-visibility: auto (from PR #210) skips layout for off-screen shelves. PR #211 fixed the shelf-level scroll by force-rendering the highlighted shelf. But the book-level scrollIntoView still fails for books at low shelf positions (0, 1, 2).

### Root cause

1. **inline: center fails at position 0**: scrollIntoView cannot center the first spine (nothing to scroll left of it). Browser interprets this as "already visible" and does nothing.

2. **80ms timeout too short**: After content-visibility: visible triggers layout, the shelf content (55 BookSpine + dnd-kit Sortable wrappers) needs more than 80ms to complete layout. The ref was still null when scrollIntoView fired.

3. **No retry**: If the ref was null on first attempt, the book was never scrolled to.

## Fix

- `inline: nearest` instead of `center` (handles edge positions correctly)
- `block: center` instead of `nearest` (better vertical visibility)
- Retry logic: up to 4 attempts, 150ms apart, when ref is null
- Initial delay: 100ms (up from 80ms)

## E2E test

Added test that creates a located book at position 0, navigates to its detail, clicks "Show on shelf", and asserts the highlighted spine is visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that verifies "Show on shelf" navigates to the bookshelf, highlights the correct book, and includes the expected URL parameters.

* **Bug Fixes**
  * Improved bookshelf highlight behavior with delayed/retrying scrolling and adjusted alignment so the highlighted spine reliably appears and shows the correct title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->