### PR TITLE
chore: ignore backend test artifacts (.coverage and test.db)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ __pycache__/
 node_modules/
 frontend/dist/
 .env
-backend/test_*.db
+backend/test*.db
+backend/.coverage
 frontend/.env
 infra/.env
 .env.local


### PR DESCRIPTION
## Summary

Two backend test artifacts kept showing up as untracked across sessions:

- `backend/test.db` — the default `TEST_DATABASE_URL` value from `AGENTS.md`'s pytest snippet writes a SQLite file with this exact name. The existing `backend/test_*.db` pattern required the underscore and missed it.
- `backend/.coverage` — `pytest --cov` writes this whenever the coverage gate runs locally.

Widen the pattern to `backend/test*.db` and add `backend/.coverage`.

## Test plan

- [x] `git status` is clean of the two artifacts after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to ignore backend test database files and coverage reports, improving development workflow cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->