### PR TITLE
fix(bookshelf): eager-load Loan.borrower so /books/shelf doesn't 500

### DIFF
--- a/backend/app/services/book.py
+++ b/backend/app/services/book.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import ColumnElement, case, delete, update
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import selectinload
+from sqlalchemy.sql.base import ExecutableOption
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
@@ -19,7 +20,7 @@ from app.services.csv_import import build_books_export_csv as build_books_export
 logger = structlog.get_logger()
 
 
-def _book_loan_options() -> tuple[object, ...]:
+def _book_loan_options() -> tuple[ExecutableOption, ...]:
     """Eager-load options for any Book query whose response will hit
     ``BookResponse.active_loan``.
 

--- a/backend/app/services/book.py
+++ b/backend/app/services/book.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
 from app.models.book import Book, ReadingStatus
+from app.models.loan import Loan
 from app.models.location import Location
 from app.schemas.book import BookCreateRequest, BookUpdateRequest
 
@@ -16,6 +17,20 @@ from app.schemas.book import BookCreateRequest, BookUpdateRequest
 from app.services.csv_import import build_books_export_csv as build_books_export_csv  # noqa: F401
 
 logger = structlog.get_logger()
+
+
+def _book_loan_options() -> tuple[object, ...]:
+    """Eager-load options for any Book query whose response will hit
+    ``BookResponse.active_loan``.
+
+    ``Book.active_loan`` is a Python property on the ORM model that walks
+    ``book.loans``; the ``LoanResponse`` schema then dereferences
+    ``loan.borrower`` (added in #222). In an async session, accessing a
+    relationship that isn't preloaded raises ``MissingGreenlet``. So the
+    chain has to load the borrower too — this helper is the single source
+    of truth for that contract.
+    """
+    return (selectinload(Book.loans).selectinload(Loan.borrower),)
 
 
 async def list_books(
@@ -72,7 +87,7 @@ async def list_books(
     count_query = select(func.count()).select_from(Book).where(*filters)
     query = (
         select(Book)
-        .options(selectinload(Book.loans))
+        .options(*_book_loan_options())
         .where(*filters)
         .order_by(Book.created_at.desc(), Book.id.desc())
         .offset((page - 1) * page_size)
@@ -148,7 +163,7 @@ async def list_all_books_for_shelf(
     """
     query = (
         select(Book)
-        .options(selectinload(Book.loans))
+        .options(*_book_loan_options())
         .where(Book.library_id == library_id)
         .order_by(
             Book.location_id.asc().nulls_last(),
@@ -180,7 +195,7 @@ async def create_book(session: AsyncSession, payload: BookCreateRequest, library
 async def get_book_or_404(session: AsyncSession, book_id: uuid.UUID, library_id: uuid.UUID) -> Book:
     result = await session.execute(
         select(Book)
-        .options(selectinload(Book.loans))
+        .options(*_book_loan_options())
         .where(Book.id == book_id, Book.library_id == library_id)
     )
     book = result.scalar_one_or_none()
@@ -216,10 +231,12 @@ async def update_book(
             raise _isbn_conflict_error() from exc
         raise
 
-    await session.refresh(book)
-    await session.refresh(book, attribute_names=["loans"])
+    # Re-fetch through ``get_book_or_404`` so the response carries the full
+    # eager-load chain (loans + each loan's borrower). A bare ``refresh`` only
+    # reloads scalar columns plus the named relationship and would leave
+    # ``loan.borrower`` lazy — fatal in async serialization since #222.
     logger.info("book_updated", book_id=str(book.id), fields=list(update_data.keys()))
-    return book
+    return await get_book_or_404(session, book.id, library_id)
 
 
 async def delete_book(session: AsyncSession, book_id: uuid.UUID, library_id: uuid.UUID) -> None:

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -14,7 +14,9 @@ from app.db.base import Base
 from app.db.session import get_db_session
 from app.main import app
 from app.models.book import Book
+from app.models.borrower import Borrower
 from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.loan import Loan
 from app.models.location import Location
 from app.models.user import User
 
@@ -525,6 +527,72 @@ async def test_shelf_endpoint_orders_by_location_and_shelf_position(
 async def test_shelf_endpoint_requires_authentication() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         assert (await client.get("/api/v1/books/shelf")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_shelf_endpoint_serializes_book_with_borrower_linked_active_loan(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """Regression: a book whose active loan is linked to a Borrower row must
+    serialize cleanly via ``GET /api/v1/books/shelf``.
+
+    Pre-fix the ``selectinload(Book.loans)`` chain didn't reach ``Loan.borrower``,
+    so async serialization tripped MissingGreenlet on ``loan.borrower`` and the
+    whole shelf response 500'd — making every book disappear from the bookshelf
+    UI in libraries that had at least one borrower-linked loan (i.e. anyone who
+    used the Borrower picker shipped in #224).
+
+    The same shape covers all read paths via the shared ``_book_loan_options``
+    helper, so this single test pins the contract.
+    """
+    from datetime import date
+
+    async with test_session() as session:
+        _, library = await _seed_user_with_library(session)
+        location_id = await _create_location(session, library.id)
+        borrower = Borrower(
+            library_id=library.id, name="Alice Liddell", contact="alice@x.com"
+        )
+        session.add(borrower)
+        await session.flush()
+
+        book = Book(
+            library_id=library.id,
+            title="Wonderland",
+            location_id=location_id,
+            shelf_position=0,
+        )
+        session.add(book)
+        await session.flush()
+
+        session.add(
+            Loan(
+                library_id=library.id,
+                book_id=book.id,
+                borrower_id=borrower.id,
+                borrower_name=borrower.name,
+                borrower_contact=borrower.contact,
+                lent_date=date.today(),
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        response = await client.get("/api/v1/books/shelf", headers=headers)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    body = payload[0]
+    assert body["title"] == "Wonderland"
+    assert body["is_currently_lent"] is True
+    assert body["active_loan"] is not None
+    assert body["active_loan"]["borrower"] is not None
+    assert body["active_loan"]["borrower"]["name"] == "Alice Liddell"
 
 
 # ── Shelf ETag / If-None-Match ─────────────────────────────────────────────────


### PR DESCRIPTION
## What broke

After the borrowers epic landed (#222), every read path that returns a `BookResponse` started serializing the nested `LoanResponse.borrower` field. `app/services/book.py` was eager-loading `selectinload(Book.loans)` but had no second-level `selectinload(Loan.borrower)` chained on — so any book with at least one borrower-linked loan tripped \`MissingGreenlet\` during async serialization. The response 500'd and **every book disappeared** from the bookshelf UI in real libraries that had used the picker shipped in #224.

The existing shelf tests (`test_shelf_endpoint_*`) seed books without loans, so they kept passing. The bug only surfaces with a populated \`Borrower\` row + an active \`Loan\` linking the two — i.e. production data.

## Fix

- New `_book_loan_options()` helper in `app/services/book.py` — single source of truth for the load chain.
- `list_books`, `list_all_books_for_shelf`, `get_book_or_404` all use it.
- `update_book` previously returned via a bare `session.refresh(book, attribute_names=["loans"])` (only loads the named relationship, leaves \`loan.borrower\` lazy → 500 on PATCH responses too). Replaced with a re-fetch through `get_book_or_404`.
- `create_book` untouched — a fresh book has no loans, so nothing dereferences a borrower.

## Regression test

`test_shelf_endpoint_serializes_book_with_borrower_linked_active_loan` seeds Borrower + Loan(book→borrower) and asserts `GET /books/shelf` is 200 with the nested `active_loan.borrower.name` populated.

## Test plan

- [ ] `cd backend && ruff check app tests`
- [ ] `cd backend && mypy app tests`
- [ ] `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`
- [ ] Manual: log in to a library that has at least one active loan against a borrower, open `/bookshelf`, verify books render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Book endpoints (list, shelf, and single-book) now include each book's loans and nested borrower details in responses; updated update behavior returns a freshly fetched book with those relations included.

* **Tests**
  * Added regression test ensuring the shelf endpoint serializes active loans with full borrower information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->