### PR TITLE
fix(bookshelf): repair scroll-to-book broken by dnd-kit wrapper divs (#218)

### DIFF
--- a/frontend/src/pages/BookshelfViewPage.tsx
+++ b/frontend/src/pages/BookshelfViewPage.tsx
@@ -62,12 +62,6 @@ export function BookshelfViewPage() {
 
   const targetLocationId = preselectedLocationId ?? highlightedBook?.location_id ?? null
 
-  const highlightedBookReady = Boolean(
-    highlightBookId &&
-    targetLocationId &&
-    localByLocation[targetLocationId]?.some((b) => b.id === highlightBookId),
-  )
-
   const [selectedRoom, setSelectedRoom] = useState<string>('')
   const [selectMode, setSelectMode] = useState(false)
   const [reorderMode, setReorderMode] = useState(false)
@@ -128,6 +122,12 @@ export function BookshelfViewPage() {
 
   const [localByLocation, setLocalByLocation] = useState<Record<string, Book[]>>({})
   useEffect(() => setLocalByLocation(booksByLocation), [booksByLocation])
+
+  const highlightedBookReady = Boolean(
+    highlightBookId &&
+    targetLocationId &&
+    booksByLocation[targetLocationId]?.some((b) => b.id === highlightBookId),
+  )
 
   const originalBookById = useMemo(() => {
     const map = new Map<string, { location_id: string | null; shelf_position: number | null }>()
@@ -202,7 +202,9 @@ export function BookshelfViewPage() {
       const spine = highlightSpineRef.current
       if (!row || !spine || cancelled) return
 
-      row.scrollTo({ left: Math.max(0, spine.offsetLeft - 24), behavior: 'smooth' })
+      const spineRect = spine.getBoundingClientRect()
+      const rowRect = row.getBoundingClientRect()
+      row.scrollTo({ left: Math.max(0, row.scrollLeft + spineRect.left - rowRect.left - 24), behavior: 'smooth' })
     }
 
     run()


### PR DESCRIPTION
Fixes #218

## Root causes

**Bug 1 — TDZ forward reference**

`highlightedBookReady` was declared at component top level but read `localByLocation`, which was only declared ~65 lines later. On the first render `targetLocationId` is `null` so the short-circuit saved us. Once data loaded both values became truthy, hitting the TDZ and throwing a `ReferenceError`.

Fix: moved the declaration to after `booksByLocation` / `localByLocation` and switched it to use the stable `booksByLocation` useMemo value (same data, no async lag).

**Bug 2 — wrong `offsetLeft`**

`spine.offsetLeft` returns the offset relative to `offsetParent`, which is the nearest positioned ancestor. dnd-kit's `SortableBookSpine` wrapper injects `<div>` elements with `transform` CSS, which creates an intermediate stacking/positioning context. So `spine.offsetLeft` was measured against that wrapper, not against `[data-shelf-row]`, producing a wrong scroll target.

Fix: replaced with `getBoundingClientRect()` arithmetic (`row.scrollLeft + spine.left - row.left`), which is viewport-relative and independent of the DOM ancestor chain.

## Test plan
- [ ] Open bookshelf view → click a book in the book list → confirm page scrolls to the correct shelf and the book is horizontally centered in its row
- [ ] Works when the book is on a shelf that requires horizontal scrolling
- [ ] Works after reordering books (dnd-kit active)
- [ ] No console errors on navigation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the accuracy of highlighted book detection in the bookshelf view, ensuring consistent and reliable recognition of selected books across all possible layout configurations and screen sizes.
  * Improved the automatic scrolling behavior when navigating to highlighted books, providing more precise positioning to keep selected books properly centered and clearly visible on your screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->