### PR TITLE
feat(borrowers): overview and detail pages (#225)

### DIFF
--- a/backend/app/api/borrowers.py
+++ b/backend/app/api/borrowers.py
@@ -5,24 +5,39 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies.library import get_library_id, require_editor_library
 from app.db.session import get_db_session
-from app.schemas.borrower import BorrowerCreate, BorrowerResponse, BorrowerUpdate
+from app.schemas.borrower import (
+    BorrowerCreate,
+    BorrowerListItem,
+    BorrowerLoanItem,
+    BorrowerResponse,
+    BorrowerUpdate,
+)
 from app.services.borrower import (
     create_borrower,
     get_borrower_or_404,
-    list_borrowers,
+    list_borrowers_with_stats,
+    list_loans_for_borrower,
     update_borrower,
 )
 
 router = APIRouter(prefix="/api/v1/borrowers", tags=["borrowers"])
 
 
-@router.get("", response_model=list[BorrowerResponse])
+@router.get("", response_model=list[BorrowerListItem])
 async def read_borrowers(
     session: AsyncSession = Depends(get_db_session),
     library_id: uuid.UUID = Depends(get_library_id),
-) -> list[BorrowerResponse]:
-    borrowers = await list_borrowers(session, library_id)
-    return [BorrowerResponse.model_validate(b) for b in borrowers]
+) -> list[BorrowerListItem]:
+    rows = await list_borrowers_with_stats(session, library_id)
+    return [
+        BorrowerListItem(
+            **BorrowerResponse.model_validate(row.borrower).model_dump(),
+            active_loans=row.active_loans,
+            total_loans=row.total_loans,
+            last_activity_at=row.last_activity_at,
+        )
+        for row in rows
+    ]
 
 
 @router.post("", response_model=BorrowerResponse, status_code=status.HTTP_201_CREATED)
@@ -54,3 +69,13 @@ async def update_borrower_endpoint(
 ) -> BorrowerResponse:
     borrower = await update_borrower(session, borrower_id, payload, library_id)
     return BorrowerResponse.model_validate(borrower)
+
+
+@router.get("/{borrower_id}/loans", response_model=list[BorrowerLoanItem])
+async def read_borrower_loans(
+    borrower_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(get_library_id),
+) -> list[BorrowerLoanItem]:
+    rows = await list_loans_for_borrower(session, borrower_id, library_id)
+    return [BorrowerLoanItem.model_validate(row) for row in rows]

--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -32,3 +32,27 @@ class BorrowerResponse(BaseModel):
     anonymized_at: datetime | None
     created_at: datetime
     updated_at: datetime
+
+
+class BorrowerListItem(BorrowerResponse):
+    """Borrower record enriched with lending-activity stats for the overview page."""
+
+    active_loans: int
+    total_loans: int
+    last_activity_at: date | None
+
+
+class BorrowerLoanItem(BaseModel):
+    """A loan as seen from the borrower-detail page — denormalized with book info."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    book_id: uuid.UUID
+    book_title: str
+    book_author: str | None
+    lent_date: date
+    due_date: date | None
+    returned_date: date | None
+    return_condition: str | None
+    notes: str | None

--- a/backend/app/services/borrower.py
+++ b/backend/app/services/borrower.py
@@ -1,15 +1,39 @@
 import uuid
+from dataclasses import dataclass
+from datetime import date
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
+from app.models.book import Book
 from app.models.borrower import Borrower
 from app.models.loan import Loan
 from app.schemas.borrower import BorrowerCreate, BorrowerUpdate
 
 logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class BorrowerWithStats:
+    borrower: Borrower
+    active_loans: int
+    total_loans: int
+    last_activity_at: date | None
+
+
+@dataclass(frozen=True)
+class BorrowerLoanRow:
+    id: uuid.UUID
+    book_id: uuid.UUID
+    book_title: str
+    book_author: str | None
+    lent_date: date
+    due_date: date | None
+    returned_date: date | None
+    return_condition: str | None
+    notes: str | None
 
 
 def _normalize_name(value: str | None) -> str:
@@ -32,6 +56,91 @@ async def list_borrowers(session: AsyncSession, library_id: uuid.UUID) -> list[B
         .order_by(Borrower.name)
     )
     return list(result.scalars().all())
+
+
+async def list_borrowers_with_stats(
+    session: AsyncSession, library_id: uuid.UUID
+) -> list[BorrowerWithStats]:
+    """List a library's borrowers with aggregated lending stats."""
+    active_count = func.count(Loan.id).filter(Loan.returned_date.is_(None))
+    total_count = func.count(Loan.id)
+
+    # The library-id check on Loan is defensive: in normal operation a loan's
+    # library_id always matches its borrower's, but pinning it here prevents a
+    # malformed cross-library row from being counted into stats.
+    stmt = (
+        select(
+            Borrower,
+            active_count.label("active_loans"),
+            total_count.label("total_loans"),
+            func.max(Loan.lent_date).label("last_activity_at"),
+        )
+        .outerjoin(
+            Loan,
+            and_(Loan.borrower_id == Borrower.id, Loan.library_id == library_id),
+        )
+        .where(Borrower.library_id == library_id)
+        .group_by(Borrower.id)
+        .order_by(Borrower.name)
+    )
+    result = await session.execute(stmt)
+    return [
+        BorrowerWithStats(
+            borrower=row[0],
+            active_loans=int(row[1] or 0),
+            total_loans=int(row[2] or 0),
+            last_activity_at=row[3],
+        )
+        for row in result.all()
+    ]
+
+
+async def list_loans_for_borrower(
+    session: AsyncSession, borrower_id: uuid.UUID, library_id: uuid.UUID
+) -> list[BorrowerLoanRow]:
+    """List a borrower's loans with denormalized book metadata.
+
+    Active loans (no returned_date) come first, then returned loans by most
+    recent return. Within each group, lent_date desc.
+    """
+    await get_borrower_or_404(session, borrower_id, library_id)
+
+    stmt = (
+        select(
+            Loan.id,
+            Loan.book_id,
+            Book.title,
+            Book.author,
+            Loan.lent_date,
+            Loan.due_date,
+            Loan.returned_date,
+            Loan.return_condition,
+            Loan.notes,
+        )
+        .join(Book, Book.id == Loan.book_id)
+        .where(Loan.borrower_id == borrower_id, Loan.library_id == library_id)
+        .order_by(
+            Loan.returned_date.is_(None).desc(),
+            Loan.returned_date.desc().nullslast(),
+            Loan.lent_date.desc(),
+            Loan.id.desc(),
+        )
+    )
+    result = await session.execute(stmt)
+    return [
+        BorrowerLoanRow(
+            id=row[0],
+            book_id=row[1],
+            book_title=row[2],
+            book_author=row[3],
+            lent_date=row[4],
+            due_date=row[5],
+            returned_date=row[6],
+            return_condition=row[7],
+            notes=row[8],
+        )
+        for row in result.all()
+    ]
 
 
 async def create_borrower(

--- a/backend/tests/test_borrower_pages.py
+++ b/backend/tests/test_borrower_pages.py
@@ -1,0 +1,345 @@
+"""Tests for the borrower overview/detail page API surface (issue #225).
+
+Covers:
+- GET /api/v1/borrowers — now returns active/total/last_activity stats
+- GET /api/v1/borrowers/{id}/loans — denormalized loan list with book info
+- library isolation on the detail endpoint
+"""
+from collections.abc import AsyncIterator, Iterator
+from datetime import date, timedelta
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.book import Book
+from app.models.borrower import Borrower
+from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.loan import Loan
+from app.models.user import User
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url="sqlite+aiosqlite:///:memory:",
+        jwt_secret_key="test-secret",
+        jwt_algorithm="HS256",
+        access_token_expire_minutes=15,
+        refresh_token_expire_days=7,
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(test_session: AsyncSession, test_settings: Settings) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        yield test_session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _seed_user_with_library(
+    session: AsyncSession, email: str = "admin@example.com"
+) -> tuple[User, Library]:
+    existing = (await session.execute(select(User).where(User.email == email))).scalar_one_or_none()
+    if existing is None:
+        user = User(email=email, hashed_password=get_password_hash("secret"))
+        session.add(user)
+        await session.flush()
+    else:
+        user = existing
+    lib = (await session.execute(
+        select(Library)
+        .join(LibraryMember, LibraryMember.library_id == Library.id)
+        .where(LibraryMember.user_id == user.id)
+        .limit(1)
+    )).scalar_one_or_none()
+    if lib is None:
+        lib = Library(name=f"Library of {email}", created_by_user_id=user.id)
+        session.add(lib)
+        await session.flush()
+        session.add(LibraryMember(library_id=lib.id, user_id=user.id, role=LibraryRole.OWNER))
+        await session.commit()
+        await session.refresh(lib)
+    return user, lib
+
+
+async def _auth_headers(
+    client: AsyncClient, session: AsyncSession, email: str = "admin@example.com"
+) -> dict[str, str]:
+    await _seed_user_with_library(session, email)
+    resp = await client.post("/api/v1/auth/login", json={"email": email, "password": "secret"})
+    assert resp.status_code == 200
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _make_book(library_id: uuid.UUID, title: str, author: str | None = None) -> Book:
+    return Book(library_id=library_id, title=title, author=author)
+
+
+def _make_loan(
+    *,
+    library_id: uuid.UUID,
+    book_id: uuid.UUID,
+    borrower_id: uuid.UUID,
+    borrower_name: str,
+    lent_date: date,
+    returned_date: date | None = None,
+    return_condition: str | None = None,
+) -> Loan:
+    return Loan(
+        library_id=library_id,
+        book_id=book_id,
+        borrower_id=borrower_id,
+        borrower_name=borrower_name,
+        lent_date=lent_date,
+        returned_date=returned_date,
+        return_condition=return_condition,
+    )
+
+
+# ── List endpoint ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_returns_stats_for_each_borrower(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    today = date.today()
+
+    alice = Borrower(library_id=lib.id, name="Alice")
+    bob = Borrower(library_id=lib.id, name="Bob")
+    test_session.add_all([alice, bob])
+    await test_session.flush()
+
+    book1 = _make_book(lib.id, "Book One", "Author 1")
+    book2 = _make_book(lib.id, "Book Two")
+    book3 = _make_book(lib.id, "Book Three")
+    test_session.add_all([book1, book2, book3])
+    await test_session.flush()
+
+    test_session.add_all([
+        # Alice: 1 active + 1 returned, total 2, last lent today
+        _make_loan(
+            library_id=lib.id, book_id=book1.id, borrower_id=alice.id,
+            borrower_name="Alice", lent_date=today,
+        ),
+        _make_loan(
+            library_id=lib.id, book_id=book2.id, borrower_id=alice.id,
+            borrower_name="Alice", lent_date=today - timedelta(days=20),
+            returned_date=today - timedelta(days=5), return_condition="good",
+        ),
+        # Bob: 1 active, total 1
+        _make_loan(
+            library_id=lib.id, book_id=book3.id, borrower_id=bob.id,
+            borrower_name="Bob", lent_date=today - timedelta(days=2),
+        ),
+    ])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "admin@example.com", "password": "secret"},
+        )
+        headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+        listed = await client.get("/api/v1/borrowers", headers=headers)
+        assert listed.status_code == 200
+        body = listed.json()
+        assert [b["name"] for b in body] == ["Alice", "Bob"]
+
+        alice_row = body[0]
+        assert alice_row["active_loans"] == 1
+        assert alice_row["total_loans"] == 2
+        assert alice_row["last_activity_at"] == today.isoformat()
+
+        bob_row = body[1]
+        assert bob_row["active_loans"] == 1
+        assert bob_row["total_loans"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_returns_zero_stats_for_borrower_without_loans(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    test_session.add(Borrower(library_id=lib.id, name="Zoe"))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.get("/api/v1/borrowers", headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["active_loans"] == 0
+        assert body[0]["total_loans"] == 0
+        assert body[0]["last_activity_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_stats_does_not_count_cross_library_loans(
+    test_session: AsyncSession,
+) -> None:
+    """A malformed cross-library loan must not leak into the borrower's stats.
+
+    In practice the API's create_loan validates library matching, but the JOIN
+    in list_borrowers_with_stats pins ``Loan.library_id`` defensively so that
+    a row with the wrong library_id (e.g. from a future bulk import bug) does
+    not inflate the counts.
+    """
+    _, lib = await _seed_user_with_library(test_session)
+    foreign_lib_id = uuid.uuid4()
+
+    alice = Borrower(library_id=lib.id, name="Alice")
+    test_session.add(alice)
+    await test_session.flush()
+
+    book = _make_book(lib.id, "B")
+    foreign_book = _make_book(foreign_lib_id, "FB")
+    test_session.add_all([book, foreign_book])
+    await test_session.flush()
+
+    # One legitimate loan in our library
+    test_session.add(_make_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=alice.id,
+        borrower_name="Alice", lent_date=date.today(),
+    ))
+    # Cross-library loan pointing at our alice.id — this should be ignored.
+    # SQLite test DB does not enforce FKs so we can construct this dangling row.
+    test_session.add(_make_loan(
+        library_id=foreign_lib_id, book_id=foreign_book.id, borrower_id=alice.id,
+        borrower_name="Alice", lent_date=date.today(),
+    ))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.get("/api/v1/borrowers", headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["total_loans"] == 1
+        assert body[0]["active_loans"] == 1
+
+
+# ── Borrower loans endpoint ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_borrower_loans_returns_active_and_returned_with_book_info(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    today = date.today()
+
+    alice = Borrower(library_id=lib.id, name="Alice")
+    test_session.add(alice)
+    await test_session.flush()
+
+    active_book = _make_book(lib.id, "Active Title", "Author A")
+    returned_book = _make_book(lib.id, "Returned Title", None)
+    test_session.add_all([active_book, returned_book])
+    await test_session.flush()
+
+    test_session.add_all([
+        _make_loan(
+            library_id=lib.id, book_id=active_book.id, borrower_id=alice.id,
+            borrower_name="Alice", lent_date=today - timedelta(days=1),
+        ),
+        _make_loan(
+            library_id=lib.id, book_id=returned_book.id, borrower_id=alice.id,
+            borrower_name="Alice", lent_date=today - timedelta(days=30),
+            returned_date=today - timedelta(days=10), return_condition="good",
+        ),
+    ])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.get(f"/api/v1/borrowers/{alice.id}/loans", headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 2
+
+        # Active loan should come first
+        assert body[0]["book_title"] == "Active Title"
+        assert body[0]["book_author"] == "Author A"
+        assert body[0]["returned_date"] is None
+        assert body[0]["return_condition"] is None
+
+        assert body[1]["book_title"] == "Returned Title"
+        assert body[1]["book_author"] is None
+        assert body[1]["returned_date"] == (today - timedelta(days=10)).isoformat()
+        assert body[1]["return_condition"] == "good"
+
+
+@pytest.mark.asyncio
+async def test_borrower_loans_returns_empty_list_when_no_loans(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    alice = Borrower(library_id=lib.id, name="Alice")
+    test_session.add(alice)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.get(f"/api/v1/borrowers/{alice.id}/loans", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_borrower_loans_returns_404_for_foreign_borrower(
+    test_session: AsyncSession,
+) -> None:
+    await _seed_user_with_library(test_session)
+    foreign_lib_id = uuid.uuid4()
+    foreign = Borrower(library_id=foreign_lib_id, name="Foreign")
+    test_session.add(foreign)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.get(f"/api/v1/borrowers/{foreign.id}/loans", headers=headers)
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_borrower_loans_returns_404_for_unknown_borrower(
+    test_session: AsyncSession,
+) -> None:
+    await _seed_user_with_library(test_session)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.get(f"/api/v1/borrowers/{uuid.uuid4()}/loans", headers=headers)
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_borrower_loans_requires_authentication() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/api/v1/borrowers/{uuid.uuid4()}/loans")
+        assert resp.status_code == 401

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1868,7 +1868,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/BorrowerResponse"
+                    "$ref": "#/components/schemas/BorrowerListItem"
                   },
                   "title": "Response Read Borrowers Api V1 Borrowers Get"
                 }
@@ -2069,6 +2069,74 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BorrowerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/borrowers/{borrower_id}/loans": {
+      "get": {
+        "tags": [
+          "borrowers"
+        ],
+        "summary": "Read Borrower Loans",
+        "operationId": "read_borrower_loans_api_v1_borrowers__borrower_id__loans_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "borrower_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Borrower Id"
+            }
+          },
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BorrowerLoanItem"
+                  },
+                  "title": "Response Read Borrower Loans Api V1 Borrowers  Borrower Id  Loans Get"
                 }
               }
             }
@@ -4275,6 +4343,192 @@
           "name"
         ],
         "title": "BorrowerCreate"
+      },
+      "BorrowerListItem": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "contact": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contact"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "anonymized_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Anonymized At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "active_loans": {
+            "type": "integer",
+            "title": "Active Loans"
+          },
+          "total_loans": {
+            "type": "integer",
+            "title": "Total Loans"
+          },
+          "last_activity_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Activity At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "contact",
+          "notes",
+          "anonymized_at",
+          "created_at",
+          "updated_at",
+          "active_loans",
+          "total_loans",
+          "last_activity_at"
+        ],
+        "title": "BorrowerListItem",
+        "description": "Borrower record enriched with lending-activity stats for the overview page."
+      },
+      "BorrowerLoanItem": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "book_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Book Id"
+          },
+          "book_title": {
+            "type": "string",
+            "title": "Book Title"
+          },
+          "book_author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Book Author"
+          },
+          "lent_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Lent Date"
+          },
+          "due_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due Date"
+          },
+          "returned_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Returned Date"
+          },
+          "return_condition": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return Condition"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "book_id",
+          "book_title",
+          "book_author",
+          "lent_date",
+          "due_date",
+          "returned_date",
+          "return_condition",
+          "notes"
+        ],
+        "title": "BorrowerLoanItem",
+        "description": "A loan as seen from the borrower-detail page — denormalized with book info."
       },
       "BorrowerResponse": {
         "properties": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,8 @@ import { ScanShelfPage } from './pages/ScanShelfPage'
 import { BookshelfViewPage } from './pages/BookshelfViewPage'
 import { PricingPage } from './pages/PricingPage'
 import { SettingsPage } from './pages/SettingsPage'
+import { BorrowersPage } from './pages/BorrowersPage'
+import { BorrowerDetailPage } from './pages/BorrowerDetailPage'
 import { LandingPage } from './pages/LandingPage'
 import { OAuthCallbackPage } from './pages/OAuthCallbackPage'
 import { PrivacyPage } from './pages/PrivacyPage'
@@ -106,6 +108,8 @@ function AppShell() {
             <Route path={ROUTES.bookshelfView} element={<BookshelfViewPage />} />
             <Route path={ROUTES.bookDetail} element={<BookDetailPage />} />
             <Route path={ROUTES.locations} element={<Navigate to={`${ROUTES.bookshelfView}?tab=locations`} replace />} />
+            <Route path={ROUTES.borrowers} element={<BorrowersPage />} />
+            <Route path={ROUTES.borrowerDetail} element={<BorrowerDetailPage />} />
             <Route path={ROUTES.settings} element={<SettingsPage />} />
           </Route>
         </Routes>

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -63,6 +63,17 @@ function IconLocations({ size = 24 }: { size?: number }) {
   )
 }
 
+function IconBorrowers({ size = 24 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  )
+}
+
 function IconSettings({ size = 24 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
@@ -102,6 +113,7 @@ const iconComponents = {
   scan: IconCamera,
   bookshelf: IconBookshelf,
   locations: IconLocations,
+  borrowers: IconBorrowers,
   settings: IconSettings,
 }
 
@@ -132,6 +144,13 @@ export function Navigation() {
     () => [
       { label: t('nav.add'), icon: 'add', path: ROUTES.addBook },
       { label: t('nav.scan'), icon: 'scan', path: ROUTES.scanShelf },
+    ],
+    [t],
+  )
+
+  const secondaryGroup = useMemo<NavItem[]>(
+    () => [
+      { label: t('nav.borrowers'), icon: 'borrowers', path: ROUTES.borrowers },
     ],
     [t],
   )
@@ -248,6 +267,23 @@ export function Navigation() {
               key={tab.path}
               onClick={() => navigate(tab.path)}
               className={`sh-sidebar-btn${active ? ' active' : ''}`}
+            >
+              <Icon size={20} />
+              <span>{tab.label}</span>
+            </button>
+          )
+        })}
+
+        <div className="sh-sidebar-divider" />
+        {secondaryGroup.map((tab) => {
+          const active = isActive(tab.path)
+          const Icon = iconComponents[tab.icon]
+          return (
+            <button
+              key={tab.path}
+              onClick={() => navigate(tab.path)}
+              className={`sh-sidebar-btn${active ? ' active' : ''}`}
+              data-testid={`nav-${tab.icon}`}
             >
               <Icon size={20} />
               <span>{tab.label}</span>

--- a/frontend/src/hooks/useBorrowers.ts
+++ b/frontend/src/hooks/useBorrowers.ts
@@ -1,9 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { listBorrowers } from '../lib/api'
+import { getBorrower, listBorrowerLoans, listBorrowers } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
 
 export const BORROWERS_QUERY_KEY = ['borrowers']
+const borrowerKey = (id: string) => ['borrower', id]
+const borrowerLoansKey = (id: string) => ['borrower', id, 'loans']
 
 export function useBorrowers() {
   const { isAuthenticated } = useAuth()
@@ -12,5 +14,25 @@ export function useBorrowers() {
     queryFn: listBorrowers,
     retry: false,
     enabled: isAuthenticated,
+  })
+}
+
+export function useBorrower(id: string) {
+  const { isAuthenticated } = useAuth()
+  return useQuery({
+    queryKey: borrowerKey(id),
+    queryFn: () => getBorrower(id),
+    retry: false,
+    enabled: isAuthenticated && Boolean(id),
+  })
+}
+
+export function useBorrowerLoans(id: string) {
+  const { isAuthenticated } = useAuth()
+  return useQuery({
+    queryKey: borrowerLoansKey(id),
+    queryFn: () => listBorrowerLoans(id),
+    retry: false,
+    enabled: isAuthenticated && Boolean(id),
   })
 }

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -8,6 +8,7 @@
     "add": "Přidat",
     "scan": "Sken",
     "locations": "Lokace",
+    "borrowers": "Dlužníci",
     "settings": "Nastavení",
     "bookshelf": "Police",
     "add_book": "Přidat knihu",
@@ -712,5 +713,28 @@
     "added": "Přidáno",
     "changed": "Změněno",
     "fixed": "Opraveno"
+  },
+  "borrowers": {
+    "title": "Dlužníci",
+    "subtitle": "Lidé, kteří si půjčili knihy z této knihovny.",
+    "search_placeholder": "Hledat podle jména…",
+    "loading": "Načítám…",
+    "empty_title": "Zatím žádní dlužníci.",
+    "empty_description": "Dlužníci se vytvoří, jakmile někomu půjčíš knihu.",
+    "no_results": "Žádný dlužník neodpovídá „{{query}}\".",
+    "active_count_one": "{{count}} aktivní půjčka",
+    "active_count_few": "{{count}} aktivní půjčky",
+    "active_count_other": "{{count}} aktivních půjček",
+    "total_count_one": "{{count}} půjčka celkem",
+    "total_count_few": "{{count}} půjčky celkem",
+    "total_count_other": "{{count}} půjček celkem",
+    "last_activity": "Poslední aktivita {{date}}",
+    "no_activity": "Zatím žádná aktivita",
+    "back_to_overview": "Zpět na seznam",
+    "section_active_loans": "Aktuálně půjčeno",
+    "section_returned_loans": "Vráceno",
+    "empty_active_loans": "Aktuálně nemá vypůjčené žádné knihy.",
+    "empty_returned_loans": "V historii nejsou žádné vrácené knihy.",
+    "detail_not_found": "Dlužník nenalezen."
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -8,6 +8,7 @@
     "add": "Add",
     "scan": "Scan",
     "locations": "Locations",
+    "borrowers": "Borrowers",
     "settings": "Settings",
     "bookshelf": "Shelves",
     "add_book": "Add book",
@@ -712,5 +713,26 @@
     "added": "Added",
     "changed": "Changed",
     "fixed": "Fixed"
+  },
+  "borrowers": {
+    "title": "Borrowers",
+    "subtitle": "People who have borrowed books from this library.",
+    "search_placeholder": "Search by name…",
+    "loading": "Loading…",
+    "empty_title": "No borrowers yet.",
+    "empty_description": "Borrowers are created when you lend a book.",
+    "no_results": "No borrowers match \"{{query}}\".",
+    "active_count_one": "{{count}} active loan",
+    "active_count_other": "{{count}} active loans",
+    "total_count_one": "{{count}} loan total",
+    "total_count_other": "{{count}} loans total",
+    "last_activity": "Last activity {{date}}",
+    "no_activity": "No activity yet",
+    "back_to_overview": "Back to borrowers",
+    "section_active_loans": "Currently borrowed",
+    "section_returned_loans": "Returned",
+    "empty_active_loans": "No books currently borrowed.",
+    "empty_returned_loans": "No returned books in history.",
+    "detail_not_found": "Borrower not found."
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,6 +8,8 @@ import type {
   BillingStatus,
   Borrower,
   BorrowerCreateRequest,
+  BorrowerListItem,
+  BorrowerLoanItem,
   CheckoutResponse,
   CsvImportConfirmRequest,
   CsvImportConfirmResponse,
@@ -481,8 +483,18 @@ export async function returnLoan(bookId: string, loanId: string, payload: LoanRe
   return response.data
 }
 
-export async function listBorrowers(): Promise<Borrower[]> {
-  const response = await apiClient.get<Borrower[]>('/api/v1/borrowers')
+export async function listBorrowers(): Promise<BorrowerListItem[]> {
+  const response = await apiClient.get<BorrowerListItem[]>('/api/v1/borrowers')
+  return response.data
+}
+
+export async function getBorrower(id: string): Promise<Borrower> {
+  const response = await apiClient.get<Borrower>(`/api/v1/borrowers/${id}`)
+  return response.data
+}
+
+export async function listBorrowerLoans(id: string): Promise<BorrowerLoanItem[]> {
+  const response = await apiClient.get<BorrowerLoanItem[]>(`/api/v1/borrowers/${id}/loans`)
   return response.data
 }
 

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -8,6 +8,8 @@ export const ROUTES = {
   scanShelf: '/scan',
   bookshelfView: '/bookshelf',
   locations: '/locations',
+  borrowers: '/borrowers',
+  borrowerDetail: '/borrowers/:borrowerId',
   settings: '/settings',
   pricing: '/pricing',
   changelog: '/changelog',
@@ -18,4 +20,8 @@ export const ROUTES = {
 
 export function getBookDetailRoute(bookId: string): string {
   return `/books/${bookId}`
+}
+
+export function getBorrowerDetailRoute(borrowerId: string): string {
+  return `/borrowers/${borrowerId}`
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -42,6 +42,24 @@ export interface Borrower {
   updated_at: string
 }
 
+export interface BorrowerListItem extends Borrower {
+  active_loans: number
+  total_loans: number
+  last_activity_at: string | null
+}
+
+export interface BorrowerLoanItem {
+  id: string
+  book_id: string
+  book_title: string
+  book_author: string | null
+  lent_date: string
+  due_date: string | null
+  returned_date: string | null
+  return_condition: 'perfect' | 'good' | 'fair' | 'damaged' | 'lost' | null
+  notes: string | null
+}
+
 export interface BorrowerCreateRequest {
   name: string
   contact?: string | null

--- a/frontend/src/pages/BorrowerDetailPage.test.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.test.tsx
@@ -1,0 +1,147 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true })),
+}))
+
+vi.mock('../lib/api', () => ({
+  getBorrower: vi.fn(),
+  listBorrowerLoans: vi.fn(),
+}))
+
+import { getBorrower, listBorrowerLoans } from '../lib/api'
+import type { Borrower, BorrowerLoanItem } from '../lib/types'
+import { BorrowerDetailPage } from './BorrowerDetailPage'
+
+function makeBorrower(overrides: Partial<Borrower> = {}): Borrower {
+  return {
+    id: 'b-alice',
+    name: 'Alice Liddell',
+    contact: 'alice@x.com',
+    notes: null,
+    anonymized_at: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeLoan(overrides: Partial<BorrowerLoanItem> = {}): BorrowerLoanItem {
+  return {
+    id: 'loan-1',
+    book_id: 'book-1',
+    book_title: 'Wonderland',
+    book_author: 'Lewis Carroll',
+    lent_date: '2026-05-01',
+    due_date: null,
+    returned_date: null,
+    return_condition: null,
+    notes: null,
+    ...overrides,
+  }
+}
+
+function renderPage(borrowerId = 'b-alice') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/borrowers/${borrowerId}`]}>
+        <Routes>
+          <Route path="/borrowers/:borrowerId" element={<BorrowerDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('BorrowerDetailPage', () => {
+  it('renders the borrower header with name, contact and notes', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower({ notes: 'Regular borrower' }))
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    expect(await screen.findByText('Alice Liddell')).toBeInTheDocument()
+    expect(screen.getByText('alice@x.com')).toBeInTheDocument()
+    expect(screen.getByText('Regular borrower')).toBeInTheDocument()
+  })
+
+  it('groups loans into active and returned sections', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower())
+    vi.mocked(listBorrowerLoans).mockResolvedValue([
+      makeLoan({ id: 'l-active-1', book_id: 'book-a', book_title: 'Active Book', returned_date: null }),
+      makeLoan({
+        id: 'l-returned-1',
+        book_id: 'book-b',
+        book_title: 'Returned Book',
+        returned_date: '2026-04-20',
+        return_condition: 'good',
+      }),
+    ])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('borrower-active-list')).toBeInTheDocument()
+      expect(screen.getByTestId('borrower-returned-list')).toBeInTheDocument()
+    })
+
+    const activeRow = screen.getByTestId('borrower-loan-l-active-1')
+    expect(activeRow).toHaveTextContent('Active Book')
+
+    const returnedRow = screen.getByTestId('borrower-loan-l-returned-1')
+    expect(returnedRow).toHaveTextContent('Returned Book')
+    expect(screen.getByTestId('borrower-loan-condition-l-returned-1')).toBeInTheDocument()
+  })
+
+  it('shows the empty state for active loans when none exist', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower())
+    vi.mocked(listBorrowerLoans).mockResolvedValue([
+      makeLoan({ id: 'l-returned-only', returned_date: '2026-04-01' }),
+    ])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('borrower-active-empty')).toBeInTheDocument()
+      expect(screen.getByTestId('borrower-returned-list')).toBeInTheDocument()
+    })
+  })
+
+  it('shows the empty state for returned loans when none exist', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower())
+    vi.mocked(listBorrowerLoans).mockResolvedValue([
+      makeLoan({ id: 'l-active-only', returned_date: null }),
+    ])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('borrower-returned-empty')).toBeInTheDocument()
+      expect(screen.getByTestId('borrower-active-list')).toBeInTheDocument()
+    })
+  })
+
+  it('shows both empty states for a brand-new borrower with no loans', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower())
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('borrower-active-empty')).toBeInTheDocument()
+      expect(screen.getByTestId('borrower-returned-empty')).toBeInTheDocument()
+    })
+  })
+
+  it('shows the not-found state when the borrower request errors', async () => {
+    vi.mocked(getBorrower).mockRejectedValue(new Error('404'))
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    expect(await screen.findByTestId('borrower-detail-error')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/BorrowerDetailPage.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.tsx
@@ -1,0 +1,193 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link, useParams } from 'react-router-dom'
+
+import { EmptyShelfIcon, NoResultsIcon } from '../components/EmptyStateIcons'
+import { useBorrower, useBorrowerLoans } from '../hooks/useBorrowers'
+import { ROUTES, getBookDetailRoute } from '../lib/routes'
+import type { BorrowerLoanItem } from '../lib/types'
+
+function formatDate(value: string | null, locale: string): string {
+  if (!value) return '—'
+  try {
+    return new Date(value).toLocaleDateString(locale)
+  } catch {
+    return value
+  }
+}
+
+interface LoanRowProps {
+  loan: BorrowerLoanItem
+  locale: string
+}
+
+function LoanRow({ loan, locale }: LoanRowProps) {
+  const { t } = useTranslation()
+  return (
+    <li
+      data-testid={`borrower-loan-${loan.id}`}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1fr) auto',
+        gap: 12,
+        padding: 12,
+        border: '1px solid var(--sh-border)',
+        borderRadius: 'var(--sh-radius-md)',
+        background: 'var(--sh-surface)',
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <Link
+          to={getBookDetailRoute(loan.book_id)}
+          style={{ fontWeight: 600, color: 'inherit', textDecoration: 'none' }}
+        >
+          {loan.book_title}
+        </Link>
+        {loan.book_author && (
+          <div style={{ fontSize: 13, color: 'var(--sh-text-muted)' }}>{loan.book_author}</div>
+        )}
+        {loan.notes && (
+          <div style={{ fontSize: 12, color: 'var(--sh-text-muted)', marginTop: 4 }}>{loan.notes}</div>
+        )}
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gap: 2,
+          fontSize: 12,
+          color: 'var(--sh-text-muted)',
+          textAlign: 'right',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <span>{t('loans.lent_date')}: {formatDate(loan.lent_date, locale)}</span>
+        {loan.due_date && <span>{t('loans.due_date')}: {formatDate(loan.due_date, locale)}</span>}
+        {loan.returned_date && (
+          <span>
+            {t('loans.return_date')}: {formatDate(loan.returned_date, locale)}
+          </span>
+        )}
+        {loan.return_condition && (
+          <span data-testid={`borrower-loan-condition-${loan.id}`}>
+            {t(`loans.condition_${loan.return_condition}`)}
+          </span>
+        )}
+      </div>
+    </li>
+  )
+}
+
+export function BorrowerDetailPage() {
+  const { borrowerId } = useParams<{ borrowerId: string }>()
+  const { t, i18n } = useTranslation()
+  const borrowerQuery = useBorrower(borrowerId ?? '')
+  const loansQuery = useBorrowerLoans(borrowerId ?? '')
+
+  const { active, returned } = useMemo(() => {
+    const all = loansQuery.data ?? []
+    return {
+      active: all.filter((l) => l.returned_date === null),
+      returned: all.filter((l) => l.returned_date !== null),
+    }
+  }, [loansQuery.data])
+
+  if (borrowerQuery.isLoading) {
+    return (
+      <main className="sh-main" style={{ padding: 24, maxWidth: 760, margin: '0 auto' }}>
+        <p data-testid="borrower-detail-loading" style={{ color: 'var(--sh-text-muted)' }}>
+          {t('borrowers.loading')}
+        </p>
+      </main>
+    )
+  }
+
+  if (borrowerQuery.isError || !borrowerQuery.data) {
+    return (
+      <main className="sh-main" style={{ padding: 24, maxWidth: 760, margin: '0 auto' }}>
+        <p data-testid="borrower-detail-error" style={{ color: 'var(--sh-text-muted)' }}>
+          {t('borrowers.detail_not_found')}
+        </p>
+        <Link to={ROUTES.borrowers}>{t('borrowers.back_to_overview')}</Link>
+      </main>
+    )
+  }
+
+  const borrower = borrowerQuery.data
+
+  return (
+    <main className="sh-main" style={{ padding: 24, maxWidth: 760, margin: '0 auto' }}>
+      <div style={{ marginBottom: 16 }}>
+        <Link
+          to={ROUTES.borrowers}
+          style={{ fontSize: 13, color: 'var(--sh-text-muted)', textDecoration: 'none' }}
+        >
+          ← {t('borrowers.back_to_overview')}
+        </Link>
+      </div>
+
+      <header style={{ marginBottom: 24 }}>
+        <h1 className="text-h2" style={{ margin: 0 }}>{borrower.name}</h1>
+        {borrower.contact && (
+          <p style={{ margin: '4px 0 0', color: 'var(--sh-text-muted)' }}>{borrower.contact}</p>
+        )}
+        {borrower.notes && (
+          <p style={{ margin: '8px 0 0', whiteSpace: 'pre-wrap' }}>{borrower.notes}</p>
+        )}
+      </header>
+
+      {/* Active loans */}
+      <section style={{ marginBottom: 24 }}>
+        <h2 className="text-h3" style={{ margin: '0 0 8px' }}>
+          {t('borrowers.section_active_loans')}
+        </h2>
+        {loansQuery.isLoading ? (
+          <p data-testid="borrower-loans-loading" style={{ color: 'var(--sh-text-muted)' }}>
+            {t('borrowers.loading')}
+          </p>
+        ) : active.length === 0 ? (
+          <div
+            data-testid="borrower-active-empty"
+            style={{ padding: 16, color: 'var(--sh-text-muted)', textAlign: 'center' }}
+          >
+            <EmptyShelfIcon size={48} />
+            <p style={{ margin: '8px 0 0' }}>{t('borrowers.empty_active_loans')}</p>
+          </div>
+        ) : (
+          <ul
+            data-testid="borrower-active-list"
+            style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}
+          >
+            {active.map((loan) => (
+              <LoanRow key={loan.id} loan={loan} locale={i18n.language} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Returned loans */}
+      <section>
+        <h2 className="text-h3" style={{ margin: '0 0 8px' }}>
+          {t('borrowers.section_returned_loans')}
+        </h2>
+        {loansQuery.isLoading ? null : returned.length === 0 ? (
+          <div
+            data-testid="borrower-returned-empty"
+            style={{ padding: 16, color: 'var(--sh-text-muted)', textAlign: 'center' }}
+          >
+            <NoResultsIcon size={48} />
+            <p style={{ margin: '8px 0 0' }}>{t('borrowers.empty_returned_loans')}</p>
+          </div>
+        ) : (
+          <ul
+            data-testid="borrower-returned-list"
+            style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}
+          >
+            {returned.map((loan) => (
+              <LoanRow key={loan.id} loan={loan} locale={i18n.language} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/frontend/src/pages/BorrowersPage.test.tsx
+++ b/frontend/src/pages/BorrowersPage.test.tsx
@@ -1,0 +1,131 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true })),
+}))
+
+vi.mock('../lib/api', () => ({
+  listBorrowers: vi.fn(),
+}))
+
+import { listBorrowers } from '../lib/api'
+import type { BorrowerListItem } from '../lib/types'
+import { BorrowersPage } from './BorrowersPage'
+
+function makeBorrower(overrides: Partial<BorrowerListItem> = {}): BorrowerListItem {
+  return {
+    id: 'b1',
+    name: 'Alice Liddell',
+    contact: 'alice@x.com',
+    notes: null,
+    anonymized_at: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+    active_loans: 0,
+    total_loans: 0,
+    last_activity_at: null,
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <BorrowersPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('BorrowersPage', () => {
+  it('shows the empty state when there are no borrowers', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([])
+    renderPage()
+    expect(await screen.findByTestId('borrowers-empty')).toBeInTheDocument()
+    expect(screen.getByText('borrowers.empty_title')).toBeInTheDocument()
+  })
+
+  it('renders one row per borrower with stats and a link to the detail page', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({
+        id: 'b-alice',
+        name: 'Alice',
+        active_loans: 2,
+        total_loans: 5,
+        last_activity_at: '2026-05-01',
+      }),
+      makeBorrower({
+        id: 'b-bob',
+        name: 'Bob',
+        contact: null,
+        active_loans: 0,
+        total_loans: 1,
+        last_activity_at: null,
+      }),
+    ])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('borrowers-list')).toBeInTheDocument()
+    })
+
+    const aliceRow = screen.getByTestId('borrower-row-b-alice')
+    expect(aliceRow).toHaveAttribute('href', '/borrowers/b-alice')
+    expect(aliceRow).toHaveTextContent('Alice')
+    expect(aliceRow).toHaveTextContent('alice@x.com')
+
+    const bobRow = screen.getByTestId('borrower-row-b-bob')
+    expect(bobRow).toHaveAttribute('href', '/borrowers/b-bob')
+
+    // Stats labels (i18n mock returns keys, so check via testid presence)
+    expect(screen.getByTestId('borrower-active-b-alice')).toBeInTheDocument()
+    expect(screen.getByTestId('borrower-total-b-alice')).toBeInTheDocument()
+    expect(screen.getByTestId('borrower-last-b-alice')).toBeInTheDocument()
+    expect(screen.getByTestId('borrower-last-b-bob')).toHaveTextContent('borrowers.no_activity')
+  })
+
+  it('filters the list by name with a case-insensitive substring search', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({ id: 'b-alice', name: 'Alice Liddell' }),
+      makeBorrower({ id: 'b-bob', name: 'Bob Builder' }),
+      makeBorrower({ id: 'b-carol', name: 'Carol Danvers' }),
+    ])
+    renderPage()
+
+    await waitFor(() => expect(screen.getByTestId('borrowers-list')).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    const searchBox = screen.getByPlaceholderText('borrowers.search_placeholder')
+    await user.type(searchBox, 'BOB')
+
+    expect(screen.queryByTestId('borrower-row-b-alice')).not.toBeInTheDocument()
+    expect(screen.getByTestId('borrower-row-b-bob')).toBeInTheDocument()
+    expect(screen.queryByTestId('borrower-row-b-carol')).not.toBeInTheDocument()
+  })
+
+  it('shows a no-results message when the search matches nothing', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({ id: 'b-alice', name: 'Alice' }),
+    ])
+    renderPage()
+
+    await waitFor(() => expect(screen.getByTestId('borrowers-list')).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('borrowers.search_placeholder'), 'zzz')
+
+    expect(screen.getByTestId('borrowers-no-results')).toBeInTheDocument()
+    expect(screen.queryByTestId('borrowers-empty')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/BorrowersPage.tsx
+++ b/frontend/src/pages/BorrowersPage.tsx
@@ -1,0 +1,157 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { NoResultsIcon } from '../components/EmptyStateIcons'
+import { useBorrowers } from '../hooks/useBorrowers'
+import { getBorrowerDetailRoute } from '../lib/routes'
+import type { BorrowerListItem } from '../lib/types'
+
+function formatDate(value: string | null, locale: string): string {
+  if (!value) return '—'
+  try {
+    return new Date(value).toLocaleDateString(locale)
+  } catch {
+    return value
+  }
+}
+
+function matchesSearch(borrower: BorrowerListItem, query: string): boolean {
+  if (!query.trim()) return true
+  const target = query.trim().toLowerCase()
+  return borrower.name.toLowerCase().includes(target)
+}
+
+export function BorrowersPage() {
+  const { t, i18n } = useTranslation()
+  const borrowersQuery = useBorrowers()
+  const [search, setSearch] = useState('')
+
+  const filtered = useMemo(() => {
+    const all = borrowersQuery.data ?? []
+    return all.filter((b) => matchesSearch(b, search))
+  }, [borrowersQuery.data, search])
+
+  const isLoading = borrowersQuery.isLoading
+  const total = borrowersQuery.data?.length ?? 0
+
+  return (
+    <main className="sh-main" style={{ padding: 24, maxWidth: 960, margin: '0 auto' }}>
+      <header style={{ marginBottom: 16 }}>
+        <h1 className="text-h2" style={{ margin: 0 }}>{t('borrowers.title')}</h1>
+        <p style={{ margin: '4px 0 0', color: 'var(--sh-text-muted)' }}>
+          {t('borrowers.subtitle')}
+        </p>
+      </header>
+
+      <div style={{ marginBottom: 16 }}>
+        <input
+          type="search"
+          className="sh-input"
+          placeholder={t('borrowers.search_placeholder')}
+          aria-label={t('borrowers.search_placeholder')}
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+      </div>
+
+      {isLoading && (
+        <p data-testid="borrowers-loading" style={{ color: 'var(--sh-text-muted)' }}>
+          {t('borrowers.loading')}
+        </p>
+      )}
+
+      {!isLoading && total === 0 && (
+        <div
+          data-testid="borrowers-empty"
+          style={{ textAlign: 'center', padding: '48px 16px', color: 'var(--sh-text-muted)' }}
+        >
+          <NoResultsIcon size={64} />
+          <h2 className="text-h3" style={{ marginTop: 12, color: 'var(--sh-text-main)' }}>
+            {t('borrowers.empty_title')}
+          </h2>
+          <p style={{ margin: '4px 0 0' }}>{t('borrowers.empty_description')}</p>
+        </div>
+      )}
+
+      {!isLoading && total > 0 && filtered.length === 0 && (
+        <div
+          data-testid="borrowers-no-results"
+          style={{ textAlign: 'center', padding: '32px 16px', color: 'var(--sh-text-muted)' }}
+        >
+          {t('borrowers.no_results', { query: search.trim() })}
+        </div>
+      )}
+
+      {!isLoading && filtered.length > 0 && (
+        <ul
+          data-testid="borrowers-list"
+          style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}
+        >
+          {filtered.map((borrower) => (
+            <li key={borrower.id}>
+              <Link
+                to={getBorrowerDetailRoute(borrower.id)}
+                data-testid={`borrower-row-${borrower.id}`}
+                className="sh-card"
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'minmax(0, 1fr) auto',
+                  gap: 12,
+                  padding: 16,
+                  textDecoration: 'none',
+                  color: 'inherit',
+                  border: '1px solid var(--sh-border)',
+                  borderRadius: 'var(--sh-radius-md)',
+                  background: 'var(--sh-surface)',
+                }}
+              >
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontWeight: 600, fontSize: 15 }}>{borrower.name}</div>
+                  {borrower.contact && (
+                    <div
+                      style={{
+                        fontSize: 13,
+                        color: 'var(--sh-text-muted)',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {borrower.contact}
+                    </div>
+                  )}
+                </div>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridAutoFlow: 'column',
+                    gap: 12,
+                    alignItems: 'center',
+                    fontSize: 12,
+                    color: 'var(--sh-text-muted)',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  <span data-testid={`borrower-active-${borrower.id}`}>
+                    {t('borrowers.active_count', { count: borrower.active_loans })}
+                  </span>
+                  <span data-testid={`borrower-total-${borrower.id}`}>
+                    {t('borrowers.total_count', { count: borrower.total_loans })}
+                  </span>
+                  <span data-testid={`borrower-last-${borrower.id}`}>
+                    {borrower.last_activity_at
+                      ? t('borrowers.last_activity', {
+                          date: formatDate(borrower.last_activity_at, i18n.language),
+                        })
+                      : t('borrowers.no_activity')}
+                  </span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Phase 4 of the Borrowers epic (#221). Adds user-facing `/borrowers` and `/borrowers/:id` pages plus the backend endpoints to power them.

### Backend

- `GET /api/v1/borrowers` now returns enriched `BorrowerListItem`s with `active_loans`, `total_loans`, `last_activity_at`. Computed via a single LEFT JOIN + GROUP BY scoped to the active library on **both** sides of the join (defensive against any cross-library row).
- New `GET /api/v1/borrowers/{id}/loans` returns `BorrowerLoanItem`s with denormalized `book_title`/`book_author` so the detail page renders without N+1 fetches. Active loans first, then returned by most recent return.
- Tests in `tests/test_borrower_pages.py` cover stats correctness, zero-state, cross-library defense, ordering of active vs. returned, empty list, 404 for foreign borrower, 404 for unknown id, and 401 without auth.

### Frontend

- `BorrowersPage` — search (case-insensitive substring, client-side), per-row stats and contact summary, link to detail.
- `BorrowerDetailPage` — name/contact/notes header + two sections (currently borrowed / returned) with per-loan dates and return condition. Book title links to the book detail.
- Three empty states (no borrowers, no active loans for a borrower, no returned history for a borrower).
- Desktop sidebar gets a secondary "Borrowers" nav link. Mobile bottom-nav unchanged — page is reachable via URL on mobile; expanding mobile nav is a separate UX call.
- New types `BorrowerListItem`, `BorrowerLoanItem`; helpers `getBorrower`, `listBorrowerLoans`; hooks `useBorrower`, `useBorrowerLoans`.
- i18n: full `borrowers.*` namespace + `nav.borrowers` in cs and en, with ICU plural forms for the count strings.

Out of scope: anonymization (#226), removal of legacy `borrower_name`/`borrower_contact` (#227), email/SMS.

Parent epic: #221
Closes #225

## Test plan

- [x] `cd frontend && npx tsc --noEmit` (no new errors)
- [x] `cd frontend && npm run lint` on touched files (clean)
- [x] `cd frontend && npm test` — 145/145 (10 new)
- [ ] `cd backend && ruff check app tests`
- [ ] `cd backend && mypy app tests`
- [ ] `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`
- [ ] `python scripts/generate_openapi.py && git diff docs/openapi.yaml` — confirm new `BorrowerListItem`/`BorrowerLoanItem` schemas and `/api/v1/borrowers/{id}/loans` operation
- [ ] Manual: open `/borrowers`, verify stats render and search filters; open a borrower, verify both sections (active/returned) and empty states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a borrowers section with searchable listing, borrower detail page, per-borrower stats (active/total/last activity), navigation link, and API endpoints to fetch borrower lists and a borrower's loans.
* **Documentation**
  * OpenAPI updated with borrower list and borrower-loans schemas/endpoints.
* **Tests**
  * New backend and frontend tests covering borrower overview, loans, pages, and UI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->