### PR TITLE
feat(borrowers): merge two duplicate Borrower records (#238)

### DIFF
--- a/backend/app/api/borrowers.py
+++ b/backend/app/api/borrowers.py
@@ -10,6 +10,7 @@ from app.schemas.borrower import (
     BorrowerListItem,
     BorrowerListResponse,
     BorrowerLoanItem,
+    BorrowerMergeRequest,
     BorrowerResponse,
     BorrowerUpdate,
 )
@@ -19,6 +20,7 @@ from app.services.borrower import (
     get_borrower_or_404,
     list_borrowers_with_stats,
     list_loans_for_borrower,
+    merge_borrowers,
     update_borrower,
 )
 
@@ -102,3 +104,14 @@ async def anonymize_borrower_endpoint(
 ) -> BorrowerResponse:
     borrower = await anonymize_borrower(session, borrower_id, library_id)
     return BorrowerResponse.model_validate(borrower)
+
+
+@router.post("/{target_id}/merge", response_model=BorrowerResponse)
+async def merge_borrower_endpoint(
+    target_id: uuid.UUID,
+    payload: BorrowerMergeRequest,
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(require_editor_library),
+) -> BorrowerResponse:
+    target = await merge_borrowers(session, payload.source_id, target_id, library_id)
+    return BorrowerResponse.model_validate(target)

--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -42,6 +42,12 @@ class BorrowerListItem(BorrowerResponse):
     last_activity_at: date | None
 
 
+class BorrowerMergeRequest(BaseModel):
+    """Body for POST /api/v1/borrowers/{target_id}/merge."""
+
+    source_id: uuid.UUID
+
+
 class BorrowerListResponse(BaseModel):
     """Paginated wrapper around BorrowerListItem rows.
 

--- a/backend/app/services/borrower.py
+++ b/backend/app/services/borrower.py
@@ -284,6 +284,63 @@ async def link_loans_to_borrowers(session: AsyncSession, library_id: uuid.UUID) 
     return linked
 
 
+async def merge_borrowers(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+    target_id: uuid.UUID,
+    library_id: uuid.UUID,
+) -> Borrower:
+    """Merge ``source`` into ``target`` and delete the source row.
+
+    - Both rows must be in ``library_id`` (404 otherwise).
+    - ``source_id == target_id`` is rejected (422).
+    - Anonymized rows on either side are rejected (422). For source, an
+      anonymized record carries no useful identity to consolidate; for
+      target, see #234 — we don't attach fresh data to a record whose
+      personal data was explicitly deleted.
+    - All ``loans.borrower_id == source`` rows are re-pointed to
+      ``target``. ADR 008's archival semantic applies: ``loan.borrower_name``
+      and ``loan.borrower_contact`` are NOT updated — they're a snapshot of
+      who the borrower was *at the time of lending*. Display code reads
+      ``loan.borrower.name`` via the relationship, so the merged loans show
+      the target's name automatically.
+    - The source row is then deleted.
+
+    Returns the target borrower (post-merge state, unchanged identity).
+    """
+    if source_id == target_id:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Cannot merge a borrower into itself",
+        )
+
+    source = await get_borrower_or_404(session, source_id, library_id)
+    target = await get_borrower_or_404(session, target_id, library_id)
+
+    if source.anonymized_at is not None or target.anonymized_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Cannot merge anonymized borrowers",
+        )
+
+    await session.execute(
+        update(Loan)
+        .where(Loan.borrower_id == source_id, Loan.library_id == library_id)
+        .values(borrower_id=target_id)
+    )
+
+    await session.delete(source)
+    await session.commit()
+    await session.refresh(target)
+    logger.info(
+        "borrowers_merged",
+        source_id=str(source_id),
+        target_id=str(target_id),
+        library_id=str(library_id),
+    )
+    return target
+
+
 async def anonymize_borrower(
     session: AsyncSession, borrower_id: uuid.UUID, library_id: uuid.UUID
 ) -> Borrower:

--- a/backend/tests/test_borrower_merge.py
+++ b/backend/tests/test_borrower_merge.py
@@ -1,0 +1,411 @@
+"""Tests for the borrower merge endpoint (issue #238).
+
+Covers:
+- happy path: merging two borrowers re-points loans and deletes source
+- ADR 008 archival semantic: loan.borrower_name snapshots are NOT updated
+- self-merge rejected (422)
+- merging anonymized rows rejected (422), either side
+- cross-library access returns 404 for both source and target
+- viewer role rejected (403)
+- unauthenticated rejected (401)
+- second merge of the same source returns 404 (idempotent in the sense that
+  a stale follow-up call cleanly fails)
+"""
+from collections.abc import AsyncIterator, Iterator
+from datetime import date, timedelta
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.book import Book
+from app.models.borrower import Borrower
+from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.loan import Loan
+from app.models.user import User
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url="sqlite+aiosqlite:///:memory:",
+        jwt_secret_key="test-secret",
+        jwt_algorithm="HS256",
+        access_token_expire_minutes=15,
+        refresh_token_expire_days=7,
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(test_session: AsyncSession, test_settings: Settings) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        yield test_session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _seed_user_with_library(
+    session: AsyncSession, email: str = "admin@example.com"
+) -> tuple[User, Library]:
+    user = (await session.execute(select(User).where(User.email == email))).scalar_one_or_none()
+    if user is None:
+        user = User(email=email, hashed_password=get_password_hash("secret"))
+        session.add(user)
+        await session.flush()
+    existing_lib = (await session.execute(
+        select(Library)
+        .join(LibraryMember, LibraryMember.library_id == Library.id)
+        .where(LibraryMember.user_id == user.id)
+        .limit(1)
+    )).scalar_one_or_none()
+    if existing_lib is not None:
+        return user, existing_lib
+    lib = Library(name=f"Library of {email}", created_by_user_id=user.id)
+    session.add(lib)
+    await session.flush()
+    session.add(LibraryMember(library_id=lib.id, user_id=user.id, role=LibraryRole.OWNER))
+    await session.commit()
+    await session.refresh(lib)
+    return user, lib
+
+
+async def _auth_headers(
+    client: AsyncClient, session: AsyncSession, email: str = "admin@example.com"
+) -> dict[str, str]:
+    await _seed_user_with_library(session, email)
+    resp = await client.post("/api/v1/auth/login", json={"email": email, "password": "secret"})
+    assert resp.status_code == 200
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _make_book(library_id: uuid.UUID, title: str = "Some Book") -> Book:
+    return Book(library_id=library_id, title=title)
+
+
+def _make_loan(
+    *,
+    library_id: uuid.UUID,
+    book_id: uuid.UUID,
+    borrower_id: uuid.UUID,
+    borrower_name: str,
+    lent_date: date,
+    returned_date: date | None = None,
+    return_condition: str | None = None,
+) -> Loan:
+    return Loan(
+        library_id=library_id,
+        book_id=book_id,
+        borrower_id=borrower_id,
+        borrower_name=borrower_name,
+        lent_date=lent_date,
+        returned_date=returned_date,
+        return_condition=return_condition,
+    )
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_merge_repoints_active_and_returned_loans_and_deletes_source(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    today = date.today()
+
+    source = Borrower(library_id=lib.id, name="Alice", contact="alice@old.com")
+    target = Borrower(library_id=lib.id, name="Alice Liddell", contact="alice@new.com")
+    test_session.add_all([source, target])
+    await test_session.flush()
+
+    book_active = _make_book(lib.id, "Active Book")
+    book_returned = _make_book(lib.id, "Returned Book")
+    test_session.add_all([book_active, book_returned])
+    await test_session.flush()
+
+    test_session.add_all([
+        _make_loan(
+            library_id=lib.id, book_id=book_active.id, borrower_id=source.id,
+            borrower_name="Alice", lent_date=today,
+        ),
+        _make_loan(
+            library_id=lib.id, book_id=book_returned.id, borrower_id=source.id,
+            borrower_name="Alice", lent_date=today - timedelta(days=20),
+            returned_date=today - timedelta(days=2), return_condition="good",
+        ),
+    ])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            f"/api/v1/borrowers/{target.id}/merge",
+            json={"source_id": str(source.id)},
+            headers=headers,
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(target.id)
+    assert body["name"] == "Alice Liddell"
+    assert body["contact"] == "alice@new.com"
+
+    # Loans now point at target
+    loans = (await test_session.execute(select(Loan).where(Loan.library_id == lib.id))).scalars().all()
+    assert len(loans) == 2
+    assert {loan.borrower_id for loan in loans} == {target.id}
+
+    # Source row is gone
+    gone = (await test_session.execute(
+        select(Borrower).where(Borrower.id == source.id)
+    )).scalar_one_or_none()
+    assert gone is None
+
+
+@pytest.mark.asyncio
+async def test_merge_does_not_update_loan_snapshots(test_session: AsyncSession) -> None:
+    """ADR 008: ``Loan.borrower_name`` is the snapshot at lend time and stays
+    that way even after merge. Display code reads ``loan.borrower.name`` via
+    the relationship — that's what gives users the merged identity on the
+    history page, not a DB rewrite."""
+    _, lib = await _seed_user_with_library(test_session)
+    source = Borrower(library_id=lib.id, name="Alice", contact="old@x.com")
+    target = Borrower(library_id=lib.id, name="Alice Liddell", contact="new@x.com")
+    test_session.add_all([source, target])
+    await test_session.flush()
+
+    book = _make_book(lib.id)
+    test_session.add(book)
+    await test_session.flush()
+
+    loan = _make_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=source.id,
+        borrower_name="Alice", lent_date=date.today(),
+    )
+    test_session.add(loan)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            f"/api/v1/borrowers/{target.id}/merge",
+            json={"source_id": str(source.id)},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+
+    refreshed = (await test_session.execute(select(Loan).where(Loan.id == loan.id))).scalar_one()
+    # Snapshot text untouched — the source's name at lend time was "Alice".
+    assert refreshed.borrower_name == "Alice"
+    # Relationship now points at target.
+    assert refreshed.borrower_id == target.id
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_merge_self_merge_returns_422(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    borrower = Borrower(library_id=lib.id, name="Lonely")
+    test_session.add(borrower)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            f"/api/v1/borrowers/{borrower.id}/merge",
+            json={"source_id": str(borrower.id)},
+            headers=headers,
+        )
+    assert resp.status_code == 422
+    assert "itself" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_merge_with_anonymized_source_returns_422(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    source = Borrower(library_id=lib.id, name="Old")
+    target = Borrower(library_id=lib.id, name="New")
+    test_session.add_all([source, target])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        anon = await client.post(
+            f"/api/v1/borrowers/{source.id}/anonymize", headers=headers
+        )
+        assert anon.status_code == 200
+
+        resp = await client.post(
+            f"/api/v1/borrowers/{target.id}/merge",
+            json={"source_id": str(source.id)},
+            headers=headers,
+        )
+    assert resp.status_code == 422
+    assert "anonymized" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_merge_with_anonymized_target_returns_422(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    source = Borrower(library_id=lib.id, name="Source")
+    target = Borrower(library_id=lib.id, name="Target")
+    test_session.add_all([source, target])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        await client.post(f"/api/v1/borrowers/{target.id}/anonymize", headers=headers)
+
+        resp = await client.post(
+            f"/api/v1/borrowers/{target.id}/merge",
+            json={"source_id": str(source.id)},
+            headers=headers,
+        )
+    assert resp.status_code == 422
+
+
+# ── Isolation ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_merge_with_foreign_source_returns_404(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    target = Borrower(library_id=lib.id, name="Target")
+    foreign_source = Borrower(library_id=uuid.uuid4(), name="Foreign")
+    test_session.add_all([target, foreign_source])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            f"/api/v1/borrowers/{target.id}/merge",
+            json={"source_id": str(foreign_source.id)},
+            headers=headers,
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_merge_with_foreign_target_returns_404(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    source = Borrower(library_id=lib.id, name="Source")
+    foreign_target = Borrower(library_id=uuid.uuid4(), name="ForeignTarget")
+    test_session.add_all([source, foreign_target])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            f"/api/v1/borrowers/{foreign_target.id}/merge",
+            json={"source_id": str(source.id)},
+            headers=headers,
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_merge_with_unknown_source_returns_404(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    target = Borrower(library_id=lib.id, name="T")
+    test_session.add(target)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            f"/api/v1/borrowers/{target.id}/merge",
+            json={"source_id": str(uuid.uuid4())},
+            headers=headers,
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_double_merge_of_same_source_returns_404(test_session: AsyncSession) -> None:
+    """The first merge succeeds and deletes the source; a stale follow-up
+    call referencing the same source must cleanly 404."""
+    _, lib = await _seed_user_with_library(test_session)
+    source = Borrower(library_id=lib.id, name="Source")
+    target = Borrower(library_id=lib.id, name="Target")
+    test_session.add_all([source, target])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+
+        first = await client.post(
+            f"/api/v1/borrowers/{target.id}/merge",
+            json={"source_id": str(source.id)},
+            headers=headers,
+        )
+        assert first.status_code == 200
+
+        second = await client.post(
+            f"/api/v1/borrowers/{target.id}/merge",
+            json={"source_id": str(source.id)},
+            headers=headers,
+        )
+        assert second.status_code == 404
+
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_merge_requires_editor_role(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session, "owner@example.com")
+    source = Borrower(library_id=lib.id, name="Source")
+    target = Borrower(library_id=lib.id, name="Target")
+    test_session.add_all([source, target])
+
+    viewer = User(email="viewer@example.com", hashed_password=get_password_hash("secret"))
+    test_session.add(viewer)
+    await test_session.flush()
+    test_session.add(LibraryMember(library_id=lib.id, user_id=viewer.id, role=LibraryRole.VIEWER))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "viewer@example.com", "password": "secret"},
+        )
+        viewer_headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+        resp = await client.post(
+            f"/api/v1/borrowers/{target.id}/merge",
+            json={"source_id": str(source.id)},
+            headers=viewer_headers,
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_merge_requires_authentication() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            f"/api/v1/borrowers/{uuid.uuid4()}/merge",
+            json={"source_id": str(uuid.uuid4())},
+        )
+    assert resp.status_code == 401

--- a/docs/adr/008-keep-legacy-loan-borrower-fields.md
+++ b/docs/adr/008-keep-legacy-loan-borrower-fields.md
@@ -156,3 +156,32 @@ is covered by the existing borrower-anonymization tests (`#226`,
   value.
 - Falls back to `loan.borrower_name` when `loan.borrower` is `null` (legacy
   loan that #223 couldn't backfill).
+
+## 2026-05-07 — Amendment: borrower merge keeps loan snapshots untouched
+
+Phase 6 (#238) introduced a "merge two duplicate borrowers" action. The
+implementation question was whether merging the source borrower into the
+target should also rewrite `loan.borrower_name` / `loan.borrower_contact`
+on the moved loan rows to match the target's identity.
+
+**Decision:** No. Loan snapshots are *not* rewritten on merge. The merge
+re-points `Loan.borrower_id` from source to target and deletes the source
+row; the snapshot columns keep recording who the borrower was *at lend
+time*, which may differ from the post-merge identity.
+
+This is the same archival semantic as the rest of this ADR. The display
+layer already prefers `loan.borrower.name` via the relationship (see the
+`LoanHistory` refactor above), so a Czech user looking at the merged
+loan history sees the target's current name on every row, even though
+the underlying snapshot column records the older variant. We get
+correct UX *and* a faithful archival record, with no DB rewrite.
+
+The exception that proves the rule is anonymization (#226), which
+*does* cascade to the snapshot columns — because anonymization's whole
+point is to erase the personal data those columns hold. Merge does not
+have that requirement, so the simpler "leave snapshots alone" rule is
+the right default here.
+
+Implementation lives in `backend/app/services/borrower.merge_borrowers`;
+the cascade-vs-snapshot behavior is asserted in
+`tests/test_borrower_merge.py::test_merge_does_not_update_loan_snapshots`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2254,6 +2254,80 @@
         }
       }
     },
+    "/api/v1/borrowers/{target_id}/merge": {
+      "post": {
+        "tags": [
+          "borrowers"
+        ],
+        "summary": "Merge Borrower Endpoint",
+        "operationId": "merge_borrower_endpoint_api_v1_borrowers__target_id__merge_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "target_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Target Id"
+            }
+          },
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BorrowerMergeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BorrowerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/books/{book_id}/loans": {
       "post": {
         "tags": [
@@ -4661,6 +4735,21 @@
         ],
         "title": "BorrowerLoanItem",
         "description": "A loan as seen from the borrower-detail page — denormalized with book info."
+      },
+      "BorrowerMergeRequest": {
+        "properties": {
+          "source_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Source Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_id"
+        ],
+        "title": "BorrowerMergeRequest",
+        "description": "Body for POST /api/v1/borrowers/{target_id}/merge."
       },
       "BorrowerResponse": {
         "properties": {

--- a/frontend/src/components/MergeBorrowerModal.tsx
+++ b/frontend/src/components/MergeBorrowerModal.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useBorrowers, useMergeBorrowers } from '../hooks/useBorrowers'
+import { useDebounce } from '../hooks/useDebounce'
+import { displayBorrowerName } from '../lib/borrowerDisplay'
+import type { Borrower, BorrowerListItem } from '../lib/types'
+import { Modal } from './Modal'
+
+interface Props {
+  /** The "keep this one" borrower — current detail page. */
+  target: Borrower
+  onClose: () => void
+}
+
+const SEARCH_PAGE_SIZE = 20
+
+/**
+ * "Merge another borrower into this one" flow:
+ *
+ *   step 1 — pick a source borrower (search-as-you-type, anonymized + the
+ *            target itself filtered out)
+ *   step 2 — confirm with explicit "this cannot be undone" warning
+ *
+ * Calls `POST /api/v1/borrowers/{target.id}/merge` on confirm.
+ */
+export function MergeBorrowerModal({ target, onClose }: Props) {
+  const { t } = useTranslation()
+  const [searchInput, setSearchInput] = useState('')
+  const [picked, setPicked] = useState<BorrowerListItem | null>(null)
+  const debouncedSearch = useDebounce(searchInput, 250)
+  const merge = useMergeBorrowers()
+
+  const borrowersQuery = useBorrowers({
+    search: debouncedSearch,
+    page: 1,
+    pageSize: SEARCH_PAGE_SIZE,
+  })
+
+  const candidates = useMemo(
+    () =>
+      (borrowersQuery.data?.items ?? []).filter(
+        (b) => b.id !== target.id && b.anonymized_at === null,
+      ),
+    [borrowersQuery.data, target.id],
+  )
+
+  const targetName = displayBorrowerName(target, t)
+  const pickedName = picked ? displayBorrowerName(picked, t) : ''
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      label={t('borrowers.merge_modal_title')}
+      maxWidth={520}
+    >
+      <div style={{ display: 'grid', gap: 12 }}>
+        <h3 style={{ margin: 0 }}>{t('borrowers.merge_modal_title')}</h3>
+
+        {!picked && (
+          <>
+            <p style={{ margin: 0, color: 'var(--sh-text-muted)', fontSize: 13 }}>
+              {t('borrowers.merge_picker_hint', { target: targetName })}
+            </p>
+            <input
+              type="search"
+              className="sh-input"
+              placeholder={t('borrowers.search_placeholder')}
+              aria-label={t('borrowers.search_placeholder')}
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              data-testid="merge-source-search"
+            />
+            {borrowersQuery.isLoading && (
+              <p style={{ margin: 0, color: 'var(--sh-text-muted)', fontSize: 13 }}>
+                {t('borrowers.loading')}
+              </p>
+            )}
+            {!borrowersQuery.isLoading && candidates.length === 0 && (
+              <p
+                data-testid="merge-no-candidates"
+                style={{ margin: 0, color: 'var(--sh-text-muted)', fontSize: 13 }}
+              >
+                {debouncedSearch
+                  ? t('borrowers.no_results', { query: debouncedSearch })
+                  : t('borrowers.merge_no_candidates')}
+              </p>
+            )}
+            {!borrowersQuery.isLoading && candidates.length > 0 && (
+              <ul
+                data-testid="merge-source-list"
+                style={{
+                  listStyle: 'none',
+                  padding: 0,
+                  margin: 0,
+                  display: 'grid',
+                  gap: 4,
+                  maxHeight: 240,
+                  overflowY: 'auto',
+                }}
+              >
+                {candidates.map((candidate) => (
+                  <li key={candidate.id}>
+                    <button
+                      type="button"
+                      data-testid={`merge-source-${candidate.id}`}
+                      onClick={() => setPicked(candidate)}
+                      style={{
+                        width: '100%',
+                        textAlign: 'left',
+                        padding: 10,
+                        background: 'var(--sh-surface)',
+                        border: '1px solid var(--sh-border)',
+                        borderRadius: 'var(--sh-radius-md)',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <div style={{ fontWeight: 500 }}>{candidate.name}</div>
+                      {candidate.contact && (
+                        <div style={{ fontSize: 12, color: 'var(--sh-text-muted)' }}>
+                          {candidate.contact}
+                        </div>
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+              <button type="button" className="sh-btn-secondary" onClick={onClose}>
+                {t('common.cancel')}
+              </button>
+            </div>
+          </>
+        )}
+
+        {picked && (
+          <>
+            <p data-testid="merge-confirm-body" style={{ margin: 0 }}>
+              {t('borrowers.merge_confirm_body', {
+                source: pickedName,
+                target: targetName,
+              })}
+            </p>
+            <p style={{ margin: 0, color: 'var(--sh-red)', fontWeight: 500 }}>
+              {t('borrowers.merge_irreversible')}
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+              <button
+                type="button"
+                className="sh-btn-secondary"
+                onClick={() => setPicked(null)}
+                disabled={merge.isPending}
+              >
+                {t('borrowers.merge_back')}
+              </button>
+              <button
+                type="button"
+                data-testid="merge-confirm"
+                className="sh-btn-primary"
+                style={{ background: 'var(--sh-red)' }}
+                disabled={merge.isPending}
+                onClick={() => {
+                  merge.mutate(
+                    { targetId: target.id, sourceId: picked.id },
+                    { onSuccess: () => onClose() },
+                  )
+                }}
+              >
+                {merge.isPending ? t('borrowers.merging') : t('borrowers.merge_confirm')}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/hooks/useBorrowers.ts
+++ b/frontend/src/hooks/useBorrowers.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 
-import { anonymizeBorrower, formatApiError, getBorrower, listBorrowerLoans, listBorrowers, updateBorrower } from '../lib/api'
+import { anonymizeBorrower, formatApiError, getBorrower, listBorrowerLoans, listBorrowers, mergeBorrowers, updateBorrower } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
 import { useToastStore } from '../lib/toast-store'
 import type { BorrowerListParams, BorrowerUpdateRequest } from '../lib/types'
@@ -62,6 +62,33 @@ export function useUpdateBorrower() {
         queryClient.invalidateQueries({ queryKey: borrowerKey(updated.id) }),
       ])
       showSuccess(t('toast.borrower_saved', 'Borrower saved.'))
+    },
+    onError: (error: unknown) => showError(formatApiError(error)),
+  })
+}
+
+export function useMergeBorrowers() {
+  const queryClient = useQueryClient()
+  const showError = useToastStore((s) => s.showError)
+  const showSuccess = useToastStore((s) => s.showSuccess)
+  const { t } = useTranslation()
+
+  return useMutation({
+    mutationFn: ({ targetId, sourceId }: { targetId: string; sourceId: string }) =>
+      mergeBorrowers(targetId, sourceId),
+    onSuccess: async (target, { sourceId }) => {
+      // Source row is gone; target's loans changed; loan caches on book pages
+      // carry borrower nesting so they need a refresh too.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: BORROWERS_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: borrowerKey(target.id) }),
+        queryClient.invalidateQueries({ queryKey: borrowerLoansKey(target.id) }),
+        queryClient.invalidateQueries({ queryKey: borrowerKey(sourceId) }),
+        queryClient.invalidateQueries({ queryKey: borrowerLoansKey(sourceId) }),
+        queryClient.invalidateQueries({ queryKey: ['loans'] }),
+        queryClient.invalidateQueries({ queryKey: ['books'] }),
+      ])
+      showSuccess(t('toast.borrowers_merged', 'Borrowers merged.'))
     },
     onError: (error: unknown) => showError(formatApiError(error)),
   })

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -27,7 +27,8 @@
     "scan_confirmed": "Knihy uloženy do knihovny!",
     "enrich_started": "Obohacování zahájeno. Data se brzy aktualizují.",
     "borrower_anonymized": "Dlužník anonymizován.",
-    "borrower_saved": "Dlužník uložen."
+    "borrower_saved": "Dlužník uložen.",
+    "borrowers_merged": "Dlužníci sloučeni."
   },
   "bulk": {
     "selected": "{{count}} vybráno",
@@ -761,6 +762,15 @@
     "anonymize_confirm_body": "Smaže jméno, kontakt i poznámky u {{name}} — a vyčistí tyto údaje u všech souvisejících půjček. Historie půjček (knihy, data, stav při vrácení) zůstává.",
     "anonymize_irreversible": "Tento krok nelze vrátit.",
     "anonymize_confirm": "Anonymizovat",
-    "anonymizing": "Anonymizuji…"
+    "anonymizing": "Anonymizuji…",
+    "merge_button": "Sloučit…",
+    "merge_modal_title": "Sloučit jiného dlužníka do tohoto",
+    "merge_picker_hint": "Vyber dlužníka, kterého chceš sloučit do {{target}}. Jeho půjčky se přesunou sem a vybraný záznam bude smazán.",
+    "merge_no_candidates": "Žádní další dlužníci ke sloučení.",
+    "merge_confirm_body": "Přesunout všechny půjčky od {{source}} k {{target}} a smazat {{source}}.",
+    "merge_irreversible": "Tento krok nelze vrátit.",
+    "merge_back": "Zpět",
+    "merge_confirm": "Sloučit",
+    "merging": "Slučuji…"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -27,7 +27,8 @@
     "scan_confirmed": "Books saved to your library!",
     "enrich_started": "Enrichment started. Data will update shortly.",
     "borrower_anonymized": "Borrower anonymized.",
-    "borrower_saved": "Borrower saved."
+    "borrower_saved": "Borrower saved.",
+    "borrowers_merged": "Borrowers merged."
   },
   "bulk": {
     "selected": "{{count}} selected",
@@ -758,6 +759,15 @@
     "anonymize_confirm_body": "This removes {{name}}'s name, contact, and notes — and clears those fields on every related loan record. The lending history (books, dates, return condition) is kept.",
     "anonymize_irreversible": "This cannot be undone.",
     "anonymize_confirm": "Anonymize",
-    "anonymizing": "Anonymizing…"
+    "anonymizing": "Anonymizing…",
+    "merge_button": "Merge…",
+    "merge_modal_title": "Merge another borrower into this one",
+    "merge_picker_hint": "Pick a borrower to merge into {{target}}. Their loans will move over and the picked record will be deleted.",
+    "merge_no_candidates": "No other borrowers to merge in.",
+    "merge_confirm_body": "Move every loan from {{source}} to {{target}}, then delete {{source}}.",
+    "merge_irreversible": "This cannot be undone.",
+    "merge_back": "Back",
+    "merge_confirm": "Merge",
+    "merging": "Merging…"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -516,6 +516,14 @@ export async function updateBorrower(id: string, payload: BorrowerUpdateRequest)
   return response.data
 }
 
+export async function mergeBorrowers(targetId: string, sourceId: string): Promise<Borrower> {
+  const response = await apiClient.post<Borrower>(
+    `/api/v1/borrowers/${targetId}/merge`,
+    { source_id: sourceId },
+  )
+  return response.data
+}
+
 export async function anonymizeBorrower(id: string): Promise<Borrower> {
   const response = await apiClient.post<Borrower>(`/api/v1/borrowers/${id}/anonymize`)
   return response.data

--- a/frontend/src/pages/BorrowerDetailPage.test.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.test.tsx
@@ -11,8 +11,10 @@ vi.mock('../contexts/AuthContext', () => ({
 vi.mock('../lib/api', () => ({
   getBorrower: vi.fn(),
   listBorrowerLoans: vi.fn(),
+  listBorrowers: vi.fn(),
   anonymizeBorrower: vi.fn(),
   updateBorrower: vi.fn(),
+  mergeBorrowers: vi.fn(),
   formatApiError: (e: unknown) => String(e),
 }))
 
@@ -21,7 +23,7 @@ vi.mock('../lib/toast-store', () => ({
     selector({ showError: vi.fn(), showSuccess: vi.fn() }),
 }))
 
-import { anonymizeBorrower, getBorrower, listBorrowerLoans, updateBorrower } from '../lib/api'
+import { anonymizeBorrower, getBorrower, listBorrowerLoans, listBorrowers, mergeBorrowers, updateBorrower } from '../lib/api'
 import type { Borrower, BorrowerLoanItem } from '../lib/types'
 import { BorrowerDetailPage } from './BorrowerDetailPage'
 
@@ -234,6 +236,122 @@ describe('BorrowerDetailPage', () => {
         notes: null,
       })
     })
+  })
+
+  it('opens the merge modal, picks a source, confirms, and calls mergeBorrowers', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower({ id: 'b-target', name: 'Alice Liddell' }))
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    vi.mocked(listBorrowers).mockResolvedValue({
+      total: 1,
+      page: 1,
+      page_size: 20,
+      items: [
+        {
+          id: 'b-source',
+          name: 'Alice',
+          contact: 'old@x.com',
+          notes: null,
+          anonymized_at: null,
+          created_at: '2026-05-01T00:00:00Z',
+          updated_at: '2026-05-01T00:00:00Z',
+          active_loans: 1,
+          total_loans: 2,
+          last_activity_at: null,
+        },
+      ],
+    })
+    vi.mocked(mergeBorrowers).mockResolvedValue(makeBorrower({ id: 'b-target', name: 'Alice Liddell' }))
+    renderPage('b-target')
+
+    const user = userEvent.setup()
+    await user.click(await screen.findByTestId('merge-button'))
+
+    // Pick the source from the candidate list.
+    await user.click(await screen.findByTestId('merge-source-b-source'))
+
+    // Confirm step shows the irreversible warning.
+    expect(await screen.findByText('borrowers.merge_irreversible')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('merge-confirm'))
+
+    await waitFor(() =>
+      expect(mergeBorrowers).toHaveBeenCalledWith('b-target', 'b-source'),
+    )
+  })
+
+  it('merge picker excludes the target itself and anonymized borrowers', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower({ id: 'b-target', name: 'Alice' }))
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    vi.mocked(listBorrowers).mockResolvedValue({
+      total: 3,
+      page: 1,
+      page_size: 20,
+      items: [
+        // The target row — must be filtered out.
+        {
+          id: 'b-target',
+          name: 'Alice',
+          contact: null,
+          notes: null,
+          anonymized_at: null,
+          created_at: '2026-05-01T00:00:00Z',
+          updated_at: '2026-05-01T00:00:00Z',
+          active_loans: 0,
+          total_loans: 0,
+          last_activity_at: null,
+        },
+        // Anonymized — must be filtered out.
+        {
+          id: 'b-anon',
+          name: 'Deleted borrower',
+          contact: null,
+          notes: null,
+          anonymized_at: '2026-05-07T00:00:00Z',
+          created_at: '2026-05-01T00:00:00Z',
+          updated_at: '2026-05-01T00:00:00Z',
+          active_loans: 0,
+          total_loans: 0,
+          last_activity_at: null,
+        },
+        // Valid candidate.
+        {
+          id: 'b-other',
+          name: 'Alice (other)',
+          contact: null,
+          notes: null,
+          anonymized_at: null,
+          created_at: '2026-05-01T00:00:00Z',
+          updated_at: '2026-05-01T00:00:00Z',
+          active_loans: 0,
+          total_loans: 0,
+          last_activity_at: null,
+        },
+      ],
+    })
+    renderPage('b-target')
+
+    const user = userEvent.setup()
+    await user.click(await screen.findByTestId('merge-button'))
+
+    expect(await screen.findByTestId('merge-source-b-other')).toBeInTheDocument()
+    expect(screen.queryByTestId('merge-source-b-target')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('merge-source-b-anon')).not.toBeInTheDocument()
+  })
+
+  it('does not show the merge button when the borrower is already anonymized', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(
+      makeBorrower({
+        name: 'Deleted borrower',
+        contact: null,
+        notes: null,
+        anonymized_at: '2026-05-07T00:00:00Z',
+      }),
+    )
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    expect(await screen.findByText('borrowers.anonymized_label')).toBeInTheDocument()
+    expect(screen.queryByTestId('merge-button')).not.toBeInTheDocument()
   })
 
   it('does not show the edit button when the borrower is already anonymized', async () => {

--- a/frontend/src/pages/BorrowerDetailPage.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.tsx
@@ -4,6 +4,7 @@ import { Link, useParams } from 'react-router-dom'
 
 import { EditBorrowerModal } from '../components/EditBorrowerModal'
 import { EmptyShelfIcon, NoResultsIcon } from '../components/EmptyStateIcons'
+import { MergeBorrowerModal } from '../components/MergeBorrowerModal'
 import { Modal } from '../components/Modal'
 import { useAnonymizeBorrower, useBorrower, useBorrowerLoans } from '../hooks/useBorrowers'
 import { displayBorrowerName } from '../lib/borrowerDisplay'
@@ -88,6 +89,7 @@ export function BorrowerDetailPage() {
   const anonymize = useAnonymizeBorrower()
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
+  const [mergeOpen, setMergeOpen] = useState(false)
 
   const { active, returned } = useMemo(() => {
     const all = loansQuery.data ?? []
@@ -170,7 +172,7 @@ export function BorrowerDetailPage() {
           )}
         </div>
         {!isAnonymized && (
-          <div style={{ display: 'flex', gap: 8 }}>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
             <button
               type="button"
               data-testid="edit-button"
@@ -178,6 +180,14 @@ export function BorrowerDetailPage() {
               onClick={() => setEditOpen(true)}
             >
               {t('borrowers.edit_button')}
+            </button>
+            <button
+              type="button"
+              data-testid="merge-button"
+              className="sh-btn-secondary"
+              onClick={() => setMergeOpen(true)}
+            >
+              {t('borrowers.merge_button')}
             </button>
             <button
               type="button"
@@ -193,6 +203,10 @@ export function BorrowerDetailPage() {
 
       {editOpen && (
         <EditBorrowerModal borrower={borrower} onClose={() => setEditOpen(false)} />
+      )}
+
+      {mergeOpen && (
+        <MergeBorrowerModal target={borrower} onClose={() => setMergeOpen(false)} />
       )}
 
       {/* Active loans */}


### PR DESCRIPTION
## Summary

Closes #238 — backlog item from the borrowers epic (#221) audit.

### Backend

New service `merge_borrowers(session, source_id, target_id, library_id)`:

- Both rows must be in the active library (404 otherwise).
- `source_id == target_id` rejected (422).
- Anonymized rows on either side rejected (422).
- All `loans.borrower_id == source` rows re-pointed to `target`. **ADR 008's archival semantic applies**: `loan.borrower_name`/`loan.borrower_contact` are NOT updated — they keep recording who the borrower was *at lend time*. Display reads `loan.borrower.name` via the relationship (since #227), so merged loans show the target's name automatically.
- Source row deleted.

New endpoint `POST /api/v1/borrowers/{target_id}/merge` with body `{"source_id": "<uuid>"}`. Editor role.

10 tests: happy path with active+returned loans, snapshot-not-rewritten assertion, self-merge 422, anonymized-source/target 422, foreign-source/target 404, unknown-source 404, double-merge 404, viewer 403, no-auth 401.

ADR 008 amended with a "borrower merge keeps loan snapshots untouched" section naming the test that asserts the contract.

### Frontend

- `mergeBorrowers(targetId, sourceId)` helper + `useMergeBorrowers` mutation invalidating list, both detail caches, both loan caches, and the broad `loans`/`books` caches.
- `MergeBorrowerModal` — two-step flow: search-as-you-type picker (target itself + anonymized filtered out client-side) → confirmation with borrower names interpolated + red "cannot be undone" warning.
- "Merge…" button next to Edit and Anonymize on the detail header. Hidden for already-anonymized rows.
- Full i18n cs+en.
- 3 new tests in `BorrowerDetailPage.test.tsx`.

## Test plan

- [x] `cd frontend && npm run lint` (clean)
- [x] `cd frontend && npx tsc --noEmit` (clean for touched files)
- [x] `cd frontend && npm test` — 162/162
- [ ] `cd backend && ruff check app tests`
- [ ] `cd backend && mypy app tests`
- [ ] `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`
- [ ] OpenAPI regen by CI for the new POST endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Borrower merge UI and API: select a source borrower, confirm irreversible merge; loans are reassigned to the target and the source record removed. Merge button and two-step modal added; success shows a "Borrowers merged." toast.
* **Documentation**
  * ADR updated to confirm that loan snapshot fields are preserved during merges; OpenAPI spec includes the new merge operation.
* **Tests**
  * Comprehensive tests for merge behavior, authorization, edge cases, and snapshot preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->