### PR TITLE
feat(borrowers): add edit modal + mobile nav tab

### DIFF
--- a/frontend/src/components/EditBorrowerModal.tsx
+++ b/frontend/src/components/EditBorrowerModal.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useUpdateBorrower } from '../hooks/useBorrowers'
+import type { Borrower } from '../lib/types'
+import { Modal } from './Modal'
+
+interface Props {
+  borrower: Borrower
+  onClose: () => void
+}
+
+export function EditBorrowerModal({ borrower, onClose }: Props) {
+  const { t } = useTranslation()
+  const [name, setName] = useState(borrower.name)
+  const [contact, setContact] = useState(borrower.contact ?? '')
+  const [notes, setNotes] = useState(borrower.notes ?? '')
+  const [error, setError] = useState<string | null>(null)
+  const updateMutation = useUpdateBorrower()
+
+  return (
+    <Modal open onClose={onClose} label={t('borrowers.edit_modal_title')} maxWidth={520}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          if (!name.trim()) {
+            setError(t('loans.borrower_name_required'))
+            return
+          }
+          updateMutation.mutate(
+            {
+              id: borrower.id,
+              payload: {
+                name: name.trim(),
+                contact: contact.trim() ? contact.trim() : null,
+                notes: notes.trim() ? notes.trim() : null,
+              },
+            },
+            {
+              onSuccess: () => onClose(),
+              onError: () => setError(t('borrowers.edit_error')),
+            },
+          )
+        }}
+        style={{ display: 'grid', gap: 12 }}
+      >
+        <h3 style={{ margin: 0 }}>{t('borrowers.edit_modal_title')}</h3>
+        <p
+          data-testid="edit-borrower-history-hint"
+          style={{ margin: 0, color: 'var(--sh-text-muted)', fontSize: 13 }}
+        >
+          {t('borrowers.edit_history_hint')}
+        </p>
+        <label style={{ display: 'grid', gap: 4, fontSize: 14, fontWeight: 500, color: 'var(--sh-text-muted)' }}>
+          {t('borrowers.field_name')}
+          <input
+            className="sh-input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            data-testid="edit-borrower-name"
+          />
+        </label>
+        <label style={{ display: 'grid', gap: 4, fontSize: 14, fontWeight: 500, color: 'var(--sh-text-muted)' }}>
+          {t('borrowers.field_contact')}
+          <input
+            className="sh-input"
+            value={contact}
+            onChange={(e) => setContact(e.target.value)}
+            data-testid="edit-borrower-contact"
+          />
+        </label>
+        <label style={{ display: 'grid', gap: 4, fontSize: 14, fontWeight: 500, color: 'var(--sh-text-muted)' }}>
+          {t('borrowers.field_notes')}
+          <textarea
+            className="sh-input"
+            rows={3}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            data-testid="edit-borrower-notes"
+          />
+        </label>
+        {error && <p style={{ margin: 0, color: 'var(--sh-red)', fontSize: 14 }}>{error}</p>}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+          <button
+            type="button"
+            className="sh-btn-secondary"
+            onClick={onClose}
+            disabled={updateMutation.isPending}
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="submit"
+            className="sh-btn-primary"
+            disabled={updateMutation.isPending}
+            data-testid="edit-borrower-save"
+          >
+            {updateMutation.isPending ? t('borrowers.saving') : t('borrowers.save')}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -162,11 +162,13 @@ export function Navigation() {
     [t],
   )
 
-  /* Mobile bottom nav: 3 tabs + center FAB */
+  /* Mobile bottom nav: 4 tabs split around the center FAB.
+     Layout: [library] [bookshelf] [FAB] [borrowers] [settings] */
   const mobileTabs = useMemo(
     () => [
       { label: t('nav.library'), icon: 'library', path: ROUTES.books },
       { label: t('nav.bookshelf'), icon: 'bookshelf', path: ROUTES.bookshelfView },
+      { label: t('nav.borrowers'), icon: 'borrowers', path: ROUTES.borrowers },
       { label: t('nav.settings'), icon: 'settings', path: ROUTES.settings },
     ],
     [t],
@@ -364,8 +366,8 @@ export function Navigation() {
       {/* ── Tab row ── */}
       <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-around' }}>
 
-        {/* First tab */}
-        {mobileTabs.slice(0, 1).map((tab) => {
+        {/* Two tabs to the left of the FAB */}
+        {mobileTabs.slice(0, 2).map((tab) => {
           const active = isActive(tab.path)
           const Icon = iconComponents[tab.icon as NavIcon]
           return (
@@ -490,8 +492,8 @@ export function Navigation() {
           )}
         </div>
 
-        {/* Last two tabs */}
-        {mobileTabs.slice(1).map((tab) => {
+        {/* Two tabs to the right of the FAB */}
+        {mobileTabs.slice(2).map((tab) => {
           const active = isActive(tab.path)
           const Icon = iconComponents[tab.icon as NavIcon]
           return (

--- a/frontend/src/hooks/useBorrowers.ts
+++ b/frontend/src/hooks/useBorrowers.ts
@@ -1,9 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 
-import { anonymizeBorrower, formatApiError, getBorrower, listBorrowerLoans, listBorrowers } from '../lib/api'
+import { anonymizeBorrower, formatApiError, getBorrower, listBorrowerLoans, listBorrowers, updateBorrower } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
 import { useToastStore } from '../lib/toast-store'
+import type { BorrowerUpdateRequest } from '../lib/types'
 
 export const BORROWERS_QUERY_KEY = ['borrowers']
 const borrowerKey = (id: string) => ['borrower', id]
@@ -36,6 +37,28 @@ export function useBorrowerLoans(id: string) {
     queryFn: () => listBorrowerLoans(id),
     retry: false,
     enabled: isAuthenticated && Boolean(id),
+  })
+}
+
+export function useUpdateBorrower() {
+  const queryClient = useQueryClient()
+  const showError = useToastStore((s) => s.showError)
+  const showSuccess = useToastStore((s) => s.showSuccess)
+  const { t } = useTranslation()
+
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: BorrowerUpdateRequest }) =>
+      updateBorrower(id, payload),
+    onSuccess: async (updated) => {
+      // ADR 008: edits do NOT propagate to historical loan rows. Only the
+      // borrower-level caches need invalidating.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: BORROWERS_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: borrowerKey(updated.id) }),
+      ])
+      showSuccess(t('toast.borrower_saved', 'Borrower saved.'))
+    },
+    onError: (error: unknown) => showError(formatApiError(error)),
   })
 }
 

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -26,7 +26,8 @@
     "location_deleted": "Umístění smazáno.",
     "scan_confirmed": "Knihy uloženy do knihovny!",
     "enrich_started": "Obohacování zahájeno. Data se brzy aktualizují.",
-    "borrower_anonymized": "Dlužník anonymizován."
+    "borrower_anonymized": "Dlužník anonymizován.",
+    "borrower_saved": "Dlužník uložen."
   },
   "bulk": {
     "selected": "{{count}} vybráno",
@@ -739,6 +740,15 @@
     "detail_not_found": "Dlužník nenalezen.",
     "anonymized_label": "Smazaný dlužník",
     "anonymized_hint": "Osobní údaje tohoto dlužníka byly smazány. Historie půjček zůstává.",
+    "edit_button": "Upravit",
+    "edit_modal_title": "Upravit dlužníka",
+    "edit_history_hint": "Změny se projeví pouze na záznamu dlužníka. Historické půjčky si ponechávají údaje, které měly v okamžiku půjčení.",
+    "edit_error": "Nepodařilo se uložit změny.",
+    "field_name": "Jméno",
+    "field_contact": "Kontakt",
+    "field_notes": "Poznámky",
+    "save": "Uložit",
+    "saving": "Ukládám…",
     "anonymize_button": "Anonymizovat",
     "anonymize_confirm_title": "Anonymizovat dlužníka?",
     "anonymize_confirm_body": "Smaže jméno, kontakt i poznámky u {{name}} — a vyčistí tyto údaje u všech souvisejících půjček. Historie půjček (knihy, data, stav při vrácení) zůstává.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -26,7 +26,8 @@
     "location_deleted": "Location deleted.",
     "scan_confirmed": "Books saved to your library!",
     "enrich_started": "Enrichment started. Data will update shortly.",
-    "borrower_anonymized": "Borrower anonymized."
+    "borrower_anonymized": "Borrower anonymized.",
+    "borrower_saved": "Borrower saved."
   },
   "bulk": {
     "selected": "{{count}} selected",
@@ -737,6 +738,15 @@
     "detail_not_found": "Borrower not found.",
     "anonymized_label": "Deleted borrower",
     "anonymized_hint": "This borrower's personal data has been deleted. Lending history is kept.",
+    "edit_button": "Edit",
+    "edit_modal_title": "Edit borrower",
+    "edit_history_hint": "Changes apply to the borrower record only. Past loan rows keep the borrower text from when they were lent.",
+    "edit_error": "Could not save changes.",
+    "field_name": "Name",
+    "field_contact": "Contact",
+    "field_notes": "Notes",
+    "save": "Save",
+    "saving": "Saving…",
     "anonymize_button": "Anonymize",
     "anonymize_confirm_title": "Anonymize borrower?",
     "anonymize_confirm_body": "This removes {{name}}'s name, contact, and notes — and clears those fields on every related loan record. The lending history (books, dates, return condition) is kept.",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   BorrowerCreateRequest,
   BorrowerListItem,
   BorrowerLoanItem,
+  BorrowerUpdateRequest,
   CheckoutResponse,
   CsvImportConfirmRequest,
   CsvImportConfirmResponse,
@@ -500,6 +501,11 @@ export async function listBorrowerLoans(id: string): Promise<BorrowerLoanItem[]>
 
 export async function createBorrower(payload: BorrowerCreateRequest): Promise<Borrower> {
   const response = await apiClient.post<Borrower>('/api/v1/borrowers', payload)
+  return response.data
+}
+
+export async function updateBorrower(id: string, payload: BorrowerUpdateRequest): Promise<Borrower> {
+  const response = await apiClient.patch<Borrower>(`/api/v1/borrowers/${id}`, payload)
   return response.data
 }
 

--- a/frontend/src/pages/BorrowerDetailPage.test.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../lib/api', () => ({
   getBorrower: vi.fn(),
   listBorrowerLoans: vi.fn(),
   anonymizeBorrower: vi.fn(),
+  updateBorrower: vi.fn(),
   formatApiError: (e: unknown) => String(e),
 }))
 
@@ -20,7 +21,7 @@ vi.mock('../lib/toast-store', () => ({
     selector({ showError: vi.fn(), showSuccess: vi.fn() }),
 }))
 
-import { anonymizeBorrower, getBorrower, listBorrowerLoans } from '../lib/api'
+import { anonymizeBorrower, getBorrower, listBorrowerLoans, updateBorrower } from '../lib/api'
 import type { Borrower, BorrowerLoanItem } from '../lib/types'
 import { BorrowerDetailPage } from './BorrowerDetailPage'
 
@@ -200,6 +201,55 @@ describe('BorrowerDetailPage', () => {
     await user.click(screen.getByTestId('anonymize-confirm'))
 
     await waitFor(() => expect(anonymizeBorrower).toHaveBeenCalledWith('b-alice'))
+  })
+
+  it('opens the edit modal and PATCHes via updateBorrower on save', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower())
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    vi.mocked(updateBorrower).mockResolvedValue(
+      makeBorrower({ name: 'Alice (Renamed)', contact: 'new@x.com' }),
+    )
+    renderPage()
+
+    const user = userEvent.setup()
+    await user.click(await screen.findByTestId('edit-button'))
+
+    // The history-doesn't-propagate hint is shown.
+    expect(await screen.findByTestId('edit-borrower-history-hint')).toBeInTheDocument()
+
+    const nameInput = screen.getByTestId('edit-borrower-name')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Alice (Renamed)')
+
+    const contactInput = screen.getByTestId('edit-borrower-contact')
+    await user.clear(contactInput)
+    await user.type(contactInput, 'new@x.com')
+
+    await user.click(screen.getByTestId('edit-borrower-save'))
+
+    await waitFor(() => {
+      expect(updateBorrower).toHaveBeenCalledWith('b-alice', {
+        name: 'Alice (Renamed)',
+        contact: 'new@x.com',
+        notes: null,
+      })
+    })
+  })
+
+  it('does not show the edit button when the borrower is already anonymized', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(
+      makeBorrower({
+        name: 'Deleted borrower',
+        contact: null,
+        notes: null,
+        anonymized_at: '2026-05-07T00:00:00Z',
+      }),
+    )
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    expect(await screen.findByText('borrowers.anonymized_label')).toBeInTheDocument()
+    expect(screen.queryByTestId('edit-button')).not.toBeInTheDocument()
   })
 
   it('cancel button closes the confirmation modal without calling the API', async () => {

--- a/frontend/src/pages/BorrowerDetailPage.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 
+import { EditBorrowerModal } from '../components/EditBorrowerModal'
 import { EmptyShelfIcon, NoResultsIcon } from '../components/EmptyStateIcons'
 import { Modal } from '../components/Modal'
 import { useAnonymizeBorrower, useBorrower, useBorrowerLoans } from '../hooks/useBorrowers'
@@ -86,6 +87,7 @@ export function BorrowerDetailPage() {
   const loansQuery = useBorrowerLoans(borrowerId ?? '')
   const anonymize = useAnonymizeBorrower()
   const [confirmOpen, setConfirmOpen] = useState(false)
+  const [editOpen, setEditOpen] = useState(false)
 
   const { active, returned } = useMemo(() => {
     const all = loansQuery.data ?? []
@@ -168,16 +170,30 @@ export function BorrowerDetailPage() {
           )}
         </div>
         {!isAnonymized && (
-          <button
-            type="button"
-            data-testid="anonymize-button"
-            className="sh-btn-secondary"
-            onClick={() => setConfirmOpen(true)}
-          >
-            {t('borrowers.anonymize_button')}
-          </button>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              type="button"
+              data-testid="edit-button"
+              className="sh-btn-secondary"
+              onClick={() => setEditOpen(true)}
+            >
+              {t('borrowers.edit_button')}
+            </button>
+            <button
+              type="button"
+              data-testid="anonymize-button"
+              className="sh-btn-secondary"
+              onClick={() => setConfirmOpen(true)}
+            >
+              {t('borrowers.anonymize_button')}
+            </button>
+          </div>
         )}
       </header>
+
+      {editOpen && (
+        <EditBorrowerModal borrower={borrower} onClose={() => setEditOpen(false)} />
+      )}
 
       {/* Active loans */}
       <section style={{ marginBottom: 24 }}>


### PR DESCRIPTION
## Summary

Audit follow-up from the borrowers epic (#221). Two UX gaps the audit flagged:

1. **Edit UI missing on the detail page.** `PATCH /api/v1/borrowers/{id}` existed since #222 but was only callable via the API.
2. **Mobile bottom nav had no Borrowers entry.** A scope decision deferred from #225 — `/borrowers` was reachable only by URL on mobile.

### Edit modal

- New `EditBorrowerModal` lets editors update name / contact / notes.
- `useUpdateBorrower` PATCHes and invalidates **only** the borrower-level caches — **not** the loan caches. ADR 008's archival semantic is enforced: edits don't propagate to historical loan rows. The modal carries an explicit hint to that effect.
- Edit button sits next to Anonymize on the detail header. Both hidden for already-anonymized borrowers.

### Mobile nav

- Bottom row goes from 3 tabs + FAB to 4 tabs + FAB: `[Library] [Bookshelf] [FAB] [Borrowers] [Settings]`.
- Reuses the existing `IconBorrowers` and `nav.borrowers` translation already shipped in #225 (desktop sidebar).

### i18n

`edit_button`, `edit_modal_title`, `edit_history_hint` (communicates ADR 008's archival rule), `edit_error`, `field_*`, `save`, `saving`, plus a `toast.borrower_saved` confirmation. Both cs and en.

## Test plan

- [x] `cd frontend && npm run lint` (clean)
- [x] `cd frontend && npx tsc --noEmit` (clean)
- [x] `cd frontend && npm test` — 156/156 (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to edit borrower information including name, contact, and notes.
  * Redesigned mobile navigation layout with improved tab organization and spacing.
  * Enhanced mobile interface compatibility with device safe areas.

* **Localization**
  * Added Czech language support for borrower editing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->