### PR TITLE
feat(usage): sidebar usage meter with plan badge, bars, and upgrade CTA (#205)

### DIFF
--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { ROUTES } from '../lib/routes'
 import { useAuth } from '../contexts/AuthContext'
 import { BookshelfInlineIcon } from './EmptyStateIcons'
+import { UsageMeterCard } from './UsageMeterCard'
 
 /* ── SVG Icons (Lucide-inspired, 24×24 viewBox) ──────────────────── */
 
@@ -254,6 +255,7 @@ export function Navigation() {
         })}
 
         <div className="sh-sidebar-divider" style={{ marginTop: 'auto' }} />
+        <UsageMeterCard />
         {settingsGroup.map((tab) => {
           const active = isActive(tab.path)
           const Icon = iconComponents[tab.icon]

--- a/frontend/src/components/UsageMeterCard.test.tsx
+++ b/frontend/src/components/UsageMeterCard.test.tsx
@@ -1,0 +1,121 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true })),
+}))
+
+vi.mock('../lib/api', () => ({
+  getBillingStatus: vi.fn(),
+}))
+
+import { getBillingStatus } from '../lib/api'
+import { UsageMeterCard } from './UsageMeterCard'
+
+function makeBilling(overrides?: object) {
+  return {
+    plan: 'free' as const,
+    status: 'active',
+    has_payment_method: false,
+    trial_ends_at: null,
+    current_period_end: null,
+    usage: { scans_used: 2, scans_limit: 5, enrichments_used: 3, enrichments_limit: 20 },
+    ...overrides,
+  }
+}
+
+function renderCard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <UsageMeterCard />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('UsageMeterCard', () => {
+  it('renders nothing when billing data is unavailable', async () => {
+    vi.mocked(getBillingStatus).mockReturnValue(new Promise(() => {}))
+    const { container } = renderCard()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows plan badge and meter rows for free plan', async () => {
+    vi.mocked(getBillingStatus).mockResolvedValue(makeBilling())
+    renderCard()
+    expect(await screen.findByTestId('usage-plan-badge')).toHaveTextContent('Free')
+    expect(screen.getByText('usage_meter.scans')).toBeInTheDocument()
+    expect(screen.getByText('usage_meter.enrichments')).toBeInTheDocument()
+  })
+
+  it('shows CTA for free plan regardless of usage', async () => {
+    vi.mocked(getBillingStatus).mockResolvedValue(makeBilling({ plan: 'free' }))
+    renderCard()
+    expect(await screen.findByRole('button', { name: /usage_meter\.cta_default/i })).toBeInTheDocument()
+  })
+
+  it('does not show CTA for paid plan with low usage', async () => {
+    vi.mocked(getBillingStatus).mockResolvedValue(
+      makeBilling({
+        plan: 'pro',
+        usage: { scans_used: 1, scans_limit: 100, enrichments_used: 1, enrichments_limit: 100 },
+      }),
+    )
+    renderCard()
+    await screen.findByTestId('usage-plan-badge')
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('shows warning CTA when usage reaches 80%', async () => {
+    vi.mocked(getBillingStatus).mockResolvedValue(
+      makeBilling({
+        plan: 'pro',
+        usage: { scans_used: 80, scans_limit: 100, enrichments_used: 0, enrichments_limit: 100 },
+      }),
+    )
+    renderCard()
+    expect(await screen.findByRole('button', { name: /usage_meter\.cta_warning/i })).toBeInTheDocument()
+  })
+
+  it('shows over-limit CTA when usage exceeds limit', async () => {
+    vi.mocked(getBillingStatus).mockResolvedValue(
+      makeBilling({
+        plan: 'pro',
+        usage: { scans_used: 100, scans_limit: 100, enrichments_used: 0, enrichments_limit: 100 },
+      }),
+    )
+    renderCard()
+    expect(await screen.findByRole('button', { name: /usage_meter\.cta_over/i })).toBeInTheDocument()
+  })
+
+  it('does not render progress bar for unlimited metric', async () => {
+    vi.mocked(getBillingStatus).mockResolvedValue(
+      makeBilling({
+        plan: 'pro',
+        usage: { scans_used: 5, scans_limit: -1, enrichments_used: 5, enrichments_limit: -1 },
+      }),
+    )
+    renderCard()
+    await screen.findByTestId('usage-plan-badge')
+    expect(document.querySelector('.sh-usage-meter-track')).not.toBeInTheDocument()
+  })
+
+  it('navigates to pricing on CTA click', async () => {
+    vi.mocked(getBillingStatus).mockResolvedValue(makeBilling({ plan: 'free' }))
+    renderCard()
+    const cta = await screen.findByRole('button', { name: /usage_meter\.cta_default/i })
+    await userEvent.click(cta)
+    // Navigation is handled by react-router — just verify the click doesn't throw
+    expect(cta).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/UsageMeterCard.tsx
+++ b/frontend/src/components/UsageMeterCard.tsx
@@ -1,0 +1,114 @@
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+import { useAuth } from '../contexts/AuthContext'
+import { useBillingStatus } from '../hooks/useBilling'
+import { ROUTES } from '../lib/routes'
+import type { SubscriptionPlan, UsageSummary } from '../lib/types'
+
+const PLAN_LABELS: Record<SubscriptionPlan, string> = {
+  free: 'Free',
+  home: 'Home',
+  pro: 'Pro',
+  library: 'Library',
+}
+
+function pct(used: number, limit: number): number {
+  if (limit <= 0) return 0
+  return Math.min(100, Math.round((used / limit) * 100))
+}
+
+function maxPct(usage: UsageSummary): number {
+  return Math.max(
+    pct(usage.scans_used, usage.scans_limit),
+    pct(usage.enrichments_used, usage.enrichments_limit),
+  )
+}
+
+interface MeterRowProps {
+  label: string
+  used: number
+  limit: number
+}
+
+function MeterRow({ label, used, limit }: MeterRowProps) {
+  const unlimited = limit === -1
+  const fillPct = pct(used, limit)
+  const isWarning = !unlimited && fillPct >= 80
+  const isOver = !unlimited && used >= limit
+  const barColor = isOver ? 'var(--sh-red)' : isWarning ? '#f59e0b' : 'var(--sh-primary)'
+
+  return (
+    <div className="sh-usage-meter-row">
+      <div className="sh-usage-meter-labels">
+        <span className="sh-usage-meter-label">{label}</span>
+        <span
+          className="sh-usage-meter-value"
+          style={{ color: isOver ? 'var(--sh-red)' : undefined }}
+        >
+          {unlimited ? `${used} / ∞` : `${used} / ${limit}`}
+        </span>
+      </div>
+      {!unlimited && (
+        <div className="sh-usage-meter-track">
+          <div
+            className="sh-usage-meter-fill"
+            style={{ width: `${fillPct}%`, background: barColor }}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function UsageMeterCard() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { isAuthenticated } = useAuth()
+  const { data: billing } = useBillingStatus({ enabled: isAuthenticated })
+
+  if (!billing) return null
+
+  const { plan, usage } = billing
+  const mp = maxPct(usage)
+
+  // CTA: always for free plan; for paid only when approaching / hitting a limit
+  const showCta = plan === 'free' || mp >= 80
+  const ctaLabel =
+    mp >= 100
+      ? t('usage_meter.cta_over')
+      : mp >= 80
+        ? t('usage_meter.cta_warning')
+        : t('usage_meter.cta_default')
+  const ctaIsUrgent = mp >= 80
+
+  return (
+    <div className="sh-usage-card" data-testid="usage-meter-card">
+      <div className="sh-usage-card__header">
+        <span className="sh-usage-plan-badge" data-testid="usage-plan-badge">
+          {PLAN_LABELS[plan]}
+        </span>
+      </div>
+
+      <MeterRow
+        label={t('usage_meter.scans')}
+        used={usage.scans_used}
+        limit={usage.scans_limit}
+      />
+      <MeterRow
+        label={t('usage_meter.enrichments')}
+        used={usage.enrichments_used}
+        limit={usage.enrichments_limit}
+      />
+
+      {showCta && (
+        <button
+          className={ctaIsUrgent ? 'sh-usage-cta sh-usage-cta--urgent' : 'sh-usage-cta'}
+          onClick={() => navigate(ROUTES.pricing)}
+        >
+          {ctaLabel}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -426,6 +426,13 @@
     "next": "Další →",
     "info": "{{page}} / {{total}}"
   },
+  "usage_meter": {
+    "scans": "Skenování",
+    "enrichments": "Obohacení",
+    "cta_default": "Zobrazit plány",
+    "cta_warning": "Upgradujte, než vám dojde limit",
+    "cta_over": "Upgradujte pro pokračování"
+  },
   "bookshelf": {
     "title": "Moje knihovny",
     "scan_shelf": "Skenovat polici",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -497,6 +497,13 @@
     "next": "Next →",
     "info": "{{page}} / {{total}}"
   },
+  "usage_meter": {
+    "scans": "Scans",
+    "enrichments": "Enrichments",
+    "cta_default": "View plans",
+    "cta_warning": "Upgrade before you run out",
+    "cta_over": "Upgrade to continue"
+  },
   "bookshelf": {
     "title": "My bookshelves",
     "scan_shelf": "Scan shelf",

--- a/frontend/src/styles/shelfy.css
+++ b/frontend/src/styles/shelfy.css
@@ -2585,3 +2585,104 @@ html.dark .lp-final-cta {
   );
   border-color: rgba(45, 122, 95, 0.15);
 }
+
+/* ── Usage Meter Card ────────────────────────────────────────── */
+
+.sh-usage-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sh-space-2);
+  padding: var(--sh-space-3) var(--sh-space-3);
+  border: 1px solid var(--sh-border);
+  border-radius: var(--sh-radius-md);
+  background: var(--sh-surface-elevated);
+  margin: var(--sh-space-2) 0;
+}
+
+.sh-usage-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 2px;
+}
+
+.sh-usage-plan-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 99px;
+  background: var(--sh-primary-bg);
+  color: var(--sh-primary);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.sh-usage-meter-row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.sh-usage-meter-labels {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--sh-space-2);
+}
+
+.sh-usage-meter-label {
+  font-size: 12px;
+  color: var(--sh-text-muted);
+}
+
+.sh-usage-meter-value {
+  font-size: 12px;
+  color: var(--sh-text-main);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.sh-usage-meter-track {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--sh-border);
+  overflow: hidden;
+}
+
+.sh-usage-meter-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.sh-usage-cta {
+  margin-top: var(--sh-space-1);
+  width: 100%;
+  padding: 5px 0;
+  background: var(--sh-primary-bg);
+  color: var(--sh-primary);
+  border: 1px solid var(--sh-primary);
+  border-radius: var(--sh-radius-md);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--sh-duration-fast) var(--sh-ease-default);
+}
+
+.sh-usage-cta:hover {
+  background: var(--sh-primary);
+  color: #fff;
+}
+
+.sh-usage-cta--urgent {
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--sh-red);
+  border-color: var(--sh-red);
+}
+
+.sh-usage-cta--urgent:hover {
+  background: var(--sh-red);
+  color: #fff;
+}


### PR DESCRIPTION
## Summary

- New `UsageMeterCard` component renders in the desktop sidebar below the auto-margin divider, just above Settings/Logout
- Shows **plan badge** (Free / Home / Pro / Library), **scans** and **enrichments** progress bars (hidden when limit is -1/unlimited), and an **upgrade CTA**
- CTA is always shown on the free plan; on paid plans only when any meter hits ≥80% (warning) or ≥100% (over-limit)
- Bar colors: normal → `--sh-primary`, warning (≥80%) → amber, over (≥100%) → `--sh-red`
- Unlimited metrics (`limit === -1`) show `N / ∞` text with no bar
- i18n keys added to `en.json` and `cs.json` under `usage_meter.*`

## Test plan

- [x] `UsageMeterCard.test.tsx` — 8 tests: null while loading, free plan with CTA, paid low-usage (no CTA), paid 80% (warning CTA), paid 100% (over CTA), unlimited hides bars, CTA click
- [x] All 8 tests pass

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a usage meter card to the sidebar displaying current plan and resource usage metrics (scans and enrichments) with progress indicators.
  * Contextual call-to-action buttons adapt based on usage levels, showing warnings at 80% capacity and alerts when limits are exceeded.

* **Tests**
  * Added comprehensive test coverage for the new usage meter component.

* **Localization**
  * Added Czech and English translations for usage meter labels and call-to-action messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->