### PR TITLE
chore(tests): enforce SQLite FK constraints + reseed dangling-FK fixtures (#247)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,21 @@ cd ../frontend
 npm run lint
 npm test -- --run
 ```
+
+## Test-DB contract
+
+The backend test suite runs against SQLite (`sqlite+aiosqlite`). Production
+runs on Postgres. To stop the two from drifting on FK semantics — the kind
+of divergence that lets dangling-FK inserts pass green tests but break
+production — `backend/tests/conftest.py` registers a global SQLAlchemy
+connect-event listener that issues `PRAGMA foreign_keys=ON` on every SQLite
+connection. The listener is re-asserted by `tests/test_sqlite_pragma.py`,
+which both reads back the pragma and proves a dangling-FK insert raises
+`IntegrityError`.
+
+**Implication for new tests:** rows must reference real parents. To
+simulate "this borrower lives in another library that the user has no
+access to," seed an actual `Library` row (with a real `created_by_user_id`)
+but skip the `LibraryMember` — see the patterns in
+`tests/test_borrowers.py::test_list_borrowers_isolated_between_libraries`
+and friends.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,8 +2,40 @@
 
 Sets TESTING=true before any app code is imported so that the rate limiter
 is disabled for the entire test suite.
+
+Also wires a global SQLAlchemy connection event that enables foreign-key
+enforcement on every SQLite connection the test suite opens. Production
+runs on Postgres which enforces FKs natively; the test suite previously
+ran on SQLite where ``PRAGMA foreign_keys`` defaults to ``OFF``, so
+``ondelete=CASCADE`` and ``ondelete=SET NULL`` were never exercised and
+dangling-FK rows could be inserted in tests without a complaint. That
+let one class of "green tests, red prod" bug through.
+
+The event listener is registered against the base ``Engine`` class so it
+applies to every async engine the per-test fixtures spin up — no
+per-engine wiring needed.
 """
 import os
 
 # Must be set before app modules are imported (limiter reads it at module load time)
 os.environ.setdefault("TESTING", "true")
+
+from sqlalchemy import event  # noqa: E402  — must come after env setup
+from sqlalchemy.engine import Engine  # noqa: E402
+
+
+@event.listens_for(Engine, "connect")
+def _enable_sqlite_foreign_keys(dbapi_connection: object, _connection_record: object) -> None:
+    """Turn on FK enforcement for every SQLite connection the test suite opens.
+
+    Detects SQLite by the DB-API module name, so it stays a no-op for any
+    Postgres-backed test (e.g. when ``TEST_DATABASE_URL`` is overridden).
+    """
+    module_name = type(dbapi_connection).__module__
+    if "sqlite" not in module_name.lower():
+        return
+    cursor = dbapi_connection.cursor()  # type: ignore[attr-defined]
+    try:
+        cursor.execute("PRAGMA foreign_keys=ON")
+    finally:
+        cursor.close()

--- a/backend/tests/test_borrower_anonymize.py
+++ b/backend/tests/test_borrower_anonymize.py
@@ -287,8 +287,11 @@ async def test_anonymize_already_anonymized_is_idempotent(
 
 @pytest.mark.asyncio
 async def test_anonymize_foreign_borrower_returns_404(test_session: AsyncSession) -> None:
-    await _seed_user_with_library(test_session)
-    foreign = Borrower(library_id=uuid.uuid4(), name="Foreign")
+    user, _ = await _seed_user_with_library(test_session)
+    foreign_lib = Library(name="Foreign", created_by_user_id=user.id)
+    test_session.add(foreign_lib)
+    await test_session.flush()
+    foreign = Borrower(library_id=foreign_lib.id, name="Foreign")
     test_session.add(foreign)
     await test_session.commit()
 

--- a/backend/tests/test_borrower_link.py
+++ b/backend/tests/test_borrower_link.py
@@ -7,9 +7,13 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from app.core.security import get_password_hash
 from app.db.base import Base
+from app.models.book import Book
 from app.models.borrower import Borrower
+from app.models.library import Library
 from app.models.loan import Loan
+from app.models.user import User
 from app.schemas.borrower import BorrowerCreate
 from app.services.borrower import create_borrower, link_loans_to_borrowers
 
@@ -25,8 +29,40 @@ async def session() -> AsyncIterator[AsyncSession]:
     await engine.dispose()
 
 
+# These tests are service-level (they call ``link_loans_to_borrowers`` directly,
+# bypassing the API). They previously fabricated ``library_id``/``book_id`` as
+# bare ``uuid.uuid4()`` values and relied on SQLite not enforcing FKs. Since
+# conftest.py turns FK enforcement on, every Loan needs a real Library +
+# real Book row to attach to.
+_SEED_USER_COUNTER = 0
+
+
+async def _seed_library(session: AsyncSession) -> uuid.UUID:
+    """Seed a Library row (with a fresh creator user) and return its id."""
+    global _SEED_USER_COUNTER
+    _SEED_USER_COUNTER += 1
+    user = User(
+        email=f"link-test-{_SEED_USER_COUNTER}@example.com",
+        hashed_password=get_password_hash("x"),
+    )
+    session.add(user)
+    await session.flush()
+    lib = Library(name=f"Link test lib {_SEED_USER_COUNTER}", created_by_user_id=user.id)
+    session.add(lib)
+    await session.flush()
+    return lib.id
+
+
+async def _seed_book(session: AsyncSession, library_id: uuid.UUID) -> uuid.UUID:
+    book = Book(library_id=library_id, title="Book")
+    session.add(book)
+    await session.flush()
+    return book.id
+
+
 def _make_loan(
     library_id: uuid.UUID,
+    book_id: uuid.UUID,
     *,
     borrower_name: str,
     borrower_contact: str | None = None,
@@ -34,7 +70,7 @@ def _make_loan(
 ) -> Loan:
     return Loan(
         library_id=library_id,
-        book_id=uuid.uuid4(),
+        book_id=book_id,
         borrower_id=borrower_id,
         borrower_name=borrower_name,
         borrower_contact=borrower_contact,
@@ -53,9 +89,10 @@ async def _all_borrowers(session: AsyncSession, library_id: uuid.UUID) -> list[B
 async def test_links_two_loans_with_same_name_and_contact_to_one_borrower(
     session: AsyncSession,
 ) -> None:
-    lib_id = uuid.uuid4()
-    session.add(_make_loan(lib_id, borrower_name="Alice", borrower_contact="alice@x.com"))
-    session.add(_make_loan(lib_id, borrower_name="Alice", borrower_contact="alice@x.com"))
+    lib_id = await _seed_library(session)
+    book_id = await _seed_book(session, lib_id)
+    session.add(_make_loan(lib_id, book_id, borrower_name="Alice", borrower_contact="alice@x.com"))
+    session.add(_make_loan(lib_id, book_id, borrower_name="Alice", borrower_contact="alice@x.com"))
     await session.commit()
 
     linked = await link_loans_to_borrowers(session, lib_id)
@@ -72,10 +109,12 @@ async def test_links_two_loans_with_same_name_and_contact_to_one_borrower(
 async def test_same_name_in_two_libraries_creates_separate_borrowers(
     session: AsyncSession,
 ) -> None:
-    lib_a = uuid.uuid4()
-    lib_b = uuid.uuid4()
-    session.add(_make_loan(lib_a, borrower_name="Alice"))
-    session.add(_make_loan(lib_b, borrower_name="Alice"))
+    lib_a = await _seed_library(session)
+    book_a = await _seed_book(session, lib_a)
+    lib_b = await _seed_library(session)
+    book_b = await _seed_book(session, lib_b)
+    session.add(_make_loan(lib_a, book_a, borrower_name="Alice"))
+    session.add(_make_loan(lib_b, book_b, borrower_name="Alice"))
     await session.commit()
 
     await link_loans_to_borrowers(session, lib_a)
@@ -90,7 +129,8 @@ async def test_same_name_in_two_libraries_creates_separate_borrowers(
 
 @pytest.mark.asyncio
 async def test_existing_borrower_id_is_not_overwritten(session: AsyncSession) -> None:
-    lib_id = uuid.uuid4()
+    lib_id = await _seed_library(session)
+    book_id = await _seed_book(session, lib_id)
     pinned = await create_borrower(
         session, BorrowerCreate(name="Pre-existing", contact="pre@x.com"), lib_id
     )
@@ -102,6 +142,7 @@ async def test_existing_borrower_id_is_not_overwritten(session: AsyncSession) ->
     session.add(
         _make_loan(
             lib_id,
+            book_id,
             borrower_name="Pre-existing",
             borrower_contact="pre@x.com",
             borrower_id=other_id,
@@ -121,10 +162,11 @@ async def test_existing_borrower_id_is_not_overwritten(session: AsyncSession) ->
 
 @pytest.mark.asyncio
 async def test_null_or_empty_contact_is_handled(session: AsyncSession) -> None:
-    lib_id = uuid.uuid4()
-    session.add(_make_loan(lib_id, borrower_name="Bob", borrower_contact=None))
-    session.add(_make_loan(lib_id, borrower_name="Bob", borrower_contact=""))
-    session.add(_make_loan(lib_id, borrower_name="Bob", borrower_contact="   "))
+    lib_id = await _seed_library(session)
+    book_id = await _seed_book(session, lib_id)
+    session.add(_make_loan(lib_id, book_id, borrower_name="Bob", borrower_contact=None))
+    session.add(_make_loan(lib_id, book_id, borrower_name="Bob", borrower_contact=""))
+    session.add(_make_loan(lib_id, book_id, borrower_name="Bob", borrower_contact="   "))
     await session.commit()
 
     await link_loans_to_borrowers(session, lib_id)
@@ -139,9 +181,10 @@ async def test_null_or_empty_contact_is_handled(session: AsyncSession) -> None:
 async def test_extra_whitespace_in_borrower_name_does_not_crash(
     session: AsyncSession,
 ) -> None:
-    lib_id = uuid.uuid4()
-    session.add(_make_loan(lib_id, borrower_name="  Alice  Smith  "))
-    session.add(_make_loan(lib_id, borrower_name="Alice Smith"))
+    lib_id = await _seed_library(session)
+    book_id = await _seed_book(session, lib_id)
+    session.add(_make_loan(lib_id, book_id, borrower_name="  Alice  Smith  "))
+    session.add(_make_loan(lib_id, book_id, borrower_name="Alice Smith"))
     await session.commit()
 
     await link_loans_to_borrowers(session, lib_id)
@@ -153,9 +196,10 @@ async def test_extra_whitespace_in_borrower_name_does_not_crash(
 
 @pytest.mark.asyncio
 async def test_blank_borrower_name_is_skipped(session: AsyncSession) -> None:
-    lib_id = uuid.uuid4()
-    session.add(_make_loan(lib_id, borrower_name="   "))
-    session.add(_make_loan(lib_id, borrower_name="Real Person"))
+    lib_id = await _seed_library(session)
+    book_id = await _seed_book(session, lib_id)
+    session.add(_make_loan(lib_id, book_id, borrower_name="   "))
+    session.add(_make_loan(lib_id, book_id, borrower_name="Real Person"))
     await session.commit()
 
     linked = await link_loans_to_borrowers(session, lib_id)
@@ -167,9 +211,10 @@ async def test_blank_borrower_name_is_skipped(session: AsyncSession) -> None:
 
 @pytest.mark.asyncio
 async def test_helper_is_idempotent(session: AsyncSession) -> None:
-    lib_id = uuid.uuid4()
-    session.add(_make_loan(lib_id, borrower_name="Alice"))
-    session.add(_make_loan(lib_id, borrower_name="Bob", borrower_contact="bob@x.com"))
+    lib_id = await _seed_library(session)
+    book_id = await _seed_book(session, lib_id)
+    session.add(_make_loan(lib_id, book_id, borrower_name="Alice"))
+    session.add(_make_loan(lib_id, book_id, borrower_name="Bob", borrower_contact="bob@x.com"))
     await session.commit()
 
     first = await link_loans_to_borrowers(session, lib_id)
@@ -184,11 +229,12 @@ async def test_helper_is_idempotent(session: AsyncSession) -> None:
 @pytest.mark.asyncio
 async def test_reuses_borrower_created_via_create_borrower(session: AsyncSession) -> None:
     """A pre-existing Borrower record should not be duplicated by the linker."""
-    lib_id = uuid.uuid4()
+    lib_id = await _seed_library(session)
+    book_id = await _seed_book(session, lib_id)
     existing = await create_borrower(
         session, BorrowerCreate(name="Alice", contact="alice@x.com"), lib_id
     )
-    session.add(_make_loan(lib_id, borrower_name="Alice", borrower_contact="alice@x.com"))
+    session.add(_make_loan(lib_id, book_id, borrower_name="Alice", borrower_contact="alice@x.com"))
     await session.commit()
 
     await link_loans_to_borrowers(session, lib_id)

--- a/backend/tests/test_borrower_merge.py
+++ b/backend/tests/test_borrower_merge.py
@@ -292,9 +292,12 @@ async def test_merge_with_anonymized_target_returns_422(test_session: AsyncSessi
 
 @pytest.mark.asyncio
 async def test_merge_with_foreign_source_returns_404(test_session: AsyncSession) -> None:
-    _, lib = await _seed_user_with_library(test_session)
+    user, lib = await _seed_user_with_library(test_session)
+    foreign_lib = Library(name="Foreign", created_by_user_id=user.id)
+    test_session.add(foreign_lib)
+    await test_session.flush()
     target = Borrower(library_id=lib.id, name="Target")
-    foreign_source = Borrower(library_id=uuid.uuid4(), name="Foreign")
+    foreign_source = Borrower(library_id=foreign_lib.id, name="Foreign")
     test_session.add_all([target, foreign_source])
     await test_session.commit()
 
@@ -310,9 +313,12 @@ async def test_merge_with_foreign_source_returns_404(test_session: AsyncSession)
 
 @pytest.mark.asyncio
 async def test_merge_with_foreign_target_returns_404(test_session: AsyncSession) -> None:
-    _, lib = await _seed_user_with_library(test_session)
+    user, lib = await _seed_user_with_library(test_session)
+    foreign_lib = Library(name="Foreign", created_by_user_id=user.id)
+    test_session.add(foreign_lib)
+    await test_session.flush()
     source = Borrower(library_id=lib.id, name="Source")
-    foreign_target = Borrower(library_id=uuid.uuid4(), name="ForeignTarget")
+    foreign_target = Borrower(library_id=foreign_lib.id, name="ForeignTarget")
     test_session.add_all([source, foreign_target])
     await test_session.commit()
 

--- a/backend/tests/test_borrower_pages.py
+++ b/backend/tests/test_borrower_pages.py
@@ -212,8 +212,12 @@ async def test_list_stats_does_not_count_cross_library_loans(
     a row with the wrong library_id (e.g. from a future bulk import bug) does
     not inflate the counts.
     """
-    _, lib = await _seed_user_with_library(test_session)
-    foreign_lib_id = uuid.uuid4()
+    user, lib = await _seed_user_with_library(test_session)
+    # Real foreign library row so the FK on the cross-library loan resolves.
+    foreign_lib = Library(name="Foreign", created_by_user_id=user.id)
+    test_session.add(foreign_lib)
+    await test_session.flush()
+    foreign_lib_id = foreign_lib.id
 
     alice = Borrower(library_id=lib.id, name="Alice")
     test_session.add(alice)
@@ -229,8 +233,8 @@ async def test_list_stats_does_not_count_cross_library_loans(
         library_id=lib.id, book_id=book.id, borrower_id=alice.id,
         borrower_name="Alice", lent_date=date.today(),
     ))
-    # Cross-library loan pointing at our alice.id — this should be ignored.
-    # SQLite test DB does not enforce FKs so we can construct this dangling row.
+    # Cross-library loan pointing at our alice.id — defensive WHERE clause in
+    # ``list_borrowers_with_stats`` should still skip it.
     test_session.add(_make_loan(
         library_id=foreign_lib_id, book_id=foreign_book.id, borrower_id=alice.id,
         borrower_name="Alice", lent_date=date.today(),
@@ -418,9 +422,11 @@ async def test_borrower_loans_returns_empty_list_when_no_loans(
 async def test_borrower_loans_returns_404_for_foreign_borrower(
     test_session: AsyncSession,
 ) -> None:
-    await _seed_user_with_library(test_session)
-    foreign_lib_id = uuid.uuid4()
-    foreign = Borrower(library_id=foreign_lib_id, name="Foreign")
+    user, _ = await _seed_user_with_library(test_session)
+    foreign_lib = Library(name="Foreign", created_by_user_id=user.id)
+    test_session.add(foreign_lib)
+    await test_session.flush()
+    foreign = Borrower(library_id=foreign_lib.id, name="Foreign")
     test_session.add(foreign)
     await test_session.commit()
 

--- a/backend/tests/test_borrower_service.py
+++ b/backend/tests/test_borrower_service.py
@@ -5,7 +5,10 @@ import uuid
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from app.core.security import get_password_hash
 from app.db.base import Base
+from app.models.library import Library
+from app.models.user import User
 from app.schemas.borrower import BorrowerCreate, BorrowerUpdate
 from app.services.borrower import (
     create_borrower,
@@ -26,9 +29,33 @@ async def session() -> AsyncIterator[AsyncSession]:
     await engine.dispose()
 
 
+_SEED_USER_COUNTER = 0
+
+
+async def _seed_library(session: AsyncSession) -> uuid.UUID:
+    """Seed a real Library row and return its id.
+
+    SQLite FK enforcement (see ``conftest.py``) requires every borrower's
+    ``library_id`` to point at a real row, so service-level tests can no
+    longer pass a bare ``uuid.uuid4()`` as the library id.
+    """
+    global _SEED_USER_COUNTER
+    _SEED_USER_COUNTER += 1
+    user = User(
+        email=f"svc-borrower-{_SEED_USER_COUNTER}@example.com",
+        hashed_password=get_password_hash("x"),
+    )
+    session.add(user)
+    await session.flush()
+    lib = Library(name=f"Svc lib {_SEED_USER_COUNTER}", created_by_user_id=user.id)
+    session.add(lib)
+    await session.flush()
+    return lib.id
+
+
 @pytest.mark.asyncio
 async def test_create_and_list_borrowers(session: AsyncSession) -> None:
-    lib_id = uuid.uuid4()
+    lib_id = await _seed_library(session)
     b = await create_borrower(session, BorrowerCreate(name="Alice", contact="alice@x.com"), lib_id)
     assert b.name == "Alice"
     assert b.library_id == lib_id
@@ -40,8 +67,8 @@ async def test_create_and_list_borrowers(session: AsyncSession) -> None:
 
 @pytest.mark.asyncio
 async def test_list_borrowers_scoped_by_library(session: AsyncSession) -> None:
-    lib_a = uuid.uuid4()
-    lib_b = uuid.uuid4()
+    lib_a = await _seed_library(session)
+    lib_b = await _seed_library(session)
     await create_borrower(session, BorrowerCreate(name="In Library A"), lib_a)
     await create_borrower(session, BorrowerCreate(name="In Library B"), lib_b)
 
@@ -51,7 +78,7 @@ async def test_list_borrowers_scoped_by_library(session: AsyncSession) -> None:
 
 @pytest.mark.asyncio
 async def test_get_borrower_or_404_success(session: AsyncSession) -> None:
-    lib_id = uuid.uuid4()
+    lib_id = await _seed_library(session)
     created = await create_borrower(session, BorrowerCreate(name="Bob"), lib_id)
     fetched = await get_borrower_or_404(session, created.id, lib_id)
     assert fetched.id == created.id
@@ -61,16 +88,17 @@ async def test_get_borrower_or_404_success(session: AsyncSession) -> None:
 async def test_get_borrower_or_404_wrong_library_raises(session: AsyncSession) -> None:
     from fastapi import HTTPException
 
-    lib_id = uuid.uuid4()
+    lib_id = await _seed_library(session)
+    other_lib_id = await _seed_library(session)
     created = await create_borrower(session, BorrowerCreate(name="Carol"), lib_id)
     with pytest.raises(HTTPException) as exc_info:
-        await get_borrower_or_404(session, created.id, uuid.uuid4())
+        await get_borrower_or_404(session, created.id, other_lib_id)
     assert exc_info.value.status_code == 404
 
 
 @pytest.mark.asyncio
 async def test_update_borrower_fields(session: AsyncSession) -> None:
-    lib_id = uuid.uuid4()
+    lib_id = await _seed_library(session)
     created = await create_borrower(
         session, BorrowerCreate(name="Dan", contact="dan@x.com", notes="VIP"), lib_id
     )
@@ -84,7 +112,7 @@ async def test_update_borrower_fields(session: AsyncSession) -> None:
 
 @pytest.mark.asyncio
 async def test_list_borrowers_sorted_alphabetically(session: AsyncSession) -> None:
-    lib_id = uuid.uuid4()
+    lib_id = await _seed_library(session)
     for name in ["Zoe", "Ana", "Mia"]:
         await create_borrower(session, BorrowerCreate(name=name), lib_id)
     results = await list_borrowers(session, lib_id)

--- a/backend/tests/test_borrowers.py
+++ b/backend/tests/test_borrowers.py
@@ -186,8 +186,9 @@ async def test_update_borrower_null_name_rejected(test_session: AsyncSession) ->
 async def test_list_borrowers_isolated_between_libraries(test_session: AsyncSession) -> None:
     """Borrowers seeded in a foreign library must not appear in the API response.
 
-    We directly insert a borrower into a different library_id so the test does
-    not depend on a second user being an editor of their own library.
+    We seed a real foreign Library (no LibraryMember row for the authed user)
+    so the borrower has a valid FK target — SQLite FK enforcement (see
+    ``conftest.py``) would otherwise reject the dangling insert.
     """
     from app.models.borrower import Borrower as BorrowerModel
 
@@ -198,9 +199,14 @@ async def test_list_borrowers_isolated_between_libraries(test_session: AsyncSess
         r = await client.post("/api/v1/borrowers", json={"name": "Own Borrower"}, headers=headers)
         assert r.status_code == 201
 
-        # Directly insert a borrower in a completely different (fake) library
-        foreign_lib_id = uuid.uuid4()
-        foreign_borrower = BorrowerModel(library_id=foreign_lib_id, name="Foreign Borrower")
+        # Seed a real foreign library that the authed user has no membership in.
+        owner_user = (await test_session.execute(
+            select(User).where(User.email == "admin@example.com")
+        )).scalar_one()
+        foreign_lib = Library(name="Foreign Library", created_by_user_id=owner_user.id)
+        test_session.add(foreign_lib)
+        await test_session.flush()
+        foreign_borrower = BorrowerModel(library_id=foreign_lib.id, name="Foreign Borrower")
         test_session.add(foreign_borrower)
         await test_session.commit()
 

--- a/backend/tests/test_gdpr_export.py
+++ b/backend/tests/test_gdpr_export.py
@@ -7,7 +7,6 @@ borrower side specifically — that fix lands alongside the borrowers epic
 """
 from collections.abc import AsyncIterator, Iterator
 import json
-import uuid
 
 from httpx import ASGITransport, AsyncClient
 import pytest

--- a/backend/tests/test_gdpr_export.py
+++ b/backend/tests/test_gdpr_export.py
@@ -175,12 +175,14 @@ async def test_export_anonymized_borrower_shows_sentinel(test_session: AsyncSess
 async def test_export_does_not_leak_borrowers_from_other_libraries(
     test_session: AsyncSession,
 ) -> None:
-    _, lib = await _seed_user_with_library(test_session)
-    foreign_lib_id = uuid.uuid4()
+    user, lib = await _seed_user_with_library(test_session)
+    foreign_lib = Library(name="Foreign", created_by_user_id=user.id)
+    test_session.add(foreign_lib)
+    await test_session.flush()
 
     test_session.add_all([
         Borrower(library_id=lib.id, name="Mine"),
-        Borrower(library_id=foreign_lib_id, name="Not Mine"),
+        Borrower(library_id=foreign_lib.id, name="Not Mine"),
     ])
     await test_session.commit()
 

--- a/backend/tests/test_sqlite_pragma.py
+++ b/backend/tests/test_sqlite_pragma.py
@@ -1,0 +1,52 @@
+"""Pin the contract that SQLite FK enforcement is on for the whole test suite.
+
+If this fails, something has nuked the connect-event listener in
+``conftest.py`` and the entire suite has silently lost its FK guarantees —
+which means any new ``ondelete=CASCADE`` / ``ondelete=SET NULL`` on the
+schema is no longer being exercised by tests, and dangling-FK inserts
+(some tests construct them deliberately) stop being meaningful.
+"""
+from collections.abc import AsyncIterator
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.db.base import Base
+from app.models.borrower import Borrower
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_pragma_foreign_keys_is_on(session: AsyncSession) -> None:
+    """The PRAGMA itself is set to 1 on every connection the suite opens."""
+    result = await session.execute(text("PRAGMA foreign_keys"))
+    value = result.scalar_one()
+    assert value == 1, (
+        "SQLite FK enforcement is OFF — the global connect-event listener in "
+        "conftest.py likely got removed. Tests that depend on cascade behavior "
+        "are now silently passing whether or not the cascade actually works."
+    )
+
+
+@pytest.mark.asyncio
+async def test_dangling_fk_insert_is_rejected(session: AsyncSession) -> None:
+    """Functional proof: inserting a Borrower whose library_id points at no
+    real Library row must raise IntegrityError. Without the PRAGMA this insert
+    would silently succeed."""
+    nonexistent_library_id = uuid.uuid4()
+    session.add(Borrower(library_id=nonexistent_library_id, name="Ghost"))
+    with pytest.raises(IntegrityError):
+        await session.commit()


### PR DESCRIPTION
## Summary

Closes #247.

Production is on Postgres (FKs natively enforced). Tests are on SQLite where `PRAGMA foreign_keys` defaults to **off**, so `ondelete=CASCADE` / `ondelete=SET NULL` were never exercised and dangling-FK inserts passed silently. Same-shape divergence as yesterday's bookshelf 500 (#253).

## Changes

**Listener.** `backend/tests/conftest.py` registers a global `connect` event on the SQLAlchemy `Engine` class that runs `PRAGMA foreign_keys=ON` on every SQLite connection. Detects SQLite by DB-API module name → no-op for Postgres-backed test runs.

**Regression test.** `backend/tests/test_sqlite_pragma.py` pins the contract two ways:
- reads `PRAGMA foreign_keys` and asserts it returns `1`
- inserts a Borrower with a fake `library_id` and asserts `IntegrityError`

If the listener gets silently removed in a refactor, this test fails and tells you exactly what was lost.

**Test fallout.** Seven tests previously seeded dangling FK rows on purpose to fake "foreign library / borrower" without setting up a second user. Rewritten to seed a real `Library` row (creator = authed user, no `LibraryMember` so the user has no access — same effective semantics for the API check).

`test_borrower_link.py` was special — service-level tests with both `library_id` and `book_id` set to bare uuids. Refactored to use `_seed_library` / `_seed_book` helpers; `_make_loan` now requires an explicit `book_id`.

**Docs.** `AGENTS.md` gets a "Test-DB contract" section naming the listener, the regression test, and the seeding pattern.

## Test plan

- [ ] `cd backend && ruff check app tests`
- [ ] `cd backend && mypy app tests`
- [ ] `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enforced SQLite foreign-key constraints for all test connections and added verification checks
  * Updated many tests to seed real database entities (libraries, users, books, borrowers) to validate referential integrity
  * Strengthened cross-library isolation, anonymization, merge, export and borrower-related scenario coverage

* **Documentation**
  * Added a testing DB contract section with guidance for writing tests that respect referential integrity and isolation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->