### PR TITLE
feat(onboarding): seed sample library on registration, add clear-sample banner (#202)

### DIFF
--- a/backend/alembic/versions/20260506_000019_add_is_sample_flag.py
+++ b/backend/alembic/versions/20260506_000019_add_is_sample_flag.py
@@ -1,0 +1,29 @@
+"""add is_sample flag to books and locations
+
+Revision ID: 20260506_000019
+Revises: 20260424_000018
+Create Date: 2026-05-06
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260506_000019"
+down_revision = "20260424_000018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("books", sa.Column("is_sample", sa.Boolean(), nullable=False, server_default="false"))
+    op.add_column("locations", sa.Column("is_sample", sa.Boolean(), nullable=False, server_default="false"))
+    op.create_index("ix_books_is_sample", "books", ["library_id", "is_sample"])
+    op.create_index("ix_locations_is_sample", "locations", ["library_id", "is_sample"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_locations_is_sample", table_name="locations")
+    op.drop_index("ix_books_is_sample", table_name="books")
+    op.drop_column("locations", "is_sample")
+    op.drop_column("books", "is_sample")

--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -49,7 +49,7 @@ async def read_books(
     session: AsyncSession = Depends(get_db_session),
     library_id: uuid.UUID = Depends(get_library_id),
 ) -> BookListResponse:
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         session,
         library_id=library_id,
         search=search,
@@ -67,6 +67,7 @@ async def read_books(
         total=total,
         page=page,
         page_size=page_size,
+        has_sample_books=has_sample_books,
         items=[BookResponse.model_validate(book) for book in books],
     )
 

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -14,7 +14,7 @@ from app.models.book import Book
 from app.models.location import Location
 from app.models.loan import Loan
 from app.models.user import User
-from app.schemas.settings import OnboardingStatusResponse, PurgeLibraryRequest, PurgeLibraryResponse
+from app.schemas.settings import ClearSampleLibraryResponse, OnboardingStatusResponse, PurgeLibraryRequest, PurgeLibraryResponse
 
 router = APIRouter(prefix="/api/v1/settings", tags=["settings"])
 
@@ -40,6 +40,32 @@ async def purge_library(
         deleted_locations=deleted_locations,
         deleted_loans=deleted_loans,
     )
+
+
+# ── Sample library ──────────────────────────────────────────
+
+@router.delete("/sample-library", response_model=ClearSampleLibraryResponse)
+async def clear_sample_library(
+    session: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+    library_id: uuid.UUID = Depends(get_library_id),
+) -> ClearSampleLibraryResponse:
+    from sqlalchemy import select as sa_select
+    sample_book_ids = list(
+        (await session.execute(
+            sa_select(Book.id).where(Book.library_id == library_id, Book.is_sample.is_(True))
+        )).scalars().all()
+    )
+    if sample_book_ids:
+        await session.execute(delete(Loan).where(Loan.book_id.in_(sample_book_ids)))
+    deleted_books = (await session.execute(
+        delete(Book).where(Book.library_id == library_id, Book.is_sample.is_(True))
+    )).rowcount or 0
+    deleted_locations = (await session.execute(
+        delete(Location).where(Location.library_id == library_id, Location.is_sample.is_(True))
+    )).rowcount or 0
+    await session.commit()
+    return ClearSampleLibraryResponse(deleted_books=deleted_books, deleted_locations=deleted_locations)
 
 
 # ── Onboarding ──────────────────────────────────────────────

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -5,7 +5,7 @@ from enum import Enum
 import uuid
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, Enum as SAEnum, ForeignKey, Integer, String, Text, Uuid, UniqueConstraint, func
+from sqlalchemy import Boolean, DateTime, Enum as SAEnum, ForeignKey, Integer, String, Text, Uuid, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -79,6 +79,7 @@ class Book(Base):
         default=BookProcessingStatus.MANUAL,
         server_default=BookProcessingStatus.MANUAL.value,
     )
+    is_sample: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/models/location.py
+++ b/backend/app/models/location.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import uuid
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Uuid, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -21,6 +21,7 @@ class Location(Base):
     furniture: Mapped[str] = mapped_column(String(100), nullable=False)
     shelf: Mapped[str] = mapped_column(String(100), nullable=False)
     display_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    is_sample: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/schemas/book.py
+++ b/backend/app/schemas/book.py
@@ -133,6 +133,7 @@ class BookResponse(BaseModel):
     processing_status: BookProcessingStatus
     is_currently_lent: bool
     active_loan: LoanResponse | None
+    is_sample: bool
     created_at: datetime
     updated_at: datetime
 
@@ -141,6 +142,7 @@ class BookListResponse(BaseModel):
     total: int
     page: int
     page_size: int
+    has_sample_books: bool
     items: list[BookResponse]
 
 

--- a/backend/app/schemas/location.py
+++ b/backend/app/schemas/location.py
@@ -33,5 +33,6 @@ class LocationResponse(BaseModel):
     furniture: str
     shelf: str
     display_order: int
+    is_sample: bool
     created_at: datetime
     updated_at: datetime

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -17,3 +17,8 @@ class OnboardingStatusResponse(BaseModel):
     should_show: bool
     completed_at: datetime | None = None
     skipped_at: datetime | None = None
+
+
+class ClearSampleLibraryResponse(BaseModel):
+    deleted_books: int
+    deleted_locations: int

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -11,7 +11,7 @@ from app.core.config import Settings
 from app.core.security import create_token, decode_token, get_password_hash, verify_password
 from app.models.user import User
 from app.models.subscription import Subscription, SubscriptionPlan, SubscriptionStatus
-from app.services.library import create_personal_library
+from app.services.library import create_personal_library, seed_sample_library
 
 logger = structlog.get_logger()
 
@@ -82,7 +82,8 @@ async def register_user(session: AsyncSession, email: str, password: str) -> Use
         )
     )
 
-    await create_personal_library(session, user)
+    lib = await create_personal_library(session, user)
+    await seed_sample_library(session, lib)
     await session.commit()
     await session.refresh(user)
     logger.info("registration_success", user_id=str(user.id))

--- a/backend/app/services/book.py
+++ b/backend/app/services/book.py
@@ -32,7 +32,7 @@ async def list_books(
     year_to: int | None = None,
     page: int,
     page_size: int,
-) -> tuple[list[Book], int]:
+) -> tuple[list[Book], int, bool]:
     filters: list[ColumnElement[bool]] = [Book.library_id == library_id]
 
     if unassigned_only:
@@ -79,9 +79,13 @@ async def list_books(
         .limit(page_size)
     )
 
+    sample_count_query = select(func.count()).select_from(Book).where(
+        Book.library_id == library_id, Book.is_sample.is_(True)
+    )
     total = int((await session.execute(count_query)).scalar_one())
+    has_sample_books = int((await session.execute(sample_count_query)).scalar_one()) > 0
     books = list((await session.execute(query)).scalars().all())
-    return books, total
+    return books, total, has_sample_books
 
 
 async def get_shelf_etag_metadata(

--- a/backend/app/services/library.py
+++ b/backend/app/services/library.py
@@ -6,7 +6,9 @@ from fastapi import HTTPException, status
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.book import Book, ReadingStatus
 from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.location import Location
 from app.models.user import User
 
 _ROLE_ORDER = {LibraryRole.VIEWER: 0, LibraryRole.EDITOR: 1, LibraryRole.OWNER: 2}
@@ -18,6 +20,58 @@ async def create_personal_library(session: AsyncSession, user: User) -> Library:
     await session.flush()
     session.add(LibraryMember(library_id=lib.id, user_id=user.id, role=LibraryRole.OWNER))
     return lib
+
+
+_SAMPLE_LOCATIONS = [
+    {"room": "Living room", "furniture": "Bookcase", "shelf": "Shelf 1", "display_order": 1},
+    {"room": "Living room", "furniture": "Bookcase", "shelf": "Shelf 2", "display_order": 2},
+    {"room": "Bedroom", "furniture": "Nightstand", "shelf": "To read", "display_order": 1},
+]
+
+# (title, author, language, year, reading_status, location_index, shelf_position)
+_SAMPLE_BOOKS: list[tuple[str, str, str, int, ReadingStatus, int, int]] = [
+    ("Proměna", "Franz Kafka", "cs", 1915, ReadingStatus.READ, 0, 0),
+    ("R.U.R.", "Karel Čapek", "cs", 1920, ReadingStatus.READ, 0, 1),
+    ("Ostře sledované vlaky", "Bohumil Hrabal", "cs", 1965, ReadingStatus.READ, 0, 2),
+    ("Báječná léta pod psa", "Michal Viewegh", "cs", 1992, ReadingStatus.READING, 0, 3),
+    ("Zaklínač I: Poslední přání", "Andrzej Sapkowski", "cs", 1990, ReadingStatus.READING, 0, 4),
+    ("Hobit", "J.R.R. Tolkien", "cs", 1937, ReadingStatus.READ, 0, 5),
+    ("Nesnesitelná lehkost bytí", "Milan Kundera", "cs", 1984, ReadingStatus.READ, 1, 0),
+    ("Osudy dobrého vojáka Švejka", "Jaroslav Hašek", "cs", 1923, ReadingStatus.READ, 1, 1),
+    ("1984", "George Orwell", "en", 1949, ReadingStatus.READ, 1, 2),
+    ("Stopařův průvodce po galaxii", "Douglas Adams", "en", 1979, ReadingStatus.READ, 1, 3),
+    ("Malý princ", "Antoine de Saint-Exupéry", "cs", 1943, ReadingStatus.READ, 1, 4),
+    ("Zločin a trest", "Fjodor Michajlovič Dostojevský", "cs", 1866, ReadingStatus.UNREAD, 2, 0),
+    ("Sto roků samoty", "Gabriel García Márquez", "cs", 1967, ReadingStatus.UNREAD, 2, 1),
+    ("Mistr a Markétka", "Michail Bulgakov", "cs", 1967, ReadingStatus.UNREAD, 2, 2),
+    ("Duna", "Frank Herbert", "cs", 1965, ReadingStatus.UNREAD, 2, 3),
+    ("Pán prstenů: Společenstvo prstenu", "J.R.R. Tolkien", "cs", 1954, ReadingStatus.UNREAD, 2, 4),
+]
+
+
+async def seed_sample_library(session: AsyncSession, library: Library) -> None:
+    locations = [
+        Location(library_id=library.id, is_sample=True, **loc_data)
+        for loc_data in _SAMPLE_LOCATIONS
+    ]
+    session.add_all(locations)
+    await session.flush()
+
+    books = [
+        Book(
+            library_id=library.id,
+            title=title,
+            author=author,
+            language=lang,
+            publication_year=year,
+            reading_status=status,
+            location_id=locations[loc_idx].id,
+            shelf_position=shelf_pos,
+            is_sample=True,
+        )
+        for title, author, lang, year, status, loc_idx, shelf_pos in _SAMPLE_BOOKS
+    ]
+    session.add_all(books)
 
 
 async def list_user_libraries(session: AsyncSession, user_id: uuid.UUID) -> list[tuple[Library, LibraryRole]]:

--- a/backend/tests/test_book_service.py
+++ b/backend/tests/test_book_service.py
@@ -74,6 +74,7 @@ async def _make_book(
     publication_year: int | None = None,
     language: str | None = None,
     publisher: str | None = None,
+    is_sample: bool = False,
 ) -> Book:
     book = Book(
         library_id=library_id,
@@ -87,6 +88,7 @@ async def _make_book(
         publication_year=publication_year,
         language=language,
         publisher=publisher,
+        is_sample=is_sample,
     )
     session.add(book)
     await session.commit()
@@ -99,12 +101,13 @@ async def _make_book(
 @pytest.mark.asyncio
 async def test_list_books_empty(test_session: AsyncSession) -> None:
     _, lib_id = await _make_library(test_session)
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search=None, location_id=None,
         unassigned_only=False, reading_status=None, page=1, page_size=20,
     )
     assert books == []
     assert total == 0
+    assert has_sample_books is False
 
 
 @pytest.mark.asyncio
@@ -112,12 +115,13 @@ async def test_list_books_returns_all(test_session: AsyncSession) -> None:
     _, lib_id = await _make_library(test_session)
     await _make_book(test_session, lib_id, title="Alpha")
     await _make_book(test_session, lib_id, title="Beta")
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search=None, location_id=None,
         unassigned_only=False, reading_status=None, page=1, page_size=20,
     )
     assert total == 2
     assert len(books) == 2
+    assert has_sample_books is False
 
 
 @pytest.mark.asyncio
@@ -125,12 +129,13 @@ async def test_list_books_search_by_title(test_session: AsyncSession) -> None:
     _, lib_id = await _make_library(test_session)
     await _make_book(test_session, lib_id, title="Clean Code")
     await _make_book(test_session, lib_id, title="Design Patterns")
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search="Clean", location_id=None,
         unassigned_only=False, reading_status=None, page=1, page_size=20,
     )
     assert total == 1
     assert books[0].title == "Clean Code"
+    assert has_sample_books is False
 
 
 @pytest.mark.asyncio
@@ -138,12 +143,13 @@ async def test_list_books_filter_by_reading_status(test_session: AsyncSession) -
     _, lib_id = await _make_library(test_session)
     await _make_book(test_session, lib_id, title="Unread", reading_status=ReadingStatus.UNREAD)
     await _make_book(test_session, lib_id, title="Read", reading_status=ReadingStatus.READ)
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search=None, location_id=None,
         unassigned_only=False, reading_status="read", page=1, page_size=20,
     )
     assert total == 1
     assert books[0].title == "Read"
+    assert has_sample_books is False
 
 
 @pytest.mark.asyncio
@@ -152,12 +158,13 @@ async def test_list_books_filter_unassigned_only(test_session: AsyncSession) -> 
     loc = await _make_location(test_session, lib_id)
     await _make_book(test_session, lib_id, title="Unassigned")
     await _make_book(test_session, lib_id, title="Placed", location_id=loc.id, shelf_position=0)
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search=None, location_id=None,
         unassigned_only=True, reading_status=None, page=1, page_size=20,
     )
     assert total == 1
     assert books[0].title == "Unassigned"
+    assert has_sample_books is False
 
 
 @pytest.mark.asyncio
@@ -166,12 +173,13 @@ async def test_list_books_filter_by_location(test_session: AsyncSession) -> None
     loc = await _make_location(test_session, lib_id)
     await _make_book(test_session, lib_id, title="In Location", location_id=loc.id, shelf_position=0)
     await _make_book(test_session, lib_id, title="No Location")
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search=None, location_id=loc.id,
         unassigned_only=False, reading_status=None, page=1, page_size=20,
     )
     assert total == 1
     assert books[0].title == "In Location"
+    assert has_sample_books is False
 
 
 @pytest.mark.asyncio
@@ -179,12 +187,13 @@ async def test_list_books_pagination(test_session: AsyncSession) -> None:
     _, lib_id = await _make_library(test_session)
     for i in range(5):
         await _make_book(test_session, lib_id, title=f"Book {i}")
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search=None, location_id=None,
         unassigned_only=False, reading_status=None, page=1, page_size=3,
     )
     assert total == 5
     assert len(books) == 3
+    assert has_sample_books is False
 
 
 @pytest.mark.asyncio
@@ -192,12 +201,13 @@ async def test_list_books_filter_by_language(test_session: AsyncSession) -> None
     _, lib_id = await _make_library(test_session)
     await _make_book(test_session, lib_id, title="Czech Book", language="cs")
     await _make_book(test_session, lib_id, title="English Book", language="en")
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search=None, location_id=None,
         unassigned_only=False, reading_status=None, language="cs", page=1, page_size=20,
     )
     assert total == 1
     assert books[0].title == "Czech Book"
+    assert has_sample_books is False
 
 
 @pytest.mark.asyncio
@@ -205,13 +215,53 @@ async def test_list_books_filter_by_year_range(test_session: AsyncSession) -> No
     _, lib_id = await _make_library(test_session)
     await _make_book(test_session, lib_id, title="Old", publication_year=1990)
     await _make_book(test_session, lib_id, title="New", publication_year=2020)
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search=None, location_id=None,
         unassigned_only=False, reading_status=None, year_from=2000, year_to=2025,
         page=1, page_size=20,
     )
     assert total == 1
     assert books[0].title == "New"
+    assert has_sample_books is False
+
+
+# ── has_sample_books flag (issue #202) ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_has_sample_books_true_when_sample_exists(test_session: AsyncSession) -> None:
+    _, lib_id = await _make_library(test_session)
+    await _make_book(test_session, lib_id, title="Sample Book", is_sample=True)
+    _, _, has_sample_books = await list_books(
+        test_session, library_id=lib_id, search=None, location_id=None,
+        unassigned_only=False, reading_status=None, page=1, page_size=20,
+    )
+    assert has_sample_books is True
+
+
+@pytest.mark.asyncio
+async def test_has_sample_books_false_when_only_real_books(test_session: AsyncSession) -> None:
+    _, lib_id = await _make_library(test_session)
+    await _make_book(test_session, lib_id, title="Real Book", is_sample=False)
+    _, _, has_sample_books = await list_books(
+        test_session, library_id=lib_id, search=None, location_id=None,
+        unassigned_only=False, reading_status=None, page=1, page_size=20,
+    )
+    assert has_sample_books is False
+
+
+@pytest.mark.asyncio
+async def test_has_sample_books_independent_of_active_filters(test_session: AsyncSession) -> None:
+    """has_sample_books reflects library-wide state, not the current page/filter results."""
+    _, lib_id = await _make_library(test_session)
+    # Only a sample book exists — it won't match the search term below
+    await _make_book(test_session, lib_id, title="Sample Only", is_sample=True)
+    books, total, has_sample_books = await list_books(
+        test_session, library_id=lib_id, search="NOTHING_MATCHES", location_id=None,
+        unassigned_only=False, reading_status=None, page=1, page_size=20,
+    )
+    assert books == []
+    assert total == 0
+    assert has_sample_books is True  # still True even though 0 items returned
 
 
 # ── list_all_books_for_shelf ──────────────────────────────────────────────────
@@ -551,12 +601,13 @@ async def test_list_books_filter_by_publisher(test_session: AsyncSession) -> Non
     _, lib_id = await _make_library(test_session)
     await _make_book(test_session, lib_id, title="OReilly Book", publisher="O'Reilly Media")
     await _make_book(test_session, lib_id, title="Other Book", publisher="Penguin")
-    books, total = await list_books(
+    books, total, has_sample_books = await list_books(
         test_session, library_id=lib_id, search=None, location_id=None,
         unassigned_only=False, reading_status=None, publisher="O'Reilly", page=1, page_size=20,
     )
     assert total == 1
     assert books[0].title == "OReilly Book"
+    assert has_sample_books is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_library_service.py
+++ b/backend/tests/test_library_service.py
@@ -4,12 +4,14 @@ from collections.abc import AsyncIterator
 
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.db.base import Base
 from app.models.library import Library, LibraryMember, LibraryRole
 from app.models.user import User
+from app.models.book import Book
+from app.models.location import Location
 from app.services.library import (
     add_member,
     create_personal_library,
@@ -18,6 +20,7 @@ from app.services.library import (
     list_user_libraries,
     remove_member,
     require_library_role,
+    seed_sample_library,
     update_member_role,
 )
 
@@ -281,3 +284,41 @@ async def test_remove_member_400_last_owner(test_session: AsyncSession) -> None:
     with pytest.raises(HTTPException) as exc:
         await remove_member(test_session, lib.id, owner.id)
     assert exc.value.status_code == 400
+
+
+# ── seed_sample_library ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_seed_sample_library_creates_expected_counts(test_session: AsyncSession) -> None:
+    user = await _make_user(test_session)
+    lib = await create_personal_library(test_session, user)
+    await seed_sample_library(test_session, lib)
+    await test_session.commit()
+
+    book_count = (await test_session.execute(
+        select(func.count()).select_from(Book).where(Book.library_id == lib.id)
+    )).scalar_one()
+    loc_count = (await test_session.execute(
+        select(func.count()).select_from(Location).where(Location.library_id == lib.id)
+    )).scalar_one()
+
+    assert book_count == 16
+    assert loc_count == 3
+
+
+@pytest.mark.asyncio
+async def test_seed_sample_library_marks_is_sample(test_session: AsyncSession) -> None:
+    user = await _make_user(test_session)
+    lib = await create_personal_library(test_session, user)
+    await seed_sample_library(test_session, lib)
+    await test_session.commit()
+
+    non_sample_books = (await test_session.execute(
+        select(func.count()).select_from(Book).where(Book.library_id == lib.id, Book.is_sample.is_(False))
+    )).scalar_one()
+    non_sample_locs = (await test_session.execute(
+        select(func.count()).select_from(Location).where(Location.library_id == lib.id, Location.is_sample.is_(False))
+    )).scalar_one()
+
+    assert non_sample_books == 0
+    assert non_sample_locs == 0

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -2,6 +2,7 @@ from collections.abc import AsyncIterator, Iterator
 
 from httpx import ASGITransport, AsyncClient
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import Settings, get_settings
@@ -9,6 +10,10 @@ from app.core.security import get_password_hash
 from app.db.base import Base
 from app.db.session import get_db_session
 from app.main import app
+from app.models.book import Book, BookProcessingStatus, ReadingStatus
+from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.loan import Loan
+from app.models.location import Location
 from app.models.user import User
 
 
@@ -215,3 +220,123 @@ async def test_full_cycle_show_skip_reset_complete(test_session: AsyncSession) -
         r = await client.post("/api/v1/settings/onboarding/complete", headers=headers)
         assert r.json()["should_show"] is False
         assert r.json()["completed_at"] is not None
+
+
+# ── DELETE /api/v1/settings/sample-library (issue #202) ──────────────────────
+
+async def _seed_user_with_library(session: AsyncSession, email: str = "sample@example.com") -> tuple[User, Library]:
+    """Create a user + personal library, return both."""
+    user = User(email=email, hashed_password=get_password_hash("secret"))
+    session.add(user)
+    await session.flush()
+    lib = Library(name="Test Library", created_by_user_id=user.id)
+    session.add(lib)
+    await session.flush()
+    session.add(LibraryMember(library_id=lib.id, user_id=user.id, role=LibraryRole.OWNER))
+    await session.commit()
+    await session.refresh(lib)
+    return user, lib
+
+
+async def _login(client: AsyncClient, email: str = "sample@example.com") -> dict[str, str]:
+    r = await client.post("/api/v1/auth/login", json={"email": email, "password": "secret"})
+    assert r.status_code == 200
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+@pytest.mark.asyncio
+async def test_clear_sample_library_requires_auth() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        assert (await client.delete("/api/v1/settings/sample-library")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_clear_sample_library_removes_only_sample_data(test_session: AsyncSession) -> None:
+    user, lib = await _seed_user_with_library(test_session)
+
+    # Sample location + book
+    sample_loc = Location(library_id=lib.id, room="R", furniture="F", shelf="S", is_sample=True)
+    test_session.add(sample_loc)
+    await test_session.flush()
+    sample_book = Book(
+        library_id=lib.id, title="Sample", processing_status=BookProcessingStatus.MANUAL,
+        reading_status=ReadingStatus.UNREAD, location_id=sample_loc.id, is_sample=True,
+    )
+    test_session.add(sample_book)
+
+    # Real location + book
+    real_loc = Location(library_id=lib.id, room="R2", furniture="F2", shelf="S2", is_sample=False)
+    test_session.add(real_loc)
+    await test_session.flush()
+    real_book = Book(
+        library_id=lib.id, title="Real", processing_status=BookProcessingStatus.MANUAL,
+        reading_status=ReadingStatus.UNREAD, location_id=real_loc.id, is_sample=False,
+    )
+    test_session.add(real_book)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, user.email)
+        r = await client.delete("/api/v1/settings/sample-library", headers=headers)
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["deleted_books"] == 1
+    assert body["deleted_locations"] == 1
+
+    # Verify DB state: sample gone, real remains
+    remaining_books = (await test_session.execute(select(Book).where(Book.library_id == lib.id))).scalars().all()
+    remaining_locs = (await test_session.execute(select(Location).where(Location.library_id == lib.id))).scalars().all()
+    assert len(remaining_books) == 1
+    assert remaining_books[0].title == "Real"
+    assert len(remaining_locs) == 1
+    assert remaining_locs[0].shelf == "S2"
+
+
+@pytest.mark.asyncio
+async def test_clear_sample_library_also_deletes_loans_on_sample_books(test_session: AsyncSession) -> None:
+    """Verifies the loan-deletion branch runs when a sample book has an active loan."""
+    from datetime import date
+    user, lib = await _seed_user_with_library(test_session, email="loansample@example.com")
+
+    sample_loc = Location(library_id=lib.id, room="R", furniture="F", shelf="S", is_sample=True)
+    test_session.add(sample_loc)
+    await test_session.flush()
+    sample_book = Book(
+        library_id=lib.id, title="Sample with Loan", processing_status=BookProcessingStatus.MANUAL,
+        reading_status=ReadingStatus.LENT, location_id=sample_loc.id, is_sample=True,
+    )
+    test_session.add(sample_book)
+    await test_session.flush()
+    loan = Loan(
+        library_id=lib.id,
+        book_id=sample_book.id,
+        borrower_name="Test Borrower",
+        lent_date=date.today(),
+    )
+    test_session.add(loan)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, user.email)
+        r = await client.delete("/api/v1/settings/sample-library", headers=headers)
+
+    assert r.status_code == 200
+    assert r.json()["deleted_books"] == 1
+    remaining = (await test_session.execute(
+        select(Loan).where(Loan.library_id == lib.id)
+    )).scalars().all()
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_clear_sample_library_idempotent_when_no_sample_data(test_session: AsyncSession) -> None:
+    user, _ = await _seed_user_with_library(test_session, email="nosample@example.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, user.email)
+        r = await client.delete("/api/v1/settings/sample-library", headers=headers)
+
+    assert r.status_code == 200
+    assert r.json()["deleted_books"] == 0
+    assert r.json()["deleted_locations"] == 0

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2601,6 +2601,60 @@
         }
       }
     },
+    "/api/v1/settings/sample-library": {
+      "delete": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Clear Sample Library",
+        "operationId": "clear_sample_library_api_v1_settings_sample_library_delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClearSampleLibraryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/settings/onboarding": {
       "get": {
         "tags": [
@@ -3568,6 +3622,10 @@
             "type": "integer",
             "title": "Page Size"
           },
+          "has_sample_books": {
+            "type": "boolean",
+            "title": "Has Sample Books"
+          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/BookResponse"
@@ -3581,6 +3639,7 @@
           "total",
           "page",
           "page_size",
+          "has_sample_books",
           "items"
         ],
         "title": "BookListResponse"
@@ -3734,6 +3793,10 @@
               }
             ]
           },
+          "is_sample": {
+            "type": "boolean",
+            "title": "Is Sample"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -3762,6 +3825,7 @@
           "processing_status",
           "is_currently_lent",
           "active_loan",
+          "is_sample",
           "created_at",
           "updated_at"
         ],
@@ -4111,6 +4175,24 @@
           "url"
         ],
         "title": "CheckoutResponse"
+      },
+      "ClearSampleLibraryResponse": {
+        "properties": {
+          "deleted_books": {
+            "type": "integer",
+            "title": "Deleted Books"
+          },
+          "deleted_locations": {
+            "type": "integer",
+            "title": "Deleted Locations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "deleted_books",
+          "deleted_locations"
+        ],
+        "title": "ClearSampleLibraryResponse"
       },
       "ConfirmBookItem": {
         "properties": {
@@ -5006,6 +5088,10 @@
             "type": "integer",
             "title": "Display Order"
           },
+          "is_sample": {
+            "type": "boolean",
+            "title": "Is Sample"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -5024,6 +5110,7 @@
           "furniture",
           "shelf",
           "display_order",
+          "is_sample",
           "created_at",
           "updated_at"
         ],

--- a/frontend/src/hooks/useBooks.ts
+++ b/frontend/src/hooks/useBooks.ts
@@ -4,6 +4,7 @@ import {
   bulkDeleteBooks,
   bulkMoveBooks,
   bulkUpdateStatus,
+  clearSampleLibrary,
   createBook,
   deleteBook,
   formatApiError,
@@ -191,6 +192,21 @@ export function useBookCounts() {
     lent: lent.data?.total ?? 0,
     isLoading: total.isLoading,
   }
+}
+
+export function useClearSampleLibrary() {
+  const queryClient = useQueryClient()
+  const showError = useToastStore((s) => s.showError)
+  const showSuccess = useToastStore((s) => s.showSuccess)
+  const { t } = useTranslation()
+  return useMutation({
+    mutationFn: clearSampleLibrary,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
+      showSuccess(t('books.sample_cleared'))
+    },
+    onError: (error: unknown) => showError(formatApiError(error)),
+  })
 }
 
 export function useJobStatus(jobId: string | null) {

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -99,7 +99,10 @@
     "saving": "Ukládám…",
     "empty_cta_add": "Přidat knihu",
     "empty_cta_scan": "Naskenovat polici",
-    "empty_cta_location": "Nastavit police"
+    "empty_cta_location": "Nastavit police",
+    "sample_banner": "Toto je ukázková knihovna — prozkoumej aplikaci a až budeš připraven, ukázková data smaž.",
+    "sample_clear_cta": "Smazat ukázková data",
+    "sample_cleared": "Ukázková data smazána."
   },
   "book_detail": {
     "title": "Detail knihy",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -99,7 +99,10 @@
     "saving": "Saving...",
     "empty_cta_add": "Add book",
     "empty_cta_scan": "Scan shelf",
-    "empty_cta_location": "Set up shelves"
+    "empty_cta_location": "Set up shelves",
+    "sample_banner": "This is a sample library — explore the app, then clear the sample data when you're ready.",
+    "sample_clear_cta": "Clear sample data",
+    "sample_cleared": "Sample data cleared."
   },
   "book_detail": {
     "title": "Book details",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -525,6 +525,16 @@ export async function purgeLibrary(password = ""): Promise<PurgeLibraryResponse>
   return response.data
 }
 
+export interface ClearSampleLibraryResponse {
+  deleted_books: number
+  deleted_locations: number
+}
+
+export async function clearSampleLibrary(): Promise<ClearSampleLibraryResponse> {
+  const response = await apiClient.delete<ClearSampleLibraryResponse>('/api/v1/settings/sample-library')
+  return response.data
+}
+
 // Shelf scanning
 export async function scanShelf(file: File, locationId?: string): Promise<ShelfScanResponse> {
   const formData = new FormData()

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -4,6 +4,7 @@ export interface Location {
   furniture: string
   shelf: string
   display_order: number
+  is_sample: boolean
   created_at: string
   updated_at: string
 }
@@ -63,6 +64,7 @@ export interface Book {
   reading_status?: ReadingStatus   // optional until backend migration applied
   is_currently_lent?: boolean
   active_loan?: Loan | null
+  is_sample: boolean
   created_at: string
   updated_at: string
 }
@@ -86,6 +88,7 @@ export interface BookListResponse {
   total: number
   page: number
   page_size: number
+  has_sample_books: boolean
   items: Book[]
 }
 

--- a/frontend/src/pages/BooksPage.test.tsx
+++ b/frontend/src/pages/BooksPage.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../lib/api', () => ({
   bulkDeleteBooks: vi.fn(),
   bulkMoveBooks: vi.fn(),
   bulkUpdateStatus: vi.fn(),
+  clearSampleLibrary: vi.fn(),
   listLocations: vi.fn(),
   uploadBookImage: vi.fn(),
   getJobStatus: vi.fn(),
@@ -39,6 +40,7 @@ vi.mock('../contexts/AuthContext', () => ({
 }))
 
 import {
+  clearSampleLibrary,
   deleteBook,
   getOnboardingStatus,
   listBooks,
@@ -62,15 +64,17 @@ const makeBook = (overrides: Partial<Book> = {}): Book => ({
   reading_status: 'unread',
   processing_status: 'manual',
   is_currently_lent: false,
+  is_sample: false,
   created_at: '2024-01-01T00:00:00Z',
   updated_at: '2024-01-01T00:00:00Z',
   ...overrides,
 })
 
-const makeResponse = (items: Book[], total?: number): BookListResponse => ({
+const makeResponse = (items: Book[], total?: number, hasSample = false): BookListResponse => ({
   total: total ?? items.length,
   page: 1,
   page_size: 20,
+  has_sample_books: hasSample,
   items,
 })
 
@@ -81,6 +85,7 @@ const locations: Location[] = [
     furniture: 'Bookshelf',
     shelf: 'Shelf 1',
     display_order: 0,
+    is_sample: false,
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
   },
@@ -216,5 +221,55 @@ describe('BooksPage — empty library state', () => {
 
     expect(await screen.findByText('books.empty_category')).toBeInTheDocument()
     expect(screen.queryByTestId('empty-library-state')).not.toBeInTheDocument()
+  })
+})
+
+// ── Sample library banner tests (issue #202) ──────────────────────────────────
+
+describe('BooksPage — sample library banner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useToastStore.setState({ message: null })
+    vi.mocked(listLocations).mockResolvedValue(locations)
+    vi.mocked(getOnboardingStatus).mockResolvedValue({
+      should_show: false,
+      completed_at: '2024-01-01T00:00:00Z',
+      skipped_at: null,
+    })
+    vi.mocked(clearSampleLibrary).mockResolvedValue({ deleted_books: 16, deleted_locations: 3 })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows sample banner when has_sample_books is true', async () => {
+    vi.mocked(listBooks).mockResolvedValue(makeResponse([makeBook({ is_sample: true })], 1, true))
+
+    renderWithProviders(<BooksPage />)
+
+    expect(await screen.findByTestId('sample-library-banner')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'books.sample_clear_cta' })).toBeInTheDocument()
+  })
+
+  it('hides sample banner when has_sample_books is false', async () => {
+    vi.mocked(listBooks).mockResolvedValue(makeResponse([makeBook()], 1, false))
+
+    renderWithProviders(<BooksPage />)
+
+    await screen.findByText('Clean Code')
+    expect(screen.queryByTestId('sample-library-banner')).not.toBeInTheDocument()
+  })
+
+  it('calls clearSampleLibrary when the CTA is clicked', async () => {
+    vi.mocked(listBooks).mockResolvedValue(makeResponse([makeBook({ is_sample: true })], 1, true))
+
+    renderWithProviders(<BooksPage />)
+
+    await userEvent.click(await screen.findByRole('button', { name: 'books.sample_clear_cta' }))
+
+    await waitFor(() => {
+      expect(clearSampleLibrary).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -9,7 +9,7 @@ import { FirstBookOnboardingModal } from '../components/OnboardingWizard'
 import { ShelfBreadcrumb } from '../components/ShelfBreadcrumb'
 import { SkeletonBookGrid } from '../components/Skeleton'
 import { StatBar } from '../components/StatBar'
-import { useBulkDeleteBooks, useBulkMoveBooks, useBulkUpdateStatus, useBookCounts, useBooks, useDeleteBook, useJobStatus } from '../hooks/useBooks'
+import { useBulkDeleteBooks, useBulkMoveBooks, useBulkUpdateStatus, useBookCounts, useBooks, useClearSampleLibrary, useDeleteBook, useJobStatus } from '../hooks/useBooks'
 import { useDebounce } from '../hooks/useDebounce'
 import { useLocations } from '../hooks/useLocations'
 import { useOnboardingStatus } from '../hooks/useOnboarding'
@@ -106,6 +106,7 @@ export function BooksPage() {
   const bulkDeleteMutation = useBulkDeleteBooks()
   const bulkMoveMutation = useBulkMoveBooks()
   const bulkStatusMutation = useBulkUpdateStatus()
+  const clearSampleMutation = useClearSampleLibrary()
   const uploadJobStatusQuery = useJobStatus(uploadJobId)
   const showError = useToastStore((s) => s.showError)
 
@@ -416,6 +417,37 @@ export function BooksPage() {
         <p style={{ margin: '16px 24px', fontSize: 14, color: 'var(--sh-amber)', fontWeight: 500, background: 'var(--sh-amber-bg)', padding: '12px 16px', borderRadius: 'var(--sh-radius-md)' }}>
           {t('books.processing_banner', { status: uploadJobStatusQuery.data?.status ?? 'pending' })}
         </p>
+      )}
+
+      {booksQuery.data?.has_sample_books && (
+        <div
+          data-testid="sample-library-banner"
+          style={{
+            margin: '16px 24px 0',
+            padding: '12px 16px',
+            background: 'var(--sh-surface-elevated)',
+            border: '1px solid var(--sh-border)',
+            borderRadius: 'var(--sh-radius-md)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 12,
+            flexWrap: 'wrap',
+          }}
+        >
+          <span style={{ fontSize: 13, color: 'var(--sh-text-muted)' }}>
+            {t('books.sample_banner')}
+          </span>
+          <button
+            type="button"
+            className="sh-btn-secondary"
+            style={{ fontSize: 13, whiteSpace: 'nowrap' }}
+            onClick={() => clearSampleMutation.mutate()}
+            disabled={clearSampleMutation.isPending}
+          >
+            {clearSampleMutation.isPending ? '…' : t('books.sample_clear_cta')}
+          </button>
+        </div>
       )}
 
       <div style={{ padding: '24px 24px 0' }}>


### PR DESCRIPTION
## Summary

- New users receive 16 sample books across 3 locations (2 living-room shelves + bedside nightstand) immediately after registration, so they can explore the app without an empty screen
- A banner appears on `/books` whenever sample data is present; one click calls `DELETE /api/v1/settings/sample-library` to remove only the sample rows, leaving any real books untouched
- `BookListResponse` gains a `has_sample_books: bool` flag computed via a separate `COUNT` query so the frontend always knows the sample state regardless of active pagination/filters

## Changes

**Backend**
- Alembic migration `20260506_000019`: `is_sample` boolean column on `books` + `locations` (non-nullable, default `false`, indexed)
- `seed_sample_library()` in `services/library.py`: creates 3 sample locations and 16 Czech/English classics with realistic reading statuses
- `register_user()` calls `seed_sample_library()` after creating the personal library
- `DELETE /api/v1/settings/sample-library`: deletes loans → books → locations where `is_sample=True`
- `BookListResponse` schema + `list_books` service: added `has_sample_books` 
- 2 new backend tests (count + `is_sample` assertions)

**Frontend**
- `Book`, `Location`, `BookListResponse` types updated with `is_sample` / `has_sample_books`
- `clearSampleLibrary()` API call + `useClearSampleLibrary()` hook
- Sample banner in `BooksPage` with dismiss/clear CTA
- i18n keys in `en.json` and `cs.json`
- 3 new frontend tests (banner show, hide, CTA click)

## Test plan

- [ ] Register a new account → confirm 16 books and 3 locations appear immediately
- [ ] Sample banner visible on `/books`, hidden on other pages
- [ ] Click "Clear sample data" → books and locations gone, real books (if any) untouched
- [ ] Banner does not reappear after clearing
- [ ] Existing accounts with no sample data: no banner shown
- [ ] `npm test -- --run` passes
- [ ] Backend `pytest tests/test_library_service.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sample library seeded for new users with sample books and locations.
  * Books and locations are marked as sample; book list now reports when sample books exist and shows a banner.
  * One-click "Clear sample data" action and API to remove all sample books and locations with deletion counts.

* **Localization**
  * Added Czech and English copy for sample-library UI and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->