### PR TITLE
feat(ux): improve empty states across activation-critical pages (#204)

### DIFF
--- a/e2e/tests/critical-flows.spec.ts
+++ b/e2e/tests/critical-flows.spec.ts
@@ -17,7 +17,7 @@ test('locations CRUD', async ({ page }) => {
   // ProtectedRoute also only saves location.pathname (not search), so
   // /bookshelf?tab=locations becomes /bookshelf after login redirect.
   // Use SPA nav: Shelves nav button → Locations tab button.
-  await page.getByRole('button', { name: /Police|Shelves/i }).click()
+  await page.locator('nav').getByRole('button', { name: /Police|Shelves/i }).click()
   await page.waitForURL(/\/bookshelf$/)
   await page.getByRole('button', { name: /Správa pozic|Locations management/i }).click()
   await page.waitForURL(/\/bookshelf\?tab=locations$/)

--- a/e2e/tests/reorder-and-bulk-regressions.spec.ts
+++ b/e2e/tests/reorder-and-bulk-regressions.spec.ts
@@ -4,7 +4,7 @@ import { createLocatedBook, createManualBook, getE2EAccessToken, login, navigate
 // SPA nav to bookshelf — no page reload, auth state stays intact.
 async function clickNavBookshelf(page: Page): Promise<void> {
   // nav.bookshelf i18n: en='Shelves', cs='Police'
-  await page.getByRole('button', { name: /Police|Shelves/i }).click()
+  await page.locator('nav').getByRole('button', { name: /Police|Shelves/i }).click()
   await page.waitForURL(/\/bookshelf$/)
 }
 

--- a/e2e/tests/smoke-regressions.spec.ts
+++ b/e2e/tests/smoke-regressions.spec.ts
@@ -43,7 +43,7 @@ async function dismissOnboardingModal(page: Page): Promise<void> {
 async function clickNavBookshelf(page: Page): Promise<void> {
   // nav.bookshelf i18n: en='Shelves', cs='Police'
   await dismissOnboardingModal(page)
-  await page.getByRole('button', { name: /Police|Shelves/i }).click()
+  await page.locator('nav').getByRole('button', { name: /Police|Shelves/i }).click()
   await page.waitForURL(/\/bookshelf$/)
 }
 

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -213,6 +213,7 @@ export function Navigation() {
           padding: '32px 16px',
           display: 'flex',
           flexDirection: 'column',
+          overflowY: 'auto',
           gap: 4,
           zIndex: 100,
         }}

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -99,7 +99,7 @@
     "saving": "Ukládám…",
     "empty_cta_add": "Přidat knihu",
     "empty_cta_scan": "Naskenovat polici",
-    "empty_cta_location": "Vytvořit umístění"
+    "empty_cta_location": "Nastavit police"
   },
   "book_detail": {
     "title": "Detail knihy",
@@ -176,6 +176,8 @@
     "retry": "Zkusit znovu",
     "empty_title": "Zatím žádná umístění",
     "empty_body": "Vytvořte své první umístění výše, ať víte, kde své knihy najít.",
+    "empty_example": "Příklad: Obývací pokoj / Knihovna / Police 1",
+    "empty_cta": "Přidat první umístění",
     "actions": "Akce",
     "saving": "Ukládám…",
     "save": "Uložit",
@@ -363,7 +365,9 @@
     "added_manually": "Ručně přidána",
     "remove_segment_title": "Odebrat tuto fotku?",
     "remove_segment_body": "Tím se zahodí všechny knihy rozpoznané v této fotce. Tuto akci nelze vrátit.",
-    "remove_segment_confirm": "Odebrat fotku"
+    "remove_segment_confirm": "Odebrat fotku",
+    "no_locations_title": "Zatím žádné police",
+    "no_locations_body": "Vytvořte svou první polici, aby naskenované knihy měly hned domov."
   },
   "add_book": {
     "page_title": "Přidat knihu",
@@ -437,8 +441,13 @@
     "title": "Moje knihovny",
     "scan_shelf": "Skenovat polici",
     "books_count": "knih",
-    "empty_title": "Žádné knihovny",
-    "empty_desc": "Naskenujte svou první polici a vytvořte digitální dvojče knihovny.",
+    "empty_title": "Vytvořte svou první polici",
+    "empty_desc": "Organizujte knihy podle místnosti, skříně a police.",
+    "empty_model_hint": "např. Obývací pokoj → Knihovna → Police 1",
+    "empty_cta_locations": "Vytvořit první polici",
+    "empty_cta_scan": "Naskenovat polici",
+    "no_books_hint": "Všechny police jsou prázdné. Naskenujte polici nebo přidejte knihy a přiřaďte je k umístění.",
+    "no_books_cta_scan": "Naskenovat polici",
     "empty_shelf": "Prázdná police",
     "tab_shelves": "Policový pohled",
     "tab_locations": "Správa pozic"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -99,7 +99,7 @@
     "saving": "Saving...",
     "empty_cta_add": "Add book",
     "empty_cta_scan": "Scan shelf",
-    "empty_cta_location": "Create a location"
+    "empty_cta_location": "Set up shelves"
   },
   "book_detail": {
     "title": "Book details",
@@ -176,6 +176,8 @@
     "retry": "Try again",
     "empty_title": "No locations yet",
     "empty_body": "Create your first location above so you always know where your books are.",
+    "empty_example": "Example: Living room / Bookcase / Shelf 1",
+    "empty_cta": "Add your first location",
     "actions": "Actions",
     "saving": "Saving…",
     "save": "Save",
@@ -434,7 +436,9 @@
     "added_manually": "Manual",
     "remove_segment_title": "Remove this photo?",
     "remove_segment_body": "This will discard all books detected in this photo. This cannot be undone.",
-    "remove_segment_confirm": "Remove photo"
+    "remove_segment_confirm": "Remove photo",
+    "no_locations_title": "No shelves yet",
+    "no_locations_body": "Create your first shelf so scanned books have a home right away."
   },
   "add_book": {
     "page_title": "Add book",
@@ -508,8 +512,13 @@
     "title": "My bookshelves",
     "scan_shelf": "Scan shelf",
     "books_count": "books",
-    "empty_title": "No bookshelves",
-    "empty_desc": "Scan your first shelf to create a digital twin of your bookshelf.",
+    "empty_title": "Create your first shelf",
+    "empty_desc": "Organize books by room, bookcase, and shelf.",
+    "empty_model_hint": "e.g. Living room → Bookcase → Shelf 1",
+    "empty_cta_locations": "Create first shelf",
+    "empty_cta_scan": "Scan a shelf",
+    "no_books_hint": "All shelves are empty. Scan a shelf or add books, then assign them to a location.",
+    "no_books_cta_scan": "Scan a shelf",
     "empty_shelf": "Empty shelf",
     "tab_shelves": "Shelf view",
     "tab_locations": "Locations management"

--- a/frontend/src/pages/BookshelfViewPage.test.tsx
+++ b/frontend/src/pages/BookshelfViewPage.test.tsx
@@ -1,0 +1,134 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BookshelfViewPage } from './BookshelfViewPage'
+import type { Book, Location } from '../lib/types'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../hooks/useLocations', () => ({
+  useLocations: vi.fn(() => ({ data: [] })),
+}))
+
+vi.mock('../hooks/useBooks', () => ({
+  useBooksForShelf: vi.fn(() => ({ data: [] })),
+  useBulkMoveBooks: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}))
+
+vi.mock('../lib/api', () => ({
+  bulkReorderBooks: vi.fn(),
+}))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: vi.fn(
+    (selector: (s: { showError: () => void; showSuccess: () => void }) => unknown) =>
+      selector({ showError: vi.fn(), showSuccess: vi.fn() }),
+  ),
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true })),
+}))
+
+// LocationsPage is rendered on the locations tab — mock it to keep tests focused
+vi.mock('./LocationsPage', () => ({
+  LocationsPage: () => <div data-testid="locations-page-stub" />,
+}))
+
+import { useLocations } from '../hooks/useLocations'
+import { useBooksForShelf } from '../hooks/useBooks'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderPage(url = '/bookshelf') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[url]}>
+        <Routes>
+          <Route path="/bookshelf" element={<BookshelfViewPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const loc1: Location = {
+  id: 'loc-1',
+  room: 'Living Room',
+  furniture: 'Bookcase',
+  shelf: 'Shelf 1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+function makeBook(overrides?: Partial<Book>): Book {
+  return {
+    id: 'book-1',
+    title: 'Test Book',
+    author: 'Author',
+    isbn: null,
+    publisher: null,
+    language: null,
+    description: null,
+    publication_year: null,
+    cover_image_url: null,
+    location_id: 'loc-1',
+    shelf_position: 0,
+    processing_status: 'done',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('BookshelfViewPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => cleanup())
+
+  it('shows no-locations empty state with CTAs when no locations exist', () => {
+    vi.mocked(useLocations).mockReturnValue({ data: [] } as ReturnType<typeof useLocations>)
+    vi.mocked(useBooksForShelf).mockReturnValue({ data: [] } as ReturnType<typeof useBooksForShelf>)
+
+    renderPage()
+
+    expect(screen.getByTestId('bookshelf-no-locations-state')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'bookshelf.empty_cta_locations' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'bookshelf.empty_cta_scan' })).toBeInTheDocument()
+  })
+
+  it('shows no-books hint when locations exist but no books are assigned', () => {
+    vi.mocked(useLocations).mockReturnValue({ data: [loc1] } as ReturnType<typeof useLocations>)
+    vi.mocked(useBooksForShelf).mockReturnValue({ data: [] } as ReturnType<typeof useBooksForShelf>)
+
+    renderPage()
+
+    expect(screen.queryByTestId('bookshelf-no-locations-state')).not.toBeInTheDocument()
+    expect(screen.getByTestId('bookshelf-no-books-hint')).toBeInTheDocument()
+  })
+
+  it('does not show empty state or hint when locations have assigned books', () => {
+    vi.mocked(useLocations).mockReturnValue({ data: [loc1] } as ReturnType<typeof useLocations>)
+    vi.mocked(useBooksForShelf).mockReturnValue({ data: [makeBook()] } as ReturnType<typeof useBooksForShelf>)
+
+    renderPage()
+
+    expect(screen.queryByTestId('bookshelf-no-locations-state')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('bookshelf-no-books-hint')).not.toBeInTheDocument()
+  })
+
+  it('renders the LocationsPage on the locations tab', () => {
+    vi.mocked(useLocations).mockReturnValue({ data: [] } as ReturnType<typeof useLocations>)
+    vi.mocked(useBooksForShelf).mockReturnValue({ data: [] } as ReturnType<typeof useBooksForShelf>)
+
+    renderPage('/bookshelf?tab=locations')
+
+    expect(screen.getByTestId('locations-page-stub')).toBeInTheDocument()
+    expect(screen.queryByTestId('bookshelf-no-locations-state')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/BookshelfViewPage.test.tsx
+++ b/frontend/src/pages/BookshelfViewPage.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
-import { type ReactNode } from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 

--- a/frontend/src/pages/BookshelfViewPage.tsx
+++ b/frontend/src/pages/BookshelfViewPage.tsx
@@ -419,10 +419,46 @@ export function BookshelfViewPage() {
         )}
 
         {Object.keys(filteredTree).length === 0 && (
-          <div className="sh-empty-state" style={{ padding: 60 }}>
+          <div className="sh-empty-state" data-testid="bookshelf-no-locations-state" style={{ padding: 60 }}>
             <div className="sh-empty-state__icon"><EmptyShelfIcon size={56} /></div>
             <h3 className="text-h3">{t('bookshelf.empty_title')}</h3>
-            <p className="text-small">{t('bookshelf.empty_desc')}</p>
+            <p className="text-small" style={{ maxWidth: 320, textAlign: 'center' }}>{t('bookshelf.empty_desc')}</p>
+            <p style={{ fontSize: 13, color: 'var(--sh-text-muted)', textAlign: 'center', marginBottom: 0 }}>
+              {t('bookshelf.empty_model_hint')}
+            </p>
+            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', justifyContent: 'center', marginTop: 20 }}>
+              <button
+                type="button"
+                className="sh-btn-primary"
+                onClick={() => navigate(`${ROUTES.bookshelfView}?tab=locations`)}
+              >
+                {t('bookshelf.empty_cta_locations')}
+              </button>
+              <button
+                type="button"
+                className="sh-btn-secondary"
+                onClick={() => navigate(ROUTES.scanShelf)}
+              >
+                {t('bookshelf.empty_cta_scan')}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {locations.length > 0 && !allBooks.some((b) => b.location_id) && (
+          <div
+            data-testid="bookshelf-no-books-hint"
+            style={{
+              display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap',
+              padding: '12px 16px', marginBottom: 20,
+              background: 'var(--sh-teal-bg)', border: '1px solid var(--sh-border)',
+              borderRadius: 'var(--sh-radius-md)', fontSize: 14, color: 'var(--sh-text-muted)',
+            }}
+          >
+            <span style={{ flex: 1 }}>{t('bookshelf.no_books_hint')}</span>
+            <button type="button" className="sh-btn-secondary" onClick={() => navigate(ROUTES.scanShelf)} style={{ flexShrink: 0 }}>
+              {t('bookshelf.no_books_cta_scan')}
+            </button>
           </div>
         )}
 

--- a/frontend/src/pages/LocationsPage.test.tsx
+++ b/frontend/src/pages/LocationsPage.test.tsx
@@ -60,6 +60,16 @@ describe('LocationsPage', () => {
     cleanup()
   })
 
+  it('shows empty state with example and CTA when no locations exist', async () => {
+    vi.mocked(listLocations).mockResolvedValue([])
+
+    renderWithProviders(<LocationsPage />)
+
+    expect(await screen.findByTestId('locations-empty-state')).toBeInTheDocument()
+    expect(screen.getByText('locations.empty_example')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'locations.empty_cta' })).toBeInTheDocument()
+  })
+
   it('shows loading state while locations are being fetched', () => {
     vi.mocked(listLocations).mockImplementation(
       () => new Promise<Location[]>(() => undefined),

--- a/frontend/src/pages/LocationsPage.tsx
+++ b/frontend/src/pages/LocationsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { LocationPinIcon } from '../components/EmptyStateIcons'
@@ -31,6 +31,7 @@ export function LocationsPage() {
   const deleteMutation = useDeleteLocation()
   const showError = useToastStore((state) => state.showError)
 
+  const roomInputRef = useRef<HTMLInputElement>(null)
   const [createForm, setCreateForm] = useState<LocationFormValues>(EMPTY_FORM)
   const [editingLocationId, setEditingLocationId] = useState<string | null>(null)
   const [editForm, setEditForm] = useState<LocationFormValues>(EMPTY_FORM)
@@ -83,6 +84,7 @@ export function LocationsPage() {
           <div>
             <label style={{ fontSize: 12, fontWeight: 500, color: 'var(--sh-text-muted)', display: 'block', marginBottom: 6 }}>{t('locations.room')}</label>
             <input
+              ref={roomInputRef}
               className="sh-input"
               aria-label={t('locations.room')}
               required
@@ -180,12 +182,29 @@ export function LocationsPage() {
       )}
 
       {!locationsQuery.isLoading && !locationsQuery.isError && sortedLocations.length === 0 && (
-        <div style={{ textAlign: 'center', padding: '64px 24px', background: 'var(--sh-surface)', borderRadius: 'var(--sh-radius-lg)', border: '1px dashed var(--sh-border-2)' }}>
-          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 16, color: 'var(--sh-border-2)' }}><LocationPinIcon size={56} /></div>
+        <div
+          data-testid="locations-empty-state"
+          className="sh-empty-state"
+          style={{ padding: '48px 24px', background: 'var(--sh-surface)', borderRadius: 'var(--sh-radius-lg)', border: '1px dashed var(--sh-border-2)' }}
+        >
+          <div className="sh-empty-state__icon" style={{ color: 'var(--sh-border-2)' }}><LocationPinIcon size={56} /></div>
           <p className="text-h3" style={{ marginBottom: 8, color: 'var(--sh-text-main)' }}>
             {t('locations.empty_title')}
           </p>
-          <p className="text-p" style={{ color: 'var(--sh-text-muted)' }}>{t('locations.empty_body')}</p>
+          <p className="text-p" style={{ color: 'var(--sh-text-muted)', marginBottom: 4 }}>{t('locations.empty_body')}</p>
+          <p style={{ fontSize: 13, color: 'var(--sh-text-muted)', fontStyle: 'italic', marginBottom: 20 }}>
+            {t('locations.empty_example')}
+          </p>
+          <button
+            type="button"
+            className="sh-btn-primary"
+            onClick={() => {
+              roomInputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+              setTimeout(() => roomInputRef.current?.focus(), 300)
+            }}
+          >
+            {t('locations.empty_cta')}
+          </button>
         </div>
       )}
 

--- a/frontend/src/pages/ScanShelfPage.tsx
+++ b/frontend/src/pages/ScanShelfPage.tsx
@@ -54,7 +54,7 @@ export function ScanShelfPage() {
   const [searchParams] = useSearchParams()
   const showError = useToastStore(s => s.showError)
 
-  const { data: locations = [] } = useLocations()
+  const { data: locations = [], isLoading: locationsLoading } = useLocations()
   const createLocationMutation = useCreateLocation()
   const scanMutation = useScanShelf()
   const confirmMutation = useConfirmShelfScan()
@@ -132,6 +132,14 @@ export function ScanShelfPage() {
       localStorage.removeItem(SCAN_DRAFT_KEY)
     }
   }, [])
+
+  const hasAutoExpandedNewLocationRef = useRef(false)
+  useEffect(() => {
+    if (!locationsLoading && locations.length === 0 && !hasAutoExpandedNewLocationRef.current) {
+      setShowNewLocation(true)
+      hasAutoExpandedNewLocationRef.current = true
+    }
+  }, [locationsLoading, locations.length])
 
   useEffect(() => {
     const hasDraftData =
@@ -503,6 +511,20 @@ export function ScanShelfPage() {
         <div>
           <h3 className="text-h3" style={{ marginBottom: 8 }}>{t('scan.step_location')}</h3>
           <p className="text-small" style={{ color: 'var(--sh-text-muted)', marginBottom: 24 }}>{t('scan.step_location_desc')}</p>
+
+          {!locationsLoading && locations.length === 0 && (
+            <div
+              data-testid="scan-no-locations-hint"
+              style={{
+                padding: '12px 16px', marginBottom: 20,
+                background: 'var(--sh-teal-bg)', border: '1px solid var(--sh-border)',
+                borderRadius: 'var(--sh-radius-md)', fontSize: 14,
+              }}
+            >
+              <p style={{ margin: 0, fontWeight: 600, color: 'var(--sh-text-main)' }}>{t('scan.no_locations_title')}</p>
+              <p style={{ margin: '4px 0 0', color: 'var(--sh-text-muted)' }}>{t('scan.no_locations_body')}</p>
+            </div>
+          )}
 
           <div className="sh-card-panel" style={{ padding: 16, marginBottom: 16 }}>
             <div className="sh-location-grid">


### PR DESCRIPTION
## Summary

- **`/bookshelf` (no locations)**: replaced generic "No bookshelves" + single line with an action-oriented empty state — explains the room → bookcase → shelf model with an example hint, primary CTA navigates to the locations tab, secondary CTA goes to scan
- **`/bookshelf` (locations exist, no books assigned)**: soft info banner above shelves explains that scanned/added books can be assigned to locations, with a scan CTA
- **`/bookshelf?tab=locations` (no locations)**: improved empty state now uses `sh-empty-state` class for consistency, shows an example location structure ("Living room / Bookcase / Shelf 1"), and has a primary CTA button that scrolls to and focuses the Room input in the create form above
- **`/scan` (no locations)**: auto-expands the "Add new location" inline form so new users aren't stuck on empty dropdowns; adds an informational teal hint box explaining why creating a shelf helps
- **`/books`**: updated tertiary CTA copy "Create a location" → "Set up shelves" (clearer intent)
- i18n: new keys added to `en.json` and `cs.json` under `bookshelf.*`, `locations.*`, and `scan.*`

## Test plan

- [x] New `BookshelfViewPage.test.tsx` — 4 tests: no-locations state, no-books hint, normal state, locations tab
- [x] `LocationsPage.test.tsx` — added test: empty state shows example and CTA
- [x] All 125 tests pass (`npx vitest run`)
- [x] Existing `/books` empty state tests unchanged and passing

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced empty-state/onboarding UIs with clearer setup guidance, model hints, and separate CTAs for creating locations vs scanning shelves
  * Scan flow shows dedicated messaging when no locations exist; remove-segment confirmation updated
  * Auto-scroll/focus and auto-expand of the new-location input when no locations exist
* **Tests**
  * Added tests for bookshelf/locations empty states and tab navigation
* **Localization**
  * Updated Czech and English UI strings for new/edge-state messaging
* **Style**
  * Sidebar now supports vertical scrolling when content overflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->