### PR TITLE
feat(borrowers): add borrower picker to loan form (#224)

### DIFF
--- a/frontend/src/components/LendBookModal.test.tsx
+++ b/frontend/src/components/LendBookModal.test.tsx
@@ -1,0 +1,214 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true })),
+}))
+
+vi.mock('../lib/api', () => ({
+  createLoan: vi.fn(),
+  listBorrowers: vi.fn(),
+  formatApiError: (e: unknown) => String(e),
+}))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: (selector: (s: { showError: () => void; showSuccess: () => void }) => unknown) =>
+    selector({ showError: vi.fn(), showSuccess: vi.fn() }),
+}))
+
+import { createLoan, listBorrowers } from '../lib/api'
+import type { Borrower, Loan } from '../lib/types'
+import { LendBookModal } from './LendBookModal'
+
+function makeBorrower(overrides: Partial<Borrower> = {}): Borrower {
+  return {
+    id: 'borrower-1',
+    name: 'Alice Liddell',
+    contact: 'alice@example.com',
+    notes: null,
+    anonymized_at: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeLoan(): Loan {
+  return {
+    id: 'loan-1',
+    book_id: 'book-1',
+    borrower_id: null,
+    borrower_name: 'Alice Liddell',
+    borrower_contact: null,
+    borrower: null,
+    lent_date: '2026-05-07',
+    due_date: null,
+    returned_date: null,
+    return_condition: null,
+    notes: null,
+    created_at: '2026-05-07T00:00:00Z',
+    is_active: true,
+  }
+}
+
+function renderModal() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <LendBookModal bookId="book-1" onClose={vi.fn()} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('LendBookModal', () => {
+  it('lists existing borrowers as datalist options', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({ id: 'b1', name: 'Alice Liddell' }),
+      makeBorrower({ id: 'b2', name: 'Bob Builder', contact: null }),
+    ])
+    renderModal()
+    await waitFor(() => {
+      const list = document.querySelector('[data-testid="borrower-suggestions"]') as HTMLDataListElement | null
+      expect(list).not.toBeNull()
+      expect(list!.querySelectorAll('option')).toHaveLength(2)
+    })
+    const list = document.querySelector('[data-testid="borrower-suggestions"]') as HTMLDataListElement
+    const values = Array.from(list.querySelectorAll('option')).map((o) => o.getAttribute('value'))
+    expect(values).toEqual(['Alice Liddell', 'Bob Builder'])
+  })
+
+  it('submits with borrower_id when typed name exactly matches an existing borrower', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({ id: 'borrower-42', name: 'Alice Liddell', contact: 'alice@x.com' }),
+    ])
+    vi.mocked(createLoan).mockResolvedValue(makeLoan())
+    renderModal()
+    await waitFor(() => expect(listBorrowers).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+    const nameInput = screen.getByPlaceholderText('loans.borrower_name')
+    await user.type(nameInput, 'Alice Liddell')
+
+    // The "existing borrower" hint should appear, the contact field should
+    // become read-only (won't be sent on submit either way).
+    expect(await screen.findByTestId('borrower-existing-match')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'loans.lend_submit' }))
+
+    await waitFor(() => expect(createLoan).toHaveBeenCalledTimes(1))
+    const [, payload] = vi.mocked(createLoan).mock.calls[0]
+    expect(payload).toMatchObject({
+      borrower_id: 'borrower-42',
+      lent_date: expect.any(String),
+    })
+    expect(payload).not.toHaveProperty('borrower_name')
+    expect(payload).not.toHaveProperty('borrower_contact')
+  })
+
+  it('matches on a normalized name (trimmed, case-insensitive, collapsed whitespace)', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({ id: 'borrower-99', name: 'Alice Liddell' }),
+    ])
+    vi.mocked(createLoan).mockResolvedValue(makeLoan())
+    renderModal()
+    await waitFor(() => expect(listBorrowers).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+    await user.type(
+      screen.getByPlaceholderText('loans.borrower_name'),
+      '  alice   liddell  ',
+    )
+    await user.click(screen.getByRole('button', { name: 'loans.lend_submit' }))
+
+    await waitFor(() => expect(createLoan).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(createLoan).mock.calls[0][1]).toMatchObject({
+      borrower_id: 'borrower-99',
+    })
+  })
+
+  it('falls back to legacy borrower_name + borrower_contact for a new borrower', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({ id: 'b1', name: 'Alice Liddell' }),
+    ])
+    vi.mocked(createLoan).mockResolvedValue(makeLoan())
+    renderModal()
+    await waitFor(() => expect(listBorrowers).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('loans.borrower_name'), 'Charlie Brown')
+    await user.type(screen.getByPlaceholderText('loans.borrower_contact'), 'charlie@x.com')
+    await user.click(screen.getByRole('button', { name: 'loans.lend_submit' }))
+
+    await waitFor(() => expect(createLoan).toHaveBeenCalledTimes(1))
+    const payload = vi.mocked(createLoan).mock.calls[0][1]
+    expect(payload).toMatchObject({
+      borrower_name: 'Charlie Brown',
+      borrower_contact: 'charlie@x.com',
+    })
+    expect(payload.borrower_id).toBeUndefined()
+  })
+
+  it('ambiguous name (two borrowers, same name) falls back to legacy flow', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({ id: 'b1', name: 'John Smith', contact: 'a@x.com' }),
+      makeBorrower({ id: 'b2', name: 'John Smith', contact: 'b@x.com' }),
+    ])
+    vi.mocked(createLoan).mockResolvedValue(makeLoan())
+    renderModal()
+    await waitFor(() => expect(listBorrowers).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('loans.borrower_name'), 'John Smith')
+
+    expect(screen.queryByTestId('borrower-existing-match')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'loans.lend_submit' }))
+
+    await waitFor(() => expect(createLoan).toHaveBeenCalledTimes(1))
+    const payload = vi.mocked(createLoan).mock.calls[0][1]
+    expect(payload).toMatchObject({ borrower_name: 'John Smith' })
+    expect(payload.borrower_id).toBeUndefined()
+  })
+
+  it('still works when there are no existing borrowers (preserves prior UX)', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([])
+    vi.mocked(createLoan).mockResolvedValue(makeLoan())
+    renderModal()
+    await waitFor(() => expect(listBorrowers).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('loans.borrower_name'), 'Eve First')
+    await user.click(screen.getByRole('button', { name: 'loans.lend_submit' }))
+
+    await waitFor(() => expect(createLoan).toHaveBeenCalledTimes(1))
+    const payload = vi.mocked(createLoan).mock.calls[0][1]
+    expect(payload).toMatchObject({ borrower_name: 'Eve First' })
+    expect(payload.borrower_id).toBeUndefined()
+  })
+
+  it('shows an inline error when submit happens with an empty name', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([])
+    renderModal()
+    await waitFor(() => expect(listBorrowers).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+    // Bypass the native required validation by submitting via form's submit
+    // button after clearing the field — userEvent will still trigger submit
+    // because we click the button programmatically; the empty-required check
+    // in our handler is what we want to exercise. Use form.requestSubmit() to
+    // skip native validation.
+    const form = screen.getByRole('button', { name: 'loans.lend_submit' }).closest('form') as HTMLFormElement
+    form.noValidate = true
+    await user.click(screen.getByRole('button', { name: 'loans.lend_submit' }))
+
+    expect(await screen.findByText('loans.borrower_name_required')).toBeInTheDocument()
+    expect(createLoan).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/LendBookModal.tsx
+++ b/frontend/src/components/LendBookModal.tsx
@@ -1,8 +1,22 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useBorrowers } from '../hooks/useBorrowers'
 import { useCreateLoan } from '../hooks/useLoans'
+import type { Borrower, LoanCreateRequest } from '../lib/types'
 import { Modal } from './Modal'
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+/** Returns the unique borrower whose normalized name equals the typed value, or null. */
+function findExactMatch(borrowers: Borrower[], typed: string): Borrower | null {
+  const target = normalize(typed)
+  if (!target) return null
+  const matches = borrowers.filter((b) => normalize(b.name) === target)
+  return matches.length === 1 ? matches[0] : null
+}
 
 export function LendBookModal({ bookId, onClose }: { bookId: string; onClose: () => void }) {
   const today = new Date().toISOString().slice(0, 10)
@@ -14,6 +28,13 @@ export function LendBookModal({ bookId, onClose }: { bookId: string; onClose: ()
   const [error, setError] = useState<string | null>(null)
   const createLoan = useCreateLoan(bookId)
   const { t } = useTranslation()
+  const borrowersQuery = useBorrowers()
+  const borrowers = useMemo(() => borrowersQuery.data ?? [], [borrowersQuery.data])
+
+  const matchedBorrower = useMemo(
+    () => findExactMatch(borrowers, borrowerName),
+    [borrowers, borrowerName],
+  )
 
   return (
     <Modal open label={t('loans.lend_modal_title')} onClose={onClose} maxWidth={520}>
@@ -25,25 +46,65 @@ export function LendBookModal({ bookId, onClose }: { bookId: string; onClose: ()
             return
           }
 
-          createLoan.mutate(
-            {
-              borrower_name: borrowerName.trim(),
-              borrower_contact: borrowerContact.trim() || null,
-              lent_date: lentDate,
-              due_date: dueDate || null,
-              notes: notes.trim() || null,
-            },
-            {
-              onSuccess: () => onClose(),
-              onError: () => setError(t('loans.lend_error')),
-            },
-          )
+          // When the typed name uniquely matches an existing borrower, link by
+          // borrower_id and let the backend supply name/contact. The typed
+          // contact is intentionally ignored — a loan form should not
+          // overwrite borrower details (issue #224).
+          const payload: LoanCreateRequest = matchedBorrower
+            ? {
+                borrower_id: matchedBorrower.id,
+                lent_date: lentDate,
+                due_date: dueDate || null,
+                notes: notes.trim() || null,
+              }
+            : {
+                borrower_name: borrowerName.trim(),
+                borrower_contact: borrowerContact.trim() || null,
+                lent_date: lentDate,
+                due_date: dueDate || null,
+                notes: notes.trim() || null,
+              }
+
+          createLoan.mutate(payload, {
+            onSuccess: () => onClose(),
+            onError: () => setError(t('loans.lend_error')),
+          })
         }}
         style={{ display: 'grid', gap: 12 }}
       >
         <h3 style={{ margin: 0 }}>{t('loans.lend_modal_title')}</h3>
-        <input className="sh-input" placeholder={t('loans.borrower_name')} value={borrowerName} onChange={(event) => setBorrowerName(event.target.value)} required />
-        <input className="sh-input" placeholder={t('loans.borrower_contact')} value={borrowerContact} onChange={(event) => setBorrowerContact(event.target.value)} />
+        <div style={{ display: 'grid', gap: 4 }}>
+          <input
+            className="sh-input"
+            list="borrower-suggestions"
+            placeholder={t('loans.borrower_name')}
+            value={borrowerName}
+            onChange={(event) => setBorrowerName(event.target.value)}
+            autoComplete="off"
+            required
+          />
+          <datalist id="borrower-suggestions" data-testid="borrower-suggestions">
+            {borrowers.map((borrower) => (
+              <option key={borrower.id} value={borrower.name} />
+            ))}
+          </datalist>
+          {matchedBorrower && (
+            <span
+              data-testid="borrower-existing-match"
+              style={{ fontSize: 12, color: 'var(--sh-text-muted)' }}
+            >
+              {t('loans.borrower_existing_match')}
+              {matchedBorrower.contact ? ` · ${matchedBorrower.contact}` : ''}
+            </span>
+          )}
+        </div>
+        <input
+          className="sh-input"
+          placeholder={t('loans.borrower_contact')}
+          value={borrowerContact}
+          onChange={(event) => setBorrowerContact(event.target.value)}
+          disabled={Boolean(matchedBorrower)}
+        />
         <label style={{ display: 'grid', gap: 4, fontSize: 14, fontWeight: 500, color: 'var(--sh-text-muted)' }}>
           {t('loans.lent_date')}
           <input className="sh-input" type="date" value={lentDate} onChange={(event) => setLentDate(event.target.value)} />

--- a/frontend/src/hooks/useBorrowers.ts
+++ b/frontend/src/hooks/useBorrowers.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { listBorrowers } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
+
+export const BORROWERS_QUERY_KEY = ['borrowers']
+
+export function useBorrowers() {
+  const { isAuthenticated } = useAuth()
+  return useQuery({
+    queryKey: BORROWERS_QUERY_KEY,
+    queryFn: listBorrowers,
+    retry: false,
+    enabled: isAuthenticated,
+  })
+}

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -272,6 +272,7 @@
     "lend_modal_title": "Půjčit knihu",
     "borrower_name": "Jméno dlužníka",
     "borrower_name_required": "Jméno dlužníka je povinné.",
+    "borrower_existing_match": "Existující dlužník",
     "borrower_contact": "E-mail nebo telefon",
     "lent_date": "Datum půjčení",
     "due_date": "Datum vrácení",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -343,6 +343,7 @@
     "lend_modal_title": "Lend book",
     "borrower_name": "Borrower name",
     "borrower_name_required": "Borrower name is required.",
+    "borrower_existing_match": "Existing borrower",
     "borrower_contact": "email or phone",
     "lent_date": "Lent date",
     "due_date": "Due date",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,8 @@ import type {
   AddMemberRequest,
   BillingInterval,
   BillingStatus,
+  Borrower,
+  BorrowerCreateRequest,
   CheckoutResponse,
   CsvImportConfirmRequest,
   CsvImportConfirmResponse,
@@ -476,6 +478,16 @@ export async function createLoan(bookId: string, payload: LoanCreateRequest): Pr
 
 export async function returnLoan(bookId: string, loanId: string, payload: LoanReturnRequest): Promise<Loan> {
   const response = await apiClient.patch<Loan>(`/api/v1/books/${bookId}/loans/${loanId}/return`, payload)
+  return response.data
+}
+
+export async function listBorrowers(): Promise<Borrower[]> {
+  const response = await apiClient.get<Borrower[]>('/api/v1/borrowers')
+  return response.data
+}
+
+export async function createBorrower(payload: BorrowerCreateRequest): Promise<Borrower> {
+  const response = await apiClient.post<Borrower>('/api/v1/borrowers', payload)
   return response.data
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -32,11 +32,35 @@ export interface LocationUpdateRequest {
 
 export type ReadingStatus = 'unread' | 'reading' | 'read' | 'lent'
 
+export interface Borrower {
+  id: string
+  name: string
+  contact: string | null
+  notes: string | null
+  anonymized_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface BorrowerCreateRequest {
+  name: string
+  contact?: string | null
+  notes?: string | null
+}
+
+export interface BorrowerUpdateRequest {
+  name?: string
+  contact?: string | null
+  notes?: string | null
+}
+
 export interface Loan {
   id: string
   book_id: string
+  borrower_id: string | null
   borrower_name: string
   borrower_contact: string | null
+  borrower: Borrower | null
   lent_date: string
   due_date: string | null
   returned_date: string | null
@@ -71,7 +95,8 @@ export interface Book {
 
 
 export interface LoanCreateRequest {
-  borrower_name: string
+  borrower_id?: string | null
+  borrower_name?: string | null
   borrower_contact?: string | null
   lent_date: string
   due_date?: string | null


### PR DESCRIPTION
## Summary

- The Lend-book modal now lists existing borrowers from the active library via a native `<datalist>` (works on mobile, matches the existing locations-form pattern, no extra deps).
- When the typed name *uniquely* matches an existing borrower (normalized: trimmed, lowercase, collapsed internal whitespace), submit sends `{ borrower_id }` and the contact input becomes read-only with an "Existing borrower" hint. Backend supplies the borrower's name/contact for the loan record.
- Otherwise (new name, ambiguous match, or empty list) submit falls back to the legacy `{ borrower_name, borrower_contact }` payload — backend's compatibility layer from #222 handles it.
- The form intentionally does **not** update borrower details from a loan submission, per #224 guidance.
- Frontend types updated to match backend `LoanResponse` since #222: `Loan.borrower_id`, nested `Loan.borrower`, `LoanCreateRequest.borrower_name` now optional. New `Borrower*` types and `listBorrowers`/`createBorrower` API helpers, new `useBorrowers` hook.
- i18n: `loans.borrower_existing_match` added in cs and en.

Backend OpenAPI is unchanged.

Parent epic: #221
Closes #224

## Test plan

- [x] `cd frontend && npm run lint` (clean for touched files)
- [x] `cd frontend && npx tsc --noEmit` (no new errors from this change; pre-existing errors in unrelated files remain)
- [x] `cd frontend && npm test` — full suite green (135/135 tests)
- [x] `LendBookModal.test.tsx` covers: datalist population, exact-name match → `borrower_id`, normalization, new-name legacy flow, ambiguous-name legacy flow, empty list, empty-name validation
- [ ] Manual smoke: open the lend modal, type an existing borrower's name, verify the hint appears and contact field becomes read-only
- [ ] Manual smoke (mobile): verify the datalist suggestions appear in iOS Safari and Android Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added borrower autocomplete suggestions to the lending modal, displaying a list of existing borrowers.
  * Implemented smart borrower matching to detect when a typed name matches an existing borrower; matched borrower contact details are displayed inline.
  * The borrower contact field is automatically disabled when an existing borrower match is detected.

* **Tests**
  * Added comprehensive test suite for borrower matching and loan submission workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->