### PR TITLE
feat(borrowers): link existing loans to borrower records (#223)

### DIFF
--- a/backend/alembic/versions/20260507_000021_link_existing_loans_to_borrowers.py
+++ b/backend/alembic/versions/20260507_000021_link_existing_loans_to_borrowers.py
@@ -1,0 +1,147 @@
+"""link existing loans to borrower records per library
+
+Revision ID: 20260507_000021
+Revises: 20260507_000020
+Create Date: 2026-05-07
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timezone
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection
+from sqlalchemy.sql import column, table
+
+revision: str = "20260507_000021"
+down_revision: str | None = "20260507_000020"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+BORROWERS_TABLE = table(
+    "borrowers",
+    column("id", sa.Uuid(as_uuid=True)),
+    column("library_id", sa.Uuid(as_uuid=True)),
+    column("name", sa.String()),
+    column("contact", sa.String()),
+    column("notes", sa.Text()),
+    column("anonymized_at", sa.DateTime(timezone=True)),
+    column("created_at", sa.DateTime(timezone=True)),
+    column("updated_at", sa.DateTime(timezone=True)),
+)
+
+LOANS_TABLE = table(
+    "loans",
+    column("id", sa.Uuid(as_uuid=True)),
+    column("library_id", sa.Uuid(as_uuid=True)),
+    column("borrower_id", sa.Uuid(as_uuid=True)),
+    column("borrower_name", sa.String()),
+    column("borrower_contact", sa.String()),
+)
+
+
+def _normalize_name(value: str | None) -> str:
+    if value is None:
+        return ""
+    return " ".join(value.split())
+
+
+def _normalize_contact(value: str | None) -> str | None:
+    if value is None:
+        return None
+    collapsed = " ".join(value.split())
+    return collapsed or None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _backfill(bind)
+
+
+def downgrade() -> None:
+    # Reverting only clears the borrower_id link. Borrower rows themselves are
+    # owned by the prior migration and will be removed when that one is rolled
+    # back. Manual creations made through the API would be lost there too,
+    # which is the same trade-off as any forward data migration.
+    op.execute(sa.text("UPDATE loans SET borrower_id = NULL"))
+
+
+def _backfill(bind: Connection) -> None:
+    library_ids = [
+        row[0]
+        for row in bind.execute(
+            sa.select(LOANS_TABLE.c.library_id)
+            .where(LOANS_TABLE.c.borrower_id.is_(None))
+            .distinct()
+        ).all()
+    ]
+    if not library_ids:
+        return
+
+    now = datetime.now(timezone.utc)
+    for library_id in library_ids:
+        _backfill_library(bind, library_id, now)
+
+
+def _backfill_library(bind: Connection, library_id: uuid.UUID, now: datetime) -> None:
+    existing = bind.execute(
+        sa.select(
+            BORROWERS_TABLE.c.id,
+            BORROWERS_TABLE.c.name,
+            BORROWERS_TABLE.c.contact,
+        ).where(BORROWERS_TABLE.c.library_id == library_id)
+    ).all()
+    bucket: dict[tuple[str, str | None], uuid.UUID] = {
+        (_normalize_name(name), _normalize_contact(contact)): borrower_id
+        for borrower_id, name, contact in existing
+    }
+
+    loans = bind.execute(
+        sa.select(
+            LOANS_TABLE.c.id,
+            LOANS_TABLE.c.borrower_name,
+            LOANS_TABLE.c.borrower_contact,
+        ).where(
+            LOANS_TABLE.c.library_id == library_id,
+            LOANS_TABLE.c.borrower_id.is_(None),
+        )
+    ).all()
+
+    new_borrowers: list[dict[str, object]] = []
+    loan_updates: list[dict[str, object]] = []
+
+    for loan_id, borrower_name, borrower_contact in loans:
+        normalized_name = _normalize_name(borrower_name)
+        if not normalized_name:
+            continue
+        normalized_contact = _normalize_contact(borrower_contact)
+        key = (normalized_name, normalized_contact)
+
+        borrower_id = bucket.get(key)
+        if borrower_id is None:
+            borrower_id = uuid.uuid4()
+            bucket[key] = borrower_id
+            new_borrowers.append(
+                {
+                    "id": borrower_id,
+                    "library_id": library_id,
+                    "name": normalized_name,
+                    "contact": normalized_contact,
+                    "notes": None,
+                    "anonymized_at": None,
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            )
+
+        loan_updates.append({"loan_id": loan_id, "borrower_id": borrower_id})
+
+    if new_borrowers:
+        bind.execute(sa.insert(BORROWERS_TABLE), new_borrowers)
+
+    update_stmt = sa.text("UPDATE loans SET borrower_id = :borrower_id WHERE id = :loan_id")
+    for params in loan_updates:
+        bind.execute(update_stmt, params)

--- a/backend/app/services/borrower.py
+++ b/backend/app/services/borrower.py
@@ -6,9 +6,23 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
 from app.models.borrower import Borrower
+from app.models.loan import Loan
 from app.schemas.borrower import BorrowerCreate, BorrowerUpdate
 
 logger = structlog.get_logger()
+
+
+def _normalize_name(value: str | None) -> str:
+    if value is None:
+        return ""
+    return " ".join(value.split())
+
+
+def _normalize_contact(value: str | None) -> str | None:
+    if value is None:
+        return None
+    collapsed = " ".join(value.split())
+    return collapsed or None
 
 
 async def list_borrowers(session: AsyncSession, library_id: uuid.UUID) -> list[Borrower]:
@@ -62,3 +76,60 @@ async def update_borrower(
     await session.refresh(borrower)
     logger.info("borrower_updated", borrower_id=str(borrower.id), fields=list(update_data.keys()))
     return borrower
+
+
+async def link_loans_to_borrowers(session: AsyncSession, library_id: uuid.UUID) -> int:
+    """Link a library's existing loans to Borrower records.
+
+    Idempotent: loans that already have ``borrower_id`` set are skipped.
+    Loans whose ``borrower_name`` is blank after whitespace normalization are
+    also skipped. Within the library, loans matching the same normalized
+    ``(name, contact)`` reuse a single Borrower; otherwise a new Borrower is
+    created. Borrowers are never shared across libraries.
+
+    Returns the number of loans linked in this call.
+    """
+    existing = (
+        await session.execute(select(Borrower).where(Borrower.library_id == library_id))
+    ).scalars().all()
+    bucket: dict[tuple[str, str | None], Borrower] = {
+        (_normalize_name(b.name), _normalize_contact(b.contact)): b for b in existing
+    }
+
+    loans = (
+        await session.execute(
+            select(Loan).where(Loan.library_id == library_id, Loan.borrower_id.is_(None))
+        )
+    ).scalars().all()
+
+    linked = 0
+    for loan in loans:
+        normalized_name = _normalize_name(loan.borrower_name)
+        if not normalized_name:
+            continue
+        normalized_contact = _normalize_contact(loan.borrower_contact)
+        key = (normalized_name, normalized_contact)
+
+        borrower = bucket.get(key)
+        if borrower is None:
+            borrower = Borrower(
+                library_id=library_id,
+                name=normalized_name,
+                contact=normalized_contact,
+            )
+            session.add(borrower)
+            await session.flush()
+            bucket[key] = borrower
+
+        loan.borrower_id = borrower.id
+        linked += 1
+
+    if linked:
+        await session.commit()
+        logger.info(
+            "loans_linked_to_borrowers",
+            library_id=str(library_id),
+            linked=linked,
+            borrowers_total=len(bucket),
+        )
+    return linked

--- a/backend/tests/test_borrower_link.py
+++ b/backend/tests/test_borrower_link.py
@@ -1,0 +1,201 @@
+"""Tests for the loan -> borrower backfill helper."""
+from collections.abc import AsyncIterator
+from datetime import date
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.db.base import Base
+from app.models.borrower import Borrower
+from app.models.loan import Loan
+from app.schemas.borrower import BorrowerCreate
+from app.services.borrower import create_borrower, link_loans_to_borrowers
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _make_loan(
+    library_id: uuid.UUID,
+    *,
+    borrower_name: str,
+    borrower_contact: str | None = None,
+    borrower_id: uuid.UUID | None = None,
+) -> Loan:
+    return Loan(
+        library_id=library_id,
+        book_id=uuid.uuid4(),
+        borrower_id=borrower_id,
+        borrower_name=borrower_name,
+        borrower_contact=borrower_contact,
+        lent_date=date.today(),
+    )
+
+
+async def _all_borrowers(session: AsyncSession, library_id: uuid.UUID) -> list[Borrower]:
+    result = await session.execute(
+        select(Borrower).where(Borrower.library_id == library_id)
+    )
+    return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_links_two_loans_with_same_name_and_contact_to_one_borrower(
+    session: AsyncSession,
+) -> None:
+    lib_id = uuid.uuid4()
+    session.add(_make_loan(lib_id, borrower_name="Alice", borrower_contact="alice@x.com"))
+    session.add(_make_loan(lib_id, borrower_name="Alice", borrower_contact="alice@x.com"))
+    await session.commit()
+
+    linked = await link_loans_to_borrowers(session, lib_id)
+
+    borrowers = await _all_borrowers(session, lib_id)
+    assert linked == 2
+    assert len(borrowers) == 1
+
+    loans = (await session.execute(select(Loan).where(Loan.library_id == lib_id))).scalars().all()
+    assert {loan.borrower_id for loan in loans} == {borrowers[0].id}
+
+
+@pytest.mark.asyncio
+async def test_same_name_in_two_libraries_creates_separate_borrowers(
+    session: AsyncSession,
+) -> None:
+    lib_a = uuid.uuid4()
+    lib_b = uuid.uuid4()
+    session.add(_make_loan(lib_a, borrower_name="Alice"))
+    session.add(_make_loan(lib_b, borrower_name="Alice"))
+    await session.commit()
+
+    await link_loans_to_borrowers(session, lib_a)
+    await link_loans_to_borrowers(session, lib_b)
+
+    borrowers_a = await _all_borrowers(session, lib_a)
+    borrowers_b = await _all_borrowers(session, lib_b)
+    assert len(borrowers_a) == 1
+    assert len(borrowers_b) == 1
+    assert borrowers_a[0].id != borrowers_b[0].id
+
+
+@pytest.mark.asyncio
+async def test_existing_borrower_id_is_not_overwritten(session: AsyncSession) -> None:
+    lib_id = uuid.uuid4()
+    pinned = await create_borrower(
+        session, BorrowerCreate(name="Pre-existing", contact="pre@x.com"), lib_id
+    )
+    # Loan that *looks* the same as the pinned borrower but already has a
+    # different borrower_id set; we must not touch it.
+    other_id = (
+        await create_borrower(session, BorrowerCreate(name="Other"), lib_id)
+    ).id
+    session.add(
+        _make_loan(
+            lib_id,
+            borrower_name="Pre-existing",
+            borrower_contact="pre@x.com",
+            borrower_id=other_id,
+        )
+    )
+    await session.commit()
+
+    linked = await link_loans_to_borrowers(session, lib_id)
+
+    assert linked == 0
+    loan = (
+        await session.execute(select(Loan).where(Loan.library_id == lib_id))
+    ).scalar_one()
+    assert loan.borrower_id == other_id
+    assert pinned.id != other_id
+
+
+@pytest.mark.asyncio
+async def test_null_or_empty_contact_is_handled(session: AsyncSession) -> None:
+    lib_id = uuid.uuid4()
+    session.add(_make_loan(lib_id, borrower_name="Bob", borrower_contact=None))
+    session.add(_make_loan(lib_id, borrower_name="Bob", borrower_contact=""))
+    session.add(_make_loan(lib_id, borrower_name="Bob", borrower_contact="   "))
+    await session.commit()
+
+    await link_loans_to_borrowers(session, lib_id)
+
+    borrowers = await _all_borrowers(session, lib_id)
+    # All three loans normalize to the same (Bob, None) key.
+    assert len(borrowers) == 1
+    assert borrowers[0].contact is None
+
+
+@pytest.mark.asyncio
+async def test_extra_whitespace_in_borrower_name_does_not_crash(
+    session: AsyncSession,
+) -> None:
+    lib_id = uuid.uuid4()
+    session.add(_make_loan(lib_id, borrower_name="  Alice  Smith  "))
+    session.add(_make_loan(lib_id, borrower_name="Alice Smith"))
+    await session.commit()
+
+    await link_loans_to_borrowers(session, lib_id)
+
+    borrowers = await _all_borrowers(session, lib_id)
+    assert len(borrowers) == 1
+    assert borrowers[0].name == "Alice Smith"
+
+
+@pytest.mark.asyncio
+async def test_blank_borrower_name_is_skipped(session: AsyncSession) -> None:
+    lib_id = uuid.uuid4()
+    session.add(_make_loan(lib_id, borrower_name="   "))
+    session.add(_make_loan(lib_id, borrower_name="Real Person"))
+    await session.commit()
+
+    linked = await link_loans_to_borrowers(session, lib_id)
+
+    assert linked == 1
+    borrowers = await _all_borrowers(session, lib_id)
+    assert [b.name for b in borrowers] == ["Real Person"]
+
+
+@pytest.mark.asyncio
+async def test_helper_is_idempotent(session: AsyncSession) -> None:
+    lib_id = uuid.uuid4()
+    session.add(_make_loan(lib_id, borrower_name="Alice"))
+    session.add(_make_loan(lib_id, borrower_name="Bob", borrower_contact="bob@x.com"))
+    await session.commit()
+
+    first = await link_loans_to_borrowers(session, lib_id)
+    second = await link_loans_to_borrowers(session, lib_id)
+
+    assert first == 2
+    assert second == 0
+    borrowers = await _all_borrowers(session, lib_id)
+    assert len(borrowers) == 2
+
+
+@pytest.mark.asyncio
+async def test_reuses_borrower_created_via_create_borrower(session: AsyncSession) -> None:
+    """A pre-existing Borrower record should not be duplicated by the linker."""
+    lib_id = uuid.uuid4()
+    existing = await create_borrower(
+        session, BorrowerCreate(name="Alice", contact="alice@x.com"), lib_id
+    )
+    session.add(_make_loan(lib_id, borrower_name="Alice", borrower_contact="alice@x.com"))
+    await session.commit()
+
+    await link_loans_to_borrowers(session, lib_id)
+
+    borrowers = await _all_borrowers(session, lib_id)
+    assert len(borrowers) == 1
+    loan = (
+        await session.execute(select(Loan).where(Loan.library_id == lib_id))
+    ).scalar_one()
+    assert loan.borrower_id == existing.id


### PR DESCRIPTION
## Summary

- Adds `link_loans_to_borrowers(session, library_id)` — an idempotent ORM helper that walks a library's loans, normalizes `borrower_name`/`borrower_contact` (trim + collapse whitespace), and either reuses an existing Borrower with the same normalized `(name, contact)` or creates one. Loans with `borrower_id` already set are skipped; loans with blank `borrower_name` are skipped.
- Adds Alembic data migration `20260507_000021` that runs the same matching via SA Core (no app imports) per distinct `loans.library_id` where `borrower_id IS NULL`. Downgrade nulls `loans.borrower_id`.
- Adds `tests/test_borrower_link.py` covering the matching rules from #223: same name+contact in one library → one borrower, same name across libraries → separate borrowers, existing `borrower_id` is not overwritten, null/empty/whitespace contact handled, extra whitespace in name does not crash, blank name skipped, helper idempotent, pre-existing API-created Borrower reused.

Conservative matching only — trim + collapse internal whitespace. No case-folding or fuzzy matching: silently merging different people would be worse than letting duplicates exist.

Out of scope: UI (#224, #225), anonymization (#226), removal of legacy columns (#227). OpenAPI unchanged.

Parent epic: #221
Closes #223

## Test plan

- [ ] `cd backend && ruff check app tests`
- [ ] `cd backend && mypy app tests`
- [ ] `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`
- [ ] Verify `tests/test_borrower_link.py` covers all 8 cases listed above
- [ ] Smoke-test migration locally against a snapshot of an installation with legacy loans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loan-to-borrower linking functionality to ensure all loans are properly associated with borrower records.
  * Intelligently reuses existing borrowers when names and contact information match, creating new borrower records as needed.

* **Chores**
  * Added database migration to backfill existing loans with appropriate borrower associations.

* **Tests**
  * Added comprehensive test coverage for loan-to-borrower linking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->