### PR TITLE
feat(borrowers): privacy-safe anonymization (#226)

### DIFF
--- a/backend/app/api/borrowers.py
+++ b/backend/app/api/borrowers.py
@@ -13,6 +13,7 @@ from app.schemas.borrower import (
     BorrowerUpdate,
 )
 from app.services.borrower import (
+    anonymize_borrower,
     create_borrower,
     get_borrower_or_404,
     list_borrowers_with_stats,
@@ -79,3 +80,13 @@ async def read_borrower_loans(
 ) -> list[BorrowerLoanItem]:
     rows = await list_loans_for_borrower(session, borrower_id, library_id)
     return [BorrowerLoanItem.model_validate(row) for row in rows]
+
+
+@router.post("/{borrower_id}/anonymize", response_model=BorrowerResponse)
+async def anonymize_borrower_endpoint(
+    borrower_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(require_editor_library),
+) -> BorrowerResponse:
+    borrower = await anonymize_borrower(session, borrower_id, library_id)
+    return BorrowerResponse.model_validate(borrower)

--- a/backend/app/services/borrower.py
+++ b/backend/app/services/borrower.py
@@ -1,9 +1,9 @@
 import uuid
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
 
 from fastapi import HTTPException, status
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
@@ -13,6 +13,12 @@ from app.models.loan import Loan
 from app.schemas.borrower import BorrowerCreate, BorrowerUpdate
 
 logger = structlog.get_logger()
+
+# Sentinel name written to anonymized borrower rows AND to the denormalized
+# ``loan.borrower_name`` column for any loan attached to that borrower. Frontend
+# detects ``anonymized_at`` to render a localized label; the DB string is
+# whatever is robust and never empty.
+ANONYMIZED_BORROWER_NAME = "Deleted borrower"
 
 
 @dataclass(frozen=True)
@@ -242,3 +248,45 @@ async def link_loans_to_borrowers(session: AsyncSession, library_id: uuid.UUID) 
             borrowers_total=len(bucket),
         )
     return linked
+
+
+async def anonymize_borrower(
+    session: AsyncSession, borrower_id: uuid.UUID, library_id: uuid.UUID
+) -> Borrower:
+    """Strip identifying data from a borrower and from their loan history.
+
+    Idempotent: calling this on an already-anonymized borrower is a no-op
+    that returns the existing row unchanged. Cross-library access raises
+    404 via ``get_borrower_or_404``.
+
+    Loan rows are updated alongside the borrower because ``Loan.borrower_name``
+    and ``Loan.borrower_contact`` carry a denormalized copy of the borrower
+    text. Leaving those untouched would defeat the anonymization.
+    """
+    borrower = await get_borrower_or_404(session, borrower_id, library_id)
+
+    if borrower.anonymized_at is not None:
+        return borrower
+
+    borrower.name = ANONYMIZED_BORROWER_NAME
+    borrower.contact = None
+    borrower.notes = None
+    borrower.anonymized_at = datetime.now(timezone.utc)
+
+    # Cascade-clear denormalized borrower text on loan rows. Loan history
+    # remains (book_id, lent/due/returned dates, return_condition) so the
+    # library still knows who borrowed what — minus the personal data.
+    await session.execute(
+        update(Loan)
+        .where(Loan.borrower_id == borrower_id, Loan.library_id == library_id)
+        .values(borrower_name=ANONYMIZED_BORROWER_NAME, borrower_contact=None)
+    )
+
+    await session.commit()
+    await session.refresh(borrower)
+    logger.info(
+        "borrower_anonymized",
+        borrower_id=str(borrower.id),
+        library_id=str(library_id),
+    )
+    return borrower

--- a/backend/tests/test_borrower_anonymize.py
+++ b/backend/tests/test_borrower_anonymize.py
@@ -1,0 +1,338 @@
+"""Tests for the borrower anonymization endpoint (issue #226).
+
+Covers:
+- anonymizing a borrower with an active loan clears identifying data
+- anonymizing a borrower with a returned loan keeps history but strips PII
+- the loan history endpoint still renders the borrower's loans afterwards
+- already-anonymized borrowers are a no-op (idempotent)
+- anonymization across libraries returns 404
+- viewer role cannot anonymize (403)
+- 401 without auth
+"""
+from collections.abc import AsyncIterator, Iterator
+from datetime import date, timedelta
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.book import Book
+from app.models.borrower import Borrower
+from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.loan import Loan
+from app.models.user import User
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url="sqlite+aiosqlite:///:memory:",
+        jwt_secret_key="test-secret",
+        jwt_algorithm="HS256",
+        access_token_expire_minutes=15,
+        refresh_token_expire_days=7,
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(test_session: AsyncSession, test_settings: Settings) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        yield test_session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _seed_user_with_library(
+    session: AsyncSession,
+    email: str = "admin@example.com",
+    role: LibraryRole = LibraryRole.OWNER,
+) -> tuple[User, Library]:
+    user = (await session.execute(select(User).where(User.email == email))).scalar_one_or_none()
+    if user is None:
+        user = User(email=email, hashed_password=get_password_hash("secret"))
+        session.add(user)
+        await session.flush()
+    lib = (await session.execute(
+        select(Library)
+        .join(LibraryMember, LibraryMember.library_id == Library.id)
+        .where(LibraryMember.user_id == user.id)
+        .limit(1)
+    )).scalar_one_or_none()
+    if lib is None:
+        lib = Library(name=f"Library of {email}", created_by_user_id=user.id)
+        session.add(lib)
+        await session.flush()
+        session.add(LibraryMember(library_id=lib.id, user_id=user.id, role=role))
+        await session.commit()
+        await session.refresh(lib)
+    return user, lib
+
+
+async def _auth_headers(
+    client: AsyncClient, session: AsyncSession, email: str = "admin@example.com"
+) -> dict[str, str]:
+    await _seed_user_with_library(session, email)
+    resp = await client.post("/api/v1/auth/login", json={"email": email, "password": "secret"})
+    assert resp.status_code == 200
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _make_book(library_id: uuid.UUID, title: str = "Some Book") -> Book:
+    return Book(library_id=library_id, title=title)
+
+
+def _make_loan(
+    *,
+    library_id: uuid.UUID,
+    book_id: uuid.UUID,
+    borrower_id: uuid.UUID,
+    borrower_name: str,
+    borrower_contact: str | None,
+    lent_date: date,
+    returned_date: date | None = None,
+    return_condition: str | None = None,
+) -> Loan:
+    return Loan(
+        library_id=library_id,
+        book_id=book_id,
+        borrower_id=borrower_id,
+        borrower_name=borrower_name,
+        borrower_contact=borrower_contact,
+        lent_date=lent_date,
+        returned_date=returned_date,
+        return_condition=return_condition,
+    )
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_anonymize_strips_borrower_pii_and_sets_anonymized_at(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    borrower = Borrower(
+        library_id=lib.id, name="Alice Liddell", contact="alice@x.com", notes="VIP"
+    )
+    test_session.add(borrower)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(f"/api/v1/borrowers/{borrower.id}/anonymize", headers=headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "Deleted borrower"
+    assert body["contact"] is None
+    assert body["notes"] is None
+    assert body["anonymized_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_anonymize_clears_borrower_text_on_active_loan(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    today = date.today()
+
+    borrower = Borrower(library_id=lib.id, name="Alice", contact="alice@x.com")
+    test_session.add(borrower)
+    await test_session.flush()
+
+    book = _make_book(lib.id)
+    test_session.add(book)
+    await test_session.flush()
+
+    loan = _make_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=borrower.id,
+        borrower_name="Alice", borrower_contact="alice@x.com", lent_date=today,
+    )
+    test_session.add(loan)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(f"/api/v1/borrowers/{borrower.id}/anonymize", headers=headers)
+        assert resp.status_code == 200
+
+    refreshed = (await test_session.execute(select(Loan).where(Loan.id == loan.id))).scalar_one()
+    assert refreshed.borrower_name == "Deleted borrower"
+    assert refreshed.borrower_contact is None
+    assert refreshed.borrower_id == borrower.id  # link is preserved
+
+
+@pytest.mark.asyncio
+async def test_anonymize_clears_borrower_text_on_returned_loan(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    today = date.today()
+
+    borrower = Borrower(library_id=lib.id, name="Bob", contact="bob@x.com")
+    test_session.add(borrower)
+    await test_session.flush()
+
+    book = _make_book(lib.id, "Returned Book")
+    test_session.add(book)
+    await test_session.flush()
+
+    loan = _make_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=borrower.id,
+        borrower_name="Bob", borrower_contact="bob@x.com",
+        lent_date=today - timedelta(days=20),
+        returned_date=today - timedelta(days=2),
+        return_condition="good",
+    )
+    test_session.add(loan)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(f"/api/v1/borrowers/{borrower.id}/anonymize", headers=headers)
+        assert resp.status_code == 200
+
+    refreshed = (await test_session.execute(select(Loan).where(Loan.id == loan.id))).scalar_one()
+    assert refreshed.borrower_name == "Deleted borrower"
+    assert refreshed.borrower_contact is None
+    # History fields preserved
+    assert refreshed.returned_date == today - timedelta(days=2)
+    assert refreshed.return_condition == "good"
+
+
+@pytest.mark.asyncio
+async def test_loan_history_endpoint_still_renders_after_anonymization(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    today = date.today()
+
+    borrower = Borrower(library_id=lib.id, name="Carol", contact="carol@x.com")
+    test_session.add(borrower)
+    await test_session.flush()
+
+    book = _make_book(lib.id, "Some Title")
+    test_session.add(book)
+    await test_session.flush()
+
+    test_session.add(_make_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=borrower.id,
+        borrower_name="Carol", borrower_contact="carol@x.com", lent_date=today,
+    ))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        anon = await client.post(f"/api/v1/borrowers/{borrower.id}/anonymize", headers=headers)
+        assert anon.status_code == 200
+
+        loans = await client.get(f"/api/v1/borrowers/{borrower.id}/loans", headers=headers)
+        assert loans.status_code == 200
+        body = loans.json()
+        assert len(body) == 1
+        assert body[0]["book_title"] == "Some Title"
+        # The endpoint is loan-centric; the borrower-detail GET tells the
+        # frontend the borrower is anonymized, so loan rows don't repeat that.
+
+        detail = await client.get(f"/api/v1/borrowers/{borrower.id}", headers=headers)
+        assert detail.status_code == 200
+        assert detail.json()["anonymized_at"] is not None
+
+
+# ── Idempotency, isolation, auth ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_anonymize_already_anonymized_is_idempotent(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    borrower = Borrower(library_id=lib.id, name="Dan")
+    test_session.add(borrower)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        first = await client.post(f"/api/v1/borrowers/{borrower.id}/anonymize", headers=headers)
+        assert first.status_code == 200
+        first_anonymized_at = first.json()["anonymized_at"]
+
+        second = await client.post(f"/api/v1/borrowers/{borrower.id}/anonymize", headers=headers)
+        assert second.status_code == 200
+        assert second.json()["anonymized_at"] == first_anonymized_at
+        assert second.json()["name"] == "Deleted borrower"
+
+
+@pytest.mark.asyncio
+async def test_anonymize_foreign_borrower_returns_404(test_session: AsyncSession) -> None:
+    await _seed_user_with_library(test_session)
+    foreign = Borrower(library_id=uuid.uuid4(), name="Foreign")
+    test_session.add(foreign)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(f"/api/v1/borrowers/{foreign.id}/anonymize", headers=headers)
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_anonymize_unknown_borrower_returns_404(test_session: AsyncSession) -> None:
+    await _seed_user_with_library(test_session)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(f"/api/v1/borrowers/{uuid.uuid4()}/anonymize", headers=headers)
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_anonymize_requires_editor_role(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session, "owner@example.com")
+    borrower = Borrower(library_id=lib.id, name="Eva")
+    test_session.add(borrower)
+
+    viewer = User(email="viewer@example.com", hashed_password=get_password_hash("secret"))
+    test_session.add(viewer)
+    await test_session.flush()
+    test_session.add(LibraryMember(library_id=lib.id, user_id=viewer.id, role=LibraryRole.VIEWER))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "viewer@example.com", "password": "secret"},
+        )
+        viewer_headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+        resp = await client.post(
+            f"/api/v1/borrowers/{borrower.id}/anonymize", headers=viewer_headers
+        )
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_anonymize_requires_authentication() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(f"/api/v1/borrowers/{uuid.uuid4()}/anonymize")
+        assert resp.status_code == 401

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2154,6 +2154,70 @@
         }
       }
     },
+    "/api/v1/borrowers/{borrower_id}/anonymize": {
+      "post": {
+        "tags": [
+          "borrowers"
+        ],
+        "summary": "Anonymize Borrower Endpoint",
+        "operationId": "anonymize_borrower_endpoint_api_v1_borrowers__borrower_id__anonymize_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "borrower_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Borrower Id"
+            }
+          },
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BorrowerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/books/{book_id}/loans": {
       "post": {
         "tags": [

--- a/frontend/src/components/LendBookModal.test.tsx
+++ b/frontend/src/components/LendBookModal.test.tsx
@@ -19,10 +19,10 @@ vi.mock('../lib/toast-store', () => ({
 }))
 
 import { createLoan, listBorrowers } from '../lib/api'
-import type { Borrower, Loan } from '../lib/types'
+import type { BorrowerListItem, Loan } from '../lib/types'
 import { LendBookModal } from './LendBookModal'
 
-function makeBorrower(overrides: Partial<Borrower> = {}): Borrower {
+function makeBorrower(overrides: Partial<BorrowerListItem> = {}): BorrowerListItem {
   return {
     id: 'borrower-1',
     name: 'Alice Liddell',
@@ -31,6 +31,9 @@ function makeBorrower(overrides: Partial<Borrower> = {}): Borrower {
     anonymized_at: null,
     created_at: '2026-05-01T00:00:00Z',
     updated_at: '2026-05-01T00:00:00Z',
+    active_loans: 0,
+    total_loans: 0,
+    last_activity_at: null,
     ...overrides,
   }
 }
@@ -191,6 +194,27 @@ describe('LendBookModal', () => {
     const payload = vi.mocked(createLoan).mock.calls[0][1]
     expect(payload).toMatchObject({ borrower_name: 'Eve First' })
     expect(payload.borrower_id).toBeUndefined()
+  })
+
+  it('excludes anonymized borrowers from the picker', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({ id: 'b-alice', name: 'Alice', anonymized_at: null }),
+      makeBorrower({
+        id: 'b-deleted',
+        name: 'Deleted borrower',
+        contact: null,
+        anonymized_at: '2026-05-07T00:00:00Z',
+      }),
+    ])
+    renderModal()
+    await waitFor(() => {
+      const list = document.querySelector('[data-testid="borrower-suggestions"]') as HTMLDataListElement | null
+      expect(list).not.toBeNull()
+      expect(list!.querySelectorAll('option')).toHaveLength(1)
+    })
+    const list = document.querySelector('[data-testid="borrower-suggestions"]') as HTMLDataListElement
+    const values = Array.from(list.querySelectorAll('option')).map((o) => o.getAttribute('value'))
+    expect(values).toEqual(['Alice'])
   })
 
   it('shows an inline error when submit happens with an empty name', async () => {

--- a/frontend/src/components/LendBookModal.tsx
+++ b/frontend/src/components/LendBookModal.tsx
@@ -29,7 +29,13 @@ export function LendBookModal({ bookId, onClose }: { bookId: string; onClose: ()
   const createLoan = useCreateLoan(bookId)
   const { t } = useTranslation()
   const borrowersQuery = useBorrowers()
-  const borrowers = useMemo(() => borrowersQuery.data ?? [], [borrowersQuery.data])
+  // Anonymized borrowers are excluded from the picker — there's no sensible
+  // reason to lend a new book to one (and they all carry the same sentinel
+  // name, which would clutter the suggestions).
+  const borrowers = useMemo(
+    () => (borrowersQuery.data ?? []).filter((b) => b.anonymized_at === null),
+    [borrowersQuery.data],
+  )
 
   const matchedBorrower = useMemo(
     () => findExactMatch(borrowers, borrowerName),

--- a/frontend/src/hooks/useBorrowers.ts
+++ b/frontend/src/hooks/useBorrowers.ts
@@ -1,7 +1,9 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
 
-import { getBorrower, listBorrowerLoans, listBorrowers } from '../lib/api'
+import { anonymizeBorrower, formatApiError, getBorrower, listBorrowerLoans, listBorrowers } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
+import { useToastStore } from '../lib/toast-store'
 
 export const BORROWERS_QUERY_KEY = ['borrowers']
 const borrowerKey = (id: string) => ['borrower', id]
@@ -34,5 +36,31 @@ export function useBorrowerLoans(id: string) {
     queryFn: () => listBorrowerLoans(id),
     retry: false,
     enabled: isAuthenticated && Boolean(id),
+  })
+}
+
+export function useAnonymizeBorrower() {
+  const queryClient = useQueryClient()
+  const showError = useToastStore((s) => s.showError)
+  const showSuccess = useToastStore((s) => s.showSuccess)
+  const { t } = useTranslation()
+
+  return useMutation({
+    mutationFn: (id: string) => anonymizeBorrower(id),
+    onSuccess: async (anonymizedBorrower) => {
+      // The borrower list, the borrower detail, and the borrower's loans
+      // (denormalized borrower text) all change at once. Invalidate broadly
+      // rather than try to splice one row in.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: BORROWERS_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: borrowerKey(anonymizedBorrower.id) }),
+        queryClient.invalidateQueries({ queryKey: borrowerLoansKey(anonymizedBorrower.id) }),
+        // Loan rows on book pages also carry denormalized borrower text.
+        queryClient.invalidateQueries({ queryKey: ['loans'] }),
+        queryClient.invalidateQueries({ queryKey: ['books'] }),
+      ])
+      showSuccess(t('toast.borrower_anonymized', 'Borrower anonymized.'))
+    },
+    onError: (error: unknown) => showError(formatApiError(error)),
   })
 }

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -25,7 +25,8 @@
     "location_saved": "Umístění uloženo.",
     "location_deleted": "Umístění smazáno.",
     "scan_confirmed": "Knihy uloženy do knihovny!",
-    "enrich_started": "Obohacování zahájeno. Data se brzy aktualizují."
+    "enrich_started": "Obohacování zahájeno. Data se brzy aktualizují.",
+    "borrower_anonymized": "Dlužník anonymizován."
   },
   "bulk": {
     "selected": "{{count}} vybráno",
@@ -735,6 +736,14 @@
     "section_returned_loans": "Vráceno",
     "empty_active_loans": "Aktuálně nemá vypůjčené žádné knihy.",
     "empty_returned_loans": "V historii nejsou žádné vrácené knihy.",
-    "detail_not_found": "Dlužník nenalezen."
+    "detail_not_found": "Dlužník nenalezen.",
+    "anonymized_label": "Smazaný dlužník",
+    "anonymized_hint": "Osobní údaje tohoto dlužníka byly smazány. Historie půjček zůstává.",
+    "anonymize_button": "Anonymizovat",
+    "anonymize_confirm_title": "Anonymizovat dlužníka?",
+    "anonymize_confirm_body": "Smaže jméno, kontakt i poznámky u {{name}} — a vyčistí tyto údaje u všech souvisejících půjček. Historie půjček (knihy, data, stav při vrácení) zůstává.",
+    "anonymize_irreversible": "Tento krok nelze vrátit.",
+    "anonymize_confirm": "Anonymizovat",
+    "anonymizing": "Anonymizuji…"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -25,7 +25,8 @@
     "location_saved": "Location saved.",
     "location_deleted": "Location deleted.",
     "scan_confirmed": "Books saved to your library!",
-    "enrich_started": "Enrichment started. Data will update shortly."
+    "enrich_started": "Enrichment started. Data will update shortly.",
+    "borrower_anonymized": "Borrower anonymized."
   },
   "bulk": {
     "selected": "{{count}} selected",
@@ -733,6 +734,14 @@
     "section_returned_loans": "Returned",
     "empty_active_loans": "No books currently borrowed.",
     "empty_returned_loans": "No returned books in history.",
-    "detail_not_found": "Borrower not found."
+    "detail_not_found": "Borrower not found.",
+    "anonymized_label": "Deleted borrower",
+    "anonymized_hint": "This borrower's personal data has been deleted. Lending history is kept.",
+    "anonymize_button": "Anonymize",
+    "anonymize_confirm_title": "Anonymize borrower?",
+    "anonymize_confirm_body": "This removes {{name}}'s name, contact, and notes — and clears those fields on every related loan record. The lending history (books, dates, return condition) is kept.",
+    "anonymize_irreversible": "This cannot be undone.",
+    "anonymize_confirm": "Anonymize",
+    "anonymizing": "Anonymizing…"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -503,6 +503,11 @@ export async function createBorrower(payload: BorrowerCreateRequest): Promise<Bo
   return response.data
 }
 
+export async function anonymizeBorrower(id: string): Promise<Borrower> {
+  const response = await apiClient.post<Borrower>(`/api/v1/borrowers/${id}/anonymize`)
+  return response.data
+}
+
 export async function uploadBookImage(file: File): Promise<UploadJobResponse> {
   const formData = new FormData()
   formData.append('image', file)

--- a/frontend/src/lib/borrowerDisplay.ts
+++ b/frontend/src/lib/borrowerDisplay.ts
@@ -1,0 +1,20 @@
+import type { TFunction } from 'i18next'
+
+import type { Borrower } from './types'
+
+/**
+ * Resolve the borrower name to display in the UI.
+ *
+ * The backend writes a hard-coded sentinel ("Deleted borrower") when a
+ * borrower is anonymized. We swap in the localized label for the user's
+ * locale rather than relying on the DB string. For non-anonymized rows the
+ * stored name is returned as-is.
+ */
+export function displayBorrowerName(
+  borrower: Pick<Borrower, 'name' | 'anonymized_at'> | null | undefined,
+  t: TFunction,
+): string {
+  if (!borrower) return ''
+  if (borrower.anonymized_at) return t('borrowers.anonymized_label')
+  return borrower.name
+}

--- a/frontend/src/pages/BorrowerDetailPage.test.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -10,9 +11,16 @@ vi.mock('../contexts/AuthContext', () => ({
 vi.mock('../lib/api', () => ({
   getBorrower: vi.fn(),
   listBorrowerLoans: vi.fn(),
+  anonymizeBorrower: vi.fn(),
+  formatApiError: (e: unknown) => String(e),
 }))
 
-import { getBorrower, listBorrowerLoans } from '../lib/api'
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: (selector: (s: { showError: () => void; showSuccess: () => void }) => unknown) =>
+    selector({ showError: vi.fn(), showSuccess: vi.fn() }),
+}))
+
+import { anonymizeBorrower, getBorrower, listBorrowerLoans } from '../lib/api'
 import type { Borrower, BorrowerLoanItem } from '../lib/types'
 import { BorrowerDetailPage } from './BorrowerDetailPage'
 
@@ -143,5 +151,71 @@ describe('BorrowerDetailPage', () => {
     renderPage()
 
     expect(await screen.findByTestId('borrower-detail-error')).toBeInTheDocument()
+  })
+
+  it('shows the localized "Deleted borrower" label and a hint when anonymized', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(
+      makeBorrower({
+        name: 'Deleted borrower',
+        contact: null,
+        notes: null,
+        anonymized_at: '2026-05-07T00:00:00Z',
+      }),
+    )
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    expect(await screen.findByText('borrowers.anonymized_label')).toBeInTheDocument()
+    expect(screen.getByTestId('borrower-anonymized-badge')).toBeInTheDocument()
+    expect(screen.queryByTestId('anonymize-button')).not.toBeInTheDocument()
+  })
+
+  it('shows the Anonymize button only when the borrower is not yet anonymized', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower())
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    expect(await screen.findByTestId('anonymize-button')).toBeInTheDocument()
+  })
+
+  it('opens the confirmation modal and calls the anonymize API on confirm', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower())
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    vi.mocked(anonymizeBorrower).mockResolvedValue(
+      makeBorrower({
+        name: 'Deleted borrower',
+        contact: null,
+        notes: null,
+        anonymized_at: '2026-05-07T00:00:00Z',
+      }),
+    )
+    renderPage()
+
+    const user = userEvent.setup()
+    await user.click(await screen.findByTestId('anonymize-button'))
+
+    // Confirmation modal includes the irreversible warning
+    expect(await screen.findByText('borrowers.anonymize_irreversible')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('anonymize-confirm'))
+
+    await waitFor(() => expect(anonymizeBorrower).toHaveBeenCalledWith('b-alice'))
+  })
+
+  it('cancel button closes the confirmation modal without calling the API', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower())
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    const user = userEvent.setup()
+    await user.click(await screen.findByTestId('anonymize-button'))
+    expect(await screen.findByText('borrowers.anonymize_irreversible')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'common.cancel' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('borrowers.anonymize_irreversible')).not.toBeInTheDocument()
+    })
+    expect(anonymizeBorrower).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/pages/BorrowerDetailPage.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.tsx
@@ -1,9 +1,11 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 
 import { EmptyShelfIcon, NoResultsIcon } from '../components/EmptyStateIcons'
-import { useBorrower, useBorrowerLoans } from '../hooks/useBorrowers'
+import { Modal } from '../components/Modal'
+import { useAnonymizeBorrower, useBorrower, useBorrowerLoans } from '../hooks/useBorrowers'
+import { displayBorrowerName } from '../lib/borrowerDisplay'
 import { ROUTES, getBookDetailRoute } from '../lib/routes'
 import type { BorrowerLoanItem } from '../lib/types'
 
@@ -82,6 +84,8 @@ export function BorrowerDetailPage() {
   const { t, i18n } = useTranslation()
   const borrowerQuery = useBorrower(borrowerId ?? '')
   const loansQuery = useBorrowerLoans(borrowerId ?? '')
+  const anonymize = useAnonymizeBorrower()
+  const [confirmOpen, setConfirmOpen] = useState(false)
 
   const { active, returned } = useMemo(() => {
     const all = loansQuery.data ?? []
@@ -113,6 +117,8 @@ export function BorrowerDetailPage() {
   }
 
   const borrower = borrowerQuery.data
+  const isAnonymized = borrower.anonymized_at !== null
+  const displayName = displayBorrowerName(borrower, t)
 
   return (
     <main className="sh-main" style={{ padding: 24, maxWidth: 760, margin: '0 auto' }}>
@@ -125,13 +131,51 @@ export function BorrowerDetailPage() {
         </Link>
       </div>
 
-      <header style={{ marginBottom: 24 }}>
-        <h1 className="text-h2" style={{ margin: 0 }}>{borrower.name}</h1>
-        {borrower.contact && (
-          <p style={{ margin: '4px 0 0', color: 'var(--sh-text-muted)' }}>{borrower.contact}</p>
-        )}
-        {borrower.notes && (
-          <p style={{ margin: '8px 0 0', whiteSpace: 'pre-wrap' }}>{borrower.notes}</p>
+      <header
+        style={{
+          marginBottom: 24,
+          display: 'flex',
+          gap: 16,
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <h1
+            className="text-h2"
+            style={{
+              margin: 0,
+              fontStyle: isAnonymized ? 'italic' : undefined,
+              color: isAnonymized ? 'var(--sh-text-muted)' : undefined,
+            }}
+          >
+            {displayName}
+          </h1>
+          {isAnonymized && (
+            <p
+              data-testid="borrower-anonymized-badge"
+              style={{ margin: '4px 0 0', fontSize: 13, color: 'var(--sh-text-muted)' }}
+            >
+              {t('borrowers.anonymized_hint')}
+            </p>
+          )}
+          {!isAnonymized && borrower.contact && (
+            <p style={{ margin: '4px 0 0', color: 'var(--sh-text-muted)' }}>{borrower.contact}</p>
+          )}
+          {!isAnonymized && borrower.notes && (
+            <p style={{ margin: '8px 0 0', whiteSpace: 'pre-wrap' }}>{borrower.notes}</p>
+          )}
+        </div>
+        {!isAnonymized && (
+          <button
+            type="button"
+            data-testid="anonymize-button"
+            className="sh-btn-secondary"
+            onClick={() => setConfirmOpen(true)}
+          >
+            {t('borrowers.anonymize_button')}
+          </button>
         )}
       </header>
 
@@ -188,6 +232,52 @@ export function BorrowerDetailPage() {
           </ul>
         )}
       </section>
+
+      {confirmOpen && (
+        <Modal
+          open
+          onClose={() => setConfirmOpen(false)}
+          label={t('borrowers.anonymize_confirm_title')}
+          maxWidth={440}
+        >
+          <div style={{ display: 'grid', gap: 12 }}>
+            <h3 style={{ margin: 0 }}>{t('borrowers.anonymize_confirm_title')}</h3>
+            <p style={{ margin: 0 }}>
+              {t('borrowers.anonymize_confirm_body', { name: displayName })}
+            </p>
+            <p style={{ margin: 0, color: 'var(--sh-red)', fontWeight: 500 }}>
+              {t('borrowers.anonymize_irreversible')}
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+              <button
+                type="button"
+                className="sh-btn-secondary"
+                onClick={() => setConfirmOpen(false)}
+                disabled={anonymize.isPending}
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                type="button"
+                data-testid="anonymize-confirm"
+                className="sh-btn-primary"
+                style={{ background: 'var(--sh-red)' }}
+                disabled={anonymize.isPending}
+                onClick={() => {
+                  if (!borrower) return
+                  anonymize.mutate(borrower.id, {
+                    onSuccess: () => setConfirmOpen(false),
+                  })
+                }}
+              >
+                {anonymize.isPending
+                  ? t('borrowers.anonymizing')
+                  : t('borrowers.anonymize_confirm')}
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
     </main>
   )
 }

--- a/frontend/src/pages/BorrowersPage.test.tsx
+++ b/frontend/src/pages/BorrowersPage.test.tsx
@@ -128,4 +128,20 @@ describe('BorrowersPage', () => {
     expect(screen.getByTestId('borrowers-no-results')).toBeInTheDocument()
     expect(screen.queryByTestId('borrowers-empty')).not.toBeInTheDocument()
   })
+
+  it('renders the localized label for an anonymized borrower instead of the DB name', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue([
+      makeBorrower({
+        id: 'b-anon',
+        name: 'Deleted borrower',
+        contact: null,
+        anonymized_at: '2026-05-07T00:00:00Z',
+      }),
+    ])
+    renderPage()
+
+    await waitFor(() => expect(screen.getByTestId('borrowers-list')).toBeInTheDocument())
+    const row = screen.getByTestId('borrower-row-b-anon')
+    expect(row).toHaveTextContent('borrowers.anonymized_label')
+  })
 })

--- a/frontend/src/pages/BorrowersPage.tsx
+++ b/frontend/src/pages/BorrowersPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 
 import { NoResultsIcon } from '../components/EmptyStateIcons'
 import { useBorrowers } from '../hooks/useBorrowers'
+import { displayBorrowerName } from '../lib/borrowerDisplay'
 import { getBorrowerDetailRoute } from '../lib/routes'
 import type { BorrowerListItem } from '../lib/types'
 
@@ -16,10 +17,12 @@ function formatDate(value: string | null, locale: string): string {
   }
 }
 
-function matchesSearch(borrower: BorrowerListItem, query: string): boolean {
+function matchesSearch(borrower: BorrowerListItem, query: string, displayName: string): boolean {
   if (!query.trim()) return true
   const target = query.trim().toLowerCase()
-  return borrower.name.toLowerCase().includes(target)
+  // Match against the displayed (possibly localized) label so users searching
+  // for "smazaný" / "deleted" find anonymized records.
+  return displayName.toLowerCase().includes(target)
 }
 
 export function BorrowersPage() {
@@ -29,8 +32,8 @@ export function BorrowersPage() {
 
   const filtered = useMemo(() => {
     const all = borrowersQuery.data ?? []
-    return all.filter((b) => matchesSearch(b, search))
-  }, [borrowersQuery.data, search])
+    return all.filter((b) => matchesSearch(b, search, displayBorrowerName(b, t)))
+  }, [borrowersQuery.data, search, t])
 
   const isLoading = borrowersQuery.isLoading
   const total = borrowersQuery.data?.length ?? 0
@@ -107,7 +110,16 @@ export function BorrowersPage() {
                 }}
               >
                 <div style={{ minWidth: 0 }}>
-                  <div style={{ fontWeight: 600, fontSize: 15 }}>{borrower.name}</div>
+                  <div
+                    style={{
+                      fontWeight: 600,
+                      fontSize: 15,
+                      fontStyle: borrower.anonymized_at ? 'italic' : undefined,
+                      color: borrower.anonymized_at ? 'var(--sh-text-muted)' : undefined,
+                    }}
+                  >
+                    {displayBorrowerName(borrower, t)}
+                  </div>
                   {borrower.contact && (
                     <div
                       style={{


### PR DESCRIPTION
## Summary

Phase 5 of the Borrowers epic (#221). Adds an irreversible anonymize action that strips identifying data from a borrower **and** from every loan row attached to them, while keeping the lending history intact.

### Backend

- New service `anonymize_borrower(session, borrower_id, library_id)`:
  - sets `name` to a fixed sentinel ("Deleted borrower"), clears `contact` and `notes`, stamps `anonymized_at`.
  - **cascades to loans**: `Loan.borrower_name`/`Loan.borrower_contact` are also cleared, because that table carries denormalized borrower text. Without this, anonymization would leak via the borrower-loans endpoint.
  - idempotent: a second call returns the existing row unchanged (no `anonymized_at` re-stamp).
- New endpoint `POST /api/v1/borrowers/{id}/anonymize` (editor role, library-scoped, 404 for cross-library).
- 7 tests in `tests/test_borrower_anonymize.py`.

### Frontend

- `useAnonymizeBorrower` invalidates all caches that carry borrower text.
- `displayBorrowerName(borrower, t)` swaps the DB sentinel for a localized label when `anonymized_at` is set. Used in the list and detail.
- `BorrowerDetailPage`: editor-only "Anonymize" button, confirmation modal with the borrower's name, an explicit "this cannot be undone" warning, and an in-flight state. When anonymized, the header shows the localized label in italic muted text plus a "personal data deleted, history kept" hint; contact/notes are hidden.
- `BorrowersPage`: italic muted row for anonymized borrowers; search matches the displayed (possibly localized) label.
- `LendBookModal`: anonymized borrowers excluded from the picker.
- Full i18n copy in cs and en.

OpenAPI is regenerated by CI.

Parent epic: #221
Closes #226

## Test plan

- [x] `cd frontend && npm run lint` (clean)
- [x] `cd frontend && npx tsc --noEmit` (clean)
- [x] `cd frontend && npm test` — 151/151 (6 new, plus a stale-fixture cleanup carried over from #225)
- [ ] `cd backend && ruff check app tests`
- [ ] `cd backend && mypy app tests`
- [ ] `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`
- [ ] OpenAPI regen + commit (CI will catch a missing diff)
- [ ] Manual: anonymize a borrower with both an active and a returned loan, confirm the borrower header and the loan rows on the book page no longer show the original name; check that the picker on the lend modal no longer suggests them; check that the loans endpoint still returns the loan history with empty contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Borrower anonymization: permanently remove personal data while preserving loan history; Anonymize button with confirmation and irreversible warning on borrower pages.
  * UI/UX: anonymized borrowers show localized "Deleted borrower" label, hidden from borrower picker, and search/filtering respects anonymized display names.
  * Frontend hook & API: client-side anonymize action with cache refresh and success/error toasts.

* **Tests**
  * Added comprehensive tests covering anonymization behavior, authorization, idempotency, and UI flows.

* **Documentation**
  * OpenAPI updated to document the anonymize endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->