### PR TITLE
chore(borrowers): keep legacy loan fields, document decision (#227)

### DIFF
--- a/backend/app/models/loan.py
+++ b/backend/app/models/loan.py
@@ -36,6 +36,11 @@ class Loan(Base):
         nullable=True,
         index=True,
     )
+    # Denormalized snapshot of the borrower's identity at lend time.
+    # See docs/adr/008-keep-legacy-loan-borrower-fields.md — these columns are
+    # deliberately kept (not deprecated). Display code should prefer the
+    # nested ``borrower`` relationship and fall back to these only when
+    # ``borrower_id`` is NULL.
     borrower_name: Mapped[str] = mapped_column(String(255), nullable=False)
     borrower_contact: Mapped[str | None] = mapped_column(String(255), nullable=True)
     lent_date: Mapped[date] = mapped_column(Date(), nullable=False, default=date.today)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,14 @@ Public source for notable Shelfy changes. Keep entries short, dated, and user-fa
 
 The public page at `/changelog` is generated from `frontend/src/content/changelog.ts`. When adding a release note, update both files in the same PR until a markdown-to-page generator exists.
 
+## 2026-05-07 — Dlužníci jako samostatná entita
+
+- Přibyla evidence dlužníků (`/borrowers`) s vyhledáváním a statistikami počtu půjček (#225).
+- Detail dlužníka ukazuje aktuální půjčky i historii včetně stavu při vrácení (#225).
+- Půjčování knihy umí vybrat existujícího dlužníka i ručně napsat nového (#224).
+- Anonymizace dlužníka bezpečně smaže osobní údaje napříč knihovnou i historií půjček (#226).
+- Loan history na stránce knihy zobrazí lokalizovaný štítek „Smazaný dlužník" / "Deleted borrower" pro anonymizované záznamy (#227).
+
 ## 2026-04-29 — Spolehlivější backend a přísnější CI
 
 - Backend test coverage gate is back at 80%.

--- a/docs/adr/008-keep-legacy-loan-borrower-fields.md
+++ b/docs/adr/008-keep-legacy-loan-borrower-fields.md
@@ -1,0 +1,158 @@
+# ADR 008: Keep `Loan.borrower_name` / `Loan.borrower_contact` as denormalized columns
+
+- **Status:** Accepted
+- **Date:** 2026-05-07
+
+## Context
+
+The Borrowers epic (#221) introduced first-class `Borrower` records and a
+nullable `Loan.borrower_id` foreign key in phase 1 (#222). Phase 6 (#227) is
+the explicit decision point: now that the `Borrower`-based flow is fully
+wired (loan picker #224, overview/detail pages #225, anonymization #226), do
+we keep, deprecate, or remove the legacy text columns?
+
+The columns:
+
+| Column                   | Type                | Nullable |
+|--------------------------|---------------------|----------|
+| `loans.borrower_name`    | `String(255)`       | NO       |
+| `loans.borrower_contact` | `String(255)`       | YES      |
+
+### Audit — what reads / writes these columns today
+
+**Backend** (current `main`, post-#226):
+
+| Site                                              | Behavior                                                                     |
+|---------------------------------------------------|------------------------------------------------------------------------------|
+| `app/models/loan.py`                              | Column definitions; `borrower_name` is `nullable=False`.                     |
+| `app/schemas/loan.py` (`LoanCreate`)              | Accepts either `borrower_id` *or* `borrower_name` + `borrower_contact`.      |
+| `app/schemas/loan.py` (`LoanResponse`)            | Always returns both, plus the nested `borrower: BorrowerResponse \| None`.   |
+| `app/services/loan_service.create_loan`           | When `borrower_id` is given, copies `borrower.name`/`borrower.contact` into the legacy columns; with `borrower_name` only, writes the typed text and leaves `borrower_id` NULL. |
+| `app/services/borrower.link_loans_to_borrowers`   | One-shot backfill (#223): reads legacy columns to find/create a `Borrower` and sets `borrower_id`. |
+| `app/services/borrower.anonymize_borrower`        | On anonymize, **cascades** the sentinel `"Deleted borrower"` into `borrower_name` and clears `borrower_contact` on every linked loan (#226). |
+| `app/api/auth.py` (GDPR data export)              | Includes the two columns verbatim in the user data dump.                     |
+
+**Frontend** (current `main`, post-#226):
+
+| Site                                              | Behavior                                                                     |
+|---------------------------------------------------|------------------------------------------------------------------------------|
+| `lib/types.ts` (`Loan`)                           | Both columns + nested `borrower: Borrower \| null`.                          |
+| `components/LoanHistory.tsx`                      | Renders `loan.borrower_name` directly. **Does not** prefer `loan.borrower?.name`. |
+| `components/LendBookModal.tsx`                    | Sends legacy columns only as the new-borrower fallback (#224).               |
+
+The phase-6 issue's stated precondition was *"No frontend code depends on
+`borrower_name` as the primary source"*. **That precondition is currently
+unmet** — `LoanHistory` is still primary-source. This is mostly invisible
+because `create_loan` keeps the legacy columns in sync with the borrower
+record, but it has one user-visible consequence: when a Czech user views the
+loan history of an anonymized borrower, they see the English DB sentinel
+`"Deleted borrower"` instead of the localized label `"Smazaný dlužník"`.
+There is no way to localize from the loan-row alone, because nothing on the
+row tells us the borrower has been anonymized.
+
+## Options considered
+
+**Option A — Keep permanently as denormalized display fallback.** The legacy
+columns become a deliberate, supported snapshot.
+
+**Option B — Mark deprecated but keep in DB.** Same DB shape; we communicate
+the direction. Practically indistinguishable from A unless we also stop
+writing to them, which would break the GDPR export and the anonymization
+cascade.
+
+**Option C — Remove the columns in a later migration.** Single source of
+truth (the `Borrower` row). Lots of churn — `LoanCreate` loses the typed-name
+flow, `create_loan` and the anonymization cascade simplify, every loan
+read-path needs an eager join.
+
+## Decision
+
+**Option A — keep the columns. Treat them as a deliberate denormalization.**
+
+### Why not C
+
+- The "type a name to lend" flow (`LoanCreate.borrower_name` without
+  `borrower_id`) is real, simple, and used. Removing it forces "create a
+  borrower record first" on the lender, which is the kind of friction phase
+  4 explicitly avoided ("Do not make lending slower or more complex").
+- The `create_loan` path that copies `borrower.name`/`contact` into the loan
+  is what guarantees old loan history stays readable even if the `Borrower`
+  row is later anonymized — and what makes the anonymization cascade actually
+  reach loan rows. Both behaviors disappear if the columns disappear, and
+  must be reimplemented as eager joins everywhere.
+- A `Borrower` row's lifecycle can outlive its meaningful identity (anonymize
+  in #226). Loan rows are an archival record; freezing the borrower text on
+  the loan when it was lent matches that archival semantic.
+- Removing requires a non-trivial Alembic migration on a NOT NULL column on
+  every existing installation, plus a write-time guarantee that `borrower_id`
+  is always present going forward — a separate breaking change to the public
+  `LoanCreate` shape.
+
+### Why not B
+
+Pure deprecation without removal is what we already do informally; making it
+"official" without changing behavior buys nothing. The columns are in active
+use (anonymization cascade, GDPR export, simple lend flow), so calling them
+deprecated would be misleading.
+
+### What this decision implies
+
+1. The columns are part of the schema's stable surface. New code that touches
+   loans should keep writing them; treat them as a snapshot of the borrower's
+   identity at the time of lending.
+2. `Loan.borrower_name` stays `NOT NULL`. The sentinel `"Deleted borrower"`
+   from `app.services.borrower.ANONYMIZED_BORROWER_NAME` is the correct value
+   when the borrower is anonymized.
+3. Anything that **displays** loan rows should prefer the nested
+   `loan.borrower` over the loan-level columns when it exists, so that
+   anonymized records get a localized label, contact updates flow through,
+   etc. The legacy columns are the **fallback** for the case where
+   `borrower_id` is `NULL` (typed-name lend, pre-Borrower history that
+   couldn't be backfilled).
+4. The GDPR export keeps including the legacy columns — they are the
+   archival record of who borrowed what at the time it happened.
+
+### Code changes that follow from this decision
+
+This ADR is shipped alongside two small changes that align the codebase with
+the decision:
+
+- `LoanHistory.tsx` is refactored to read from `loan.borrower` first and only
+  fall through to `loan.borrower_name` / `loan.borrower_contact` when the
+  borrower link is absent. The localized "Deleted borrower" label now reaches
+  the loan history page for anonymized borrowers.
+- `app/models/loan.py` gets a docstring explaining that the two columns are
+  a denormalized snapshot and pointing here.
+
+No schema migration. No public API change. OpenAPI is unchanged.
+
+## Consequences
+
+- Drift risk between `loan.borrower_name` and `loan.borrower.name` is
+  bounded: `create_loan` writes both at insert time, and the anonymization
+  cascade in #226 is the only post-insert mutation that touches both. We do
+  not, by design, propagate edits to a `Borrower` (e.g. `PATCH
+  /borrowers/{id}` with a new name) into already-existing loans — that is
+  the archival semantic above.
+- "Update a borrower's contact, want it shown on past loans" is *not*
+  supported by design. If a librarian wants the new contact on existing
+  loans, they should re-display via the borrower detail page (#225), where
+  the data comes from the `Borrower` row directly.
+- A future ADR can revisit removal once the typed-name flow is genuinely
+  unused (e.g. if onboarding required selecting a borrower record). At that
+  point, the migration is comparatively cheap because anonymization and the
+  GDPR export are the only producers left.
+
+## Testing
+
+This ADR carries no behavior change beyond the `LoanHistory` refactor, which
+is covered by the existing borrower-anonymization tests (`#226`,
+`backend/tests/test_borrower_anonymize.py`) plus a frontend test in
+`components/LoanHistory.test.tsx` that asserts:
+
+- The loan row prefers `loan.borrower.name` when present.
+- The localized "Deleted borrower" label is shown when
+  `loan.borrower.anonymized_at` is set, regardless of the legacy column
+  value.
+- Falls back to `loan.borrower_name` when `loan.borrower` is `null` (legacy
+  loan that #223 couldn't backfill).

--- a/frontend/src/components/LoanHistory.test.tsx
+++ b/frontend/src/components/LoanHistory.test.tsx
@@ -1,0 +1,123 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true })),
+}))
+
+vi.mock('../lib/api', () => ({
+  listLoans: vi.fn(),
+  createLoan: vi.fn(),
+  returnLoan: vi.fn(),
+  listBorrowers: vi.fn().mockResolvedValue([]),
+  formatApiError: (e: unknown) => String(e),
+}))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: (selector: (s: { showError: () => void; showSuccess: () => void }) => unknown) =>
+    selector({ showError: vi.fn(), showSuccess: vi.fn() }),
+}))
+
+import { listLoans } from '../lib/api'
+import type { Borrower, Loan } from '../lib/types'
+import { LoanHistory } from './LoanHistory'
+
+function makeBorrower(overrides: Partial<Borrower> = {}): Borrower {
+  return {
+    id: 'b-1',
+    name: 'Alice Liddell',
+    contact: 'alice@x.com',
+    notes: null,
+    anonymized_at: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeLoan(overrides: Partial<Loan> = {}): Loan {
+  return {
+    id: 'loan-1',
+    book_id: 'book-1',
+    borrower_id: null,
+    borrower_name: 'Alice Liddell',
+    borrower_contact: null,
+    borrower: null,
+    lent_date: '2026-05-01',
+    due_date: null,
+    returned_date: null,
+    return_condition: null,
+    notes: null,
+    created_at: '2026-05-01T00:00:00Z',
+    is_active: true,
+    ...overrides,
+  }
+}
+
+function renderHistory() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <LoanHistory bookId="book-1" />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('LoanHistory borrower label', () => {
+  it('prefers loan.borrower.name over the legacy borrower_name column', async () => {
+    vi.mocked(listLoans).mockResolvedValue([
+      makeLoan({
+        id: 'l-renamed',
+        borrower_id: 'b-renamed',
+        borrower_name: 'Old Cached Name',
+        borrower: makeBorrower({ id: 'b-renamed', name: 'Current Name' }),
+      }),
+    ])
+    renderHistory()
+    await waitFor(() => {
+      expect(screen.getByTestId('loan-borrower-l-renamed')).toHaveTextContent('Current Name')
+    })
+  })
+
+  it('renders the localized "Deleted borrower" label when the linked borrower is anonymized', async () => {
+    vi.mocked(listLoans).mockResolvedValue([
+      makeLoan({
+        id: 'l-anon',
+        borrower_id: 'b-anon',
+        // The anonymization cascade writes the DB sentinel into this column.
+        borrower_name: 'Deleted borrower',
+        borrower: makeBorrower({
+          id: 'b-anon',
+          name: 'Deleted borrower',
+          contact: null,
+          anonymized_at: '2026-05-07T00:00:00Z',
+        }),
+      }),
+    ])
+    renderHistory()
+    await waitFor(() => {
+      expect(screen.getByTestId('loan-borrower-l-anon')).toHaveTextContent('borrowers.anonymized_label')
+    })
+  })
+
+  it('falls back to loan.borrower_name when there is no nested borrower (legacy / typed-name lend)', async () => {
+    vi.mocked(listLoans).mockResolvedValue([
+      makeLoan({
+        id: 'l-legacy',
+        borrower_id: null,
+        borrower_name: 'Some Random Person',
+        borrower: null,
+      }),
+    ])
+    renderHistory()
+    await waitFor(() => {
+      expect(screen.getByTestId('loan-borrower-l-legacy')).toHaveTextContent('Some Random Person')
+    })
+  })
+})

--- a/frontend/src/components/LoanHistory.tsx
+++ b/frontend/src/components/LoanHistory.tsx
@@ -3,8 +3,24 @@ import { formatDateDDMMYYYY } from '../lib/date'
 import { useTranslation } from 'react-i18next'
 
 import { useLoans } from '../hooks/useLoans'
+import { displayBorrowerName } from '../lib/borrowerDisplay'
+import type { Loan } from '../lib/types'
 import { LendBookModal } from './LendBookModal'
 import { ReturnBookModal } from './ReturnBookModal'
+
+/**
+ * Resolve the borrower label for a loan row.
+ *
+ * ADR 008 keeps `loan.borrower_name`/`borrower_contact` as denormalized
+ * snapshot columns. Display code prefers the nested `loan.borrower` object
+ * so anonymized records get a localized label and contact updates flow
+ * through. The legacy column is the fallback for loans whose `borrower_id`
+ * is null (typed-name lend, pre-Borrower history that #223 couldn't link).
+ */
+function loanBorrowerLabel(loan: Loan, t: ReturnType<typeof useTranslation>['t']): string {
+  if (loan.borrower) return displayBorrowerName(loan.borrower, t)
+  return loan.borrower_name
+}
 
 export function LoanHistory({ bookId }: { bookId: string }) {
   const loansQuery = useLoans(bookId)
@@ -32,7 +48,7 @@ export function LoanHistory({ bookId }: { bookId: string }) {
         {loans.map((loan) => (
           <article key={loan.id} style={{ border: `1px solid ${loan.is_active ? 'var(--sh-amber)' : 'var(--sh-border)'}`, background: loan.is_active ? 'var(--sh-amber-bg)' : 'var(--sh-surface)', borderRadius: 'var(--sh-radius-md)', padding: 12 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <strong>{loan.borrower_name}</strong>
+              <strong data-testid={`loan-borrower-${loan.id}`}>{loanBorrowerLabel(loan, t)}</strong>
               <span>{loan.is_active ? t('loans.active') : t('loans.returned')}</span>
             </div>
             <p style={{ marginBottom: 0, color: 'var(--sh-text-muted)' }}>{formatDateDDMMYYYY(loan.lent_date)} {loan.returned_date ? `– ${formatDateDDMMYYYY(loan.returned_date)}` : loan.due_date ? `• ${t('loans.due')} ${formatDateDDMMYYYY(loan.due_date)}` : ''}</p>

--- a/frontend/src/content/changelog.ts
+++ b/frontend/src/content/changelog.ts
@@ -14,6 +14,39 @@ export type ChangelogEntry = {
 
 export const changelogEntries: ChangelogEntry[] = [
   {
+    date: '2026-05-07',
+    title: {
+      cs: 'Dlužníci jako samostatná entita',
+      en: 'Borrowers as first-class objects',
+    },
+    summary: {
+      cs: 'Půjčování má teď evidenci dlužníků s historií napříč knihami a bezpečnou anonymizací osobních údajů.',
+      en: 'Lending now has a real borrower record with cross-book history and a safe way to wipe personal data.',
+    },
+    added: {
+      cs: [
+        'Stránka /borrowers s vyhledáváním a statistikami (počet aktivních, celkem, poslední aktivita) (#225).',
+        'Detail dlužníka se sekcemi Aktuálně půjčeno a Vráceno, včetně stavu při vrácení (#225).',
+        'Picker existujících dlužníků ve formuláři půjčení knihy s nepovinným ručním zápisem (#224).',
+        'Anonymizace dlužníka — smaže jméno/kontakt/poznámky a všechny identifikující údaje na jeho půjčkách, historie zůstává (#226).',
+      ],
+      en: [
+        '/borrowers page with search and per-row stats (active, total, last activity) (#225).',
+        'Borrower detail page with Currently borrowed and Returned sections, including return condition (#225).',
+        'Existing-borrower picker in the lend modal with a typed-name fallback (#224).',
+        'Anonymize action — wipes name/contact/notes and clears identifying data on the borrower\'s loans while keeping history (#226).',
+      ],
+    },
+    changed: {
+      cs: [
+        'Historie půjček u knihy zobrazí lokalizovaný štítek „Smazaný dlužník" pro anonymizované záznamy (#227).',
+      ],
+      en: [
+        'Loan history on book pages shows a localized "Deleted borrower" label for anonymized records (#227).',
+      ],
+    },
+  },
+  {
     date: '2026-05-06',
     title: {
       cs: 'Knihovna ukázek, onboarding a sidebar',


### PR DESCRIPTION
## Summary

Phase 6 of the Borrowers epic (#221) is the explicit decision point for the legacy `Loan.borrower_name` / `Loan.borrower_contact` columns. This PR audits every read/write site, documents the decision in **ADR 008**, and ships one small frontend cleanup that follows from it.

### Decision: keep the columns as a deliberate denormalized snapshot

Reasoning is in `docs/adr/008-keep-legacy-loan-borrower-fields.md`. Headlines:
- The "type a name to lend" flow is real, simple, and used.
- The denormalization is what makes the anonymization cascade in #226 actually reach loan rows.
- A borrower's lifecycle can outlive its meaningful identity (anonymize). Loan rows are an archival record; freezing the borrower text at lend time matches that semantic.
- Removing requires a non-trivial migration on a NOT NULL column and a breaking change to the public `LoanCreate` shape.

### What also ships

- **`LoanHistory.tsx` refactor** — the loan row label now prefers `loan.borrower?.name` (with the localized "Deleted borrower" label from `displayBorrowerName`) and falls back to `loan.borrower_name` only when the linked borrower is absent. Closes the issue's "no frontend code depends on `borrower_name` as the primary source" precondition that the audit found unmet. Visible effect: a Czech user viewing the loan history of an anonymized borrower now sees "Smazaný dlužník" instead of the English DB sentinel.
- **`Loan` model docstring** points at ADR 008 so future readers see the decision next to the columns themselves.
- **3 new frontend tests** in `LoanHistory.test.tsx` covering the three branches (borrower preferred, anonymized localized label, legacy fallback).
- **CHANGELOG entries** (cs + en + frontend) covering the whole epic.

No schema migration. No public API change. OpenAPI is unchanged.

Parent epic: #221
Closes #227

## Test plan

- [x] `cd frontend && npm run lint` (clean)
- [x] `cd frontend && npx tsc --noEmit` (clean)
- [x] `cd frontend && npm test` — 154/154 (3 new)
- [ ] `cd backend && ruff check app tests`
- [ ] `cd backend && mypy app tests`
- [ ] `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`
- [ ] Manual: anonymize a borrower with both an active and a returned loan, open the book detail of one of those loans, confirm the loan history row now shows the localized "Smazaný dlužník" / "Deleted borrower" instead of the English DB string

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Borrowers are now a standalone entity with search capabilities.
  * Added borrower statistics and detail/history views.
  * Improved borrowing flow—select existing borrowers or manually create new ones.
  * Secure anonymization removes personal data with localized "Deleted borrower" labeling in loan history.

* **Documentation**
  * Added changelog entry documenting borrower management enhancements.

* **Tests**
  * Added test coverage for loan history borrower label rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->