### PR TITLE
chore(changelog): document the rest of the borrowers epic + audit follow-ups

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,10 +6,14 @@ The public page at `/changelog` is generated from `frontend/src/content/changelo
 
 ## 2026-05-07 — Dlužníci jako samostatná entita
 
-- Přibyla evidence dlužníků (`/borrowers`) s vyhledáváním a statistikami počtu půjček (#225).
+- Přibyla evidence dlužníků (`/borrowers`) s vyhledáváním a statistikami počtu půjček. Hledání i stránkování běží na serveru a fungují i ve velkých knihovnách (#225, #237).
 - Detail dlužníka ukazuje aktuální půjčky i historii včetně stavu při vrácení (#225).
-- Půjčování knihy umí vybrat existujícího dlužníka i ručně napsat nového (#224).
+- Půjčování knihy umí vybrat existujícího dlužníka z našeptávače i ručně napsat nového (#224).
+- Údaje dlužníka (jméno, kontakt, poznámky) jdou upravit přímo z detailu (#236).
 - Anonymizace dlužníka bezpečně smaže osobní údaje napříč knihovnou i historií půjček (#226).
+- Sloučení dvou duplicitních záznamů dlužníka do jednoho — historie půjček se konsoliduje (#238).
+- GDPR export osobních dat zahrnuje záznamy dlužníků z každé knihovny (#235).
+- Záložka Dlužníci v mobilní spodní navigaci.
 - Loan history na stránce knihy zobrazí lokalizovaný štítek „Smazaný dlužník" / "Deleted borrower" pro anonymizované záznamy (#227).
 
 ## 2026-04-29 — Spolehlivější backend a přísnější CI

--- a/frontend/src/content/changelog.ts
+++ b/frontend/src/content/changelog.ts
@@ -25,23 +25,31 @@ export const changelogEntries: ChangelogEntry[] = [
     },
     added: {
       cs: [
-        'Stránka /borrowers s vyhledáváním a statistikami (počet aktivních, celkem, poslední aktivita) (#225).',
+        'Stránka /borrowers s vyhledáváním a statistikami (počet aktivních, celkem, poslední aktivita); hledání i stránkování běží na serveru (#225, #237).',
         'Detail dlužníka se sekcemi Aktuálně půjčeno a Vráceno, včetně stavu při vrácení (#225).',
         'Picker existujících dlužníků ve formuláři půjčení knihy s nepovinným ručním zápisem (#224).',
+        'Úprava údajů dlužníka (jméno, kontakt, poznámky) z detailu (#236).',
         'Anonymizace dlužníka — smaže jméno/kontakt/poznámky a všechny identifikující údaje na jeho půjčkách, historie zůstává (#226).',
+        'Sloučení dvou duplicitních záznamů dlužníka do jednoho — historie půjček se konsoliduje (#238).',
+        'Záložka Dlužníci v mobilní spodní navigaci (#236).',
       ],
       en: [
-        '/borrowers page with search and per-row stats (active, total, last activity) (#225).',
+        '/borrowers page with search and per-row stats (active, total, last activity); search and pagination run server-side (#225, #237).',
         'Borrower detail page with Currently borrowed and Returned sections, including return condition (#225).',
         'Existing-borrower picker in the lend modal with a typed-name fallback (#224).',
+        'Edit borrower (name, contact, notes) directly from the detail page (#236).',
         'Anonymize action — wipes name/contact/notes and clears identifying data on the borrower\'s loans while keeping history (#226).',
+        'Merge two duplicate borrower records into one — lending history is consolidated (#238).',
+        'Borrowers tab in the mobile bottom navigation (#236).',
       ],
     },
     changed: {
       cs: [
+        'GDPR export osobních dat zahrnuje záznamy dlužníků z každé knihovny (#235).',
         'Historie půjček u knihy zobrazí lokalizovaný štítek „Smazaný dlužník" pro anonymizované záznamy (#227).',
       ],
       en: [
+        'GDPR data export now includes the standalone borrower list per library (#235).',
         'Loan history on book pages shows a localized "Deleted borrower" label for anonymized records (#227).',
       ],
     },


### PR DESCRIPTION
## Summary

The existing 2026-05-07 changelog entry only covered the first four phases of the borrowers epic (#224, #225, #226, #227). The same day shipped four more user-visible capabilities that the public changelog skipped:

- Server-side search + pagination on \`/borrowers\` (#237)
- Edit borrower from the detail page (#236)
- Merge two duplicate borrower records (#238, #241)
- GDPR data export now includes standalone borrower records (#235)
- Borrowers tab in mobile bottom navigation (#236)

Both the markdown source (\`docs/CHANGELOG.md\`) and the TypeScript source that renders \`/changelog\` (\`frontend/src/content/changelog.ts\`) are updated.

## Test plan

- [x] \`cd frontend && npx tsc --noEmit\` clean for changelog.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog entries with expanded details on borrower-related features, including borrower search functionality, loan management, data editing, anonymization capabilities, duplicate record merging, and GDPR export enhancements.
  * Enhanced localization for changelog entries in Czech and English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->