### PR TITLE
fix(loans): reject creating a loan against an anonymized borrower

### DIFF
--- a/backend/app/services/loan_service.py
+++ b/backend/app/services/loan_service.py
@@ -27,6 +27,15 @@ async def create_loan(session: AsyncSession, book_id: UUID, data: LoanCreate, li
 
     if data.borrower_id is not None:
         borrower = await get_borrower_or_404(session, data.borrower_id, library_id)
+        if borrower.anonymized_at is not None:
+            # The frontend filters anonymized borrowers out of the picker, but
+            # the backend has to enforce this too — otherwise a hand-crafted
+            # request would attach a fresh loan to a borrower whose personal
+            # data the librarian explicitly chose to delete.
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Cannot lend a book to an anonymized borrower",
+            )
         borrower_id = borrower.id
         borrower_name = borrower.name
         borrower_contact = borrower.contact

--- a/backend/tests/test_loans.py
+++ b/backend/tests/test_loans.py
@@ -508,3 +508,39 @@ async def test_create_loan_without_borrower_info_returns_422(
         )
 
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_loan_against_anonymized_borrower_returns_422(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """Backend defense: a hand-crafted request that picks an anonymized
+    borrower must be rejected, even though the frontend filters them out
+    of the picker."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        borrower_resp = await client.post(
+            "/api/v1/borrowers",
+            json={"name": "Erica"},
+            headers=headers,
+        )
+        assert borrower_resp.status_code == 201
+        borrower_id = borrower_resp.json()["id"]
+
+        anon_resp = await client.post(
+            f"/api/v1/borrowers/{borrower_id}/anonymize",
+            headers=headers,
+        )
+        assert anon_resp.status_code == 200
+
+        book_id = await _create_book(client, headers)
+        response = await client.post(
+            f"/api/v1/books/{book_id}/loans",
+            json={"borrower_id": borrower_id},
+            headers=headers,
+        )
+
+    assert response.status_code == 422
+    assert "anonymized" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Audit follow-up from the borrowers epic (#221). Backend defense to match the frontend filter shipped in #226: a hand-crafted request to `POST /api/v1/books/{book_id}/loans` with an anonymized `borrower_id` previously succeeded, attaching a fresh loan to a borrower whose personal data the librarian explicitly chose to delete. Backend now returns 422.

The legacy `borrower_name` text flow is unaffected.

Test in `tests/test_loans.py` covers: create borrower → anonymize → attempt new loan with that `borrower_id` → 422 with "anonymized" in the detail.

## Test plan

- [ ] `cd backend && ruff check app tests`
- [ ] `cd backend && mypy app tests`
- [ ] `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The system now prevents creating loans for anonymized borrowers, returning a 422 error with a descriptive message when such an attempt is made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->