### PR TITLE
fix: enforce 2000-char cap for borrower and loan notes

### DIFF
--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -3,17 +3,19 @@ from datetime import date, datetime
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+MAX_NOTES_LENGTH = 2000
+
 
 class BorrowerCreate(BaseModel):
     name: str = Field(min_length=1, max_length=255)
     contact: str | None = Field(None, max_length=255)
-    notes: str | None = None
+    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)
 
 
 class BorrowerUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
     contact: str | None = Field(default=None, max_length=255)
-    notes: str | None = None
+    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)
 
     @model_validator(mode="after")
     def reject_explicit_nulls(self) -> "BorrowerUpdate":

--- a/backend/app/schemas/loan.py
+++ b/backend/app/schemas/loan.py
@@ -4,7 +4,7 @@ import uuid
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
-from app.schemas.borrower import BorrowerResponse
+from app.schemas.borrower import BorrowerResponse, MAX_NOTES_LENGTH
 
 
 class LoanCreate(BaseModel):
@@ -13,7 +13,7 @@ class LoanCreate(BaseModel):
     borrower_contact: str | None = Field(None, max_length=255)
     lent_date: date = Field(default_factory=date.today)
     due_date: date | None = None
-    notes: str | None = None
+    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)
 
     @model_validator(mode="after")
     def require_borrower_name_without_id(self) -> "LoanCreate":
@@ -25,7 +25,7 @@ class LoanCreate(BaseModel):
 class LoanReturn(BaseModel):
     returned_date: date = Field(default_factory=date.today)
     return_condition: Literal["perfect", "good", "fair", "damaged", "lost"]
-    notes: str | None = None
+    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)
 
 
 class LoanResponse(BaseModel):

--- a/backend/tests/test_borrowers.py
+++ b/backend/tests/test_borrowers.py
@@ -182,6 +182,20 @@ async def test_update_borrower_null_name_rejected(test_session: AsyncSession) ->
         assert 400 <= resp.status_code < 500
 
 
+
+
+@pytest.mark.asyncio
+async def test_create_borrower_rejects_notes_over_2000_chars(test_session: AsyncSession) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+
+        response = await client.post(
+            "/api/v1/borrowers",
+            json={"name": "Alice", "notes": "x" * 2001},
+            headers=headers,
+        )
+
+    assert response.status_code == 422
 @pytest.mark.asyncio
 async def test_list_borrowers_isolated_between_libraries(test_session: AsyncSession) -> None:
     """Borrowers seeded in a foreign library must not appear in the API response.

--- a/backend/tests/test_loans.py
+++ b/backend/tests/test_loans.py
@@ -145,6 +145,22 @@ async def test_create_loan(test_session: async_sessionmaker[AsyncSession]) -> No
     assert body["is_active"] is True
 
 
+
+
+@pytest.mark.asyncio
+async def test_create_loan_rejects_notes_over_2000_chars(test_session: async_sessionmaker[AsyncSession]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+
+        book_id = await _create_book(client, headers)
+        response = await client.post(
+            f"/api/v1/books/{book_id}/loans",
+            json={"borrower_name": "Alice", "notes": "x" * 2001},
+            headers=headers,
+        )
+
+    assert response.status_code == 422
 @pytest.mark.asyncio
 async def test_create_loan_book_not_found(test_session: async_sessionmaker[AsyncSession]) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/frontend/src/components/EditBorrowerModal.tsx
+++ b/frontend/src/components/EditBorrowerModal.tsx
@@ -78,6 +78,7 @@ export function EditBorrowerModal({ borrower, onClose }: Props) {
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
             data-testid="edit-borrower-notes"
+            maxLength={2000}
           />
         </label>
         {error && <p style={{ margin: 0, color: 'var(--sh-red)', fontSize: 14 }}>{error}</p>}

--- a/frontend/src/components/LendBookModal.tsx
+++ b/frontend/src/components/LendBookModal.tsx
@@ -125,7 +125,9 @@ export function LendBookModal({ bookId, onClose }: { bookId: string; onClose: ()
           {t('loans.due_date')}
           <input className="sh-input" type="date" value={dueDate} onChange={(event) => setDueDate(event.target.value)} />
         </label>
-        <textarea className="sh-input" rows={3} placeholder={t('loans.notes')} value={notes} onChange={(event) => setNotes(event.target.value)} />
+        <textarea className="sh-input" rows={3} placeholder={t('loans.notes')} value={notes} onChange={(event) => setNotes(event.target.value)}
+          maxLength={2000}
+        />
         {error && <p style={{ margin: 0, color: 'var(--sh-red)', fontSize: 14 }}>{error}</p>}
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
           <button type="button" className="sh-btn-secondary" onClick={onClose}>{t('loans.cancel')}</button>

--- a/frontend/src/components/ReturnBookModal.tsx
+++ b/frontend/src/components/ReturnBookModal.tsx
@@ -39,7 +39,9 @@ export function ReturnBookModal({ bookId, loanId, onClose }: { bookId: string; l
             <option value="lost">{t('loans.condition_lost')}</option>
           </select>
         </label>
-        <textarea className="sh-input" rows={3} placeholder={t('loans.return_notes')} value={notes} onChange={(event) => setNotes(event.target.value)} />
+        <textarea className="sh-input" rows={3} placeholder={t('loans.return_notes')} value={notes} onChange={(event) => setNotes(event.target.value)}
+          maxLength={2000}
+        />
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
           <button type="button" className="sh-btn-secondary" onClick={onClose}>{t('loans.cancel')}</button>
           <button type="submit" className="sh-btn-primary" disabled={returnLoan.isPending}>{returnLoan.isPending ? t('loans.return_saving') : t('loans.return_submit')}</button>


### PR DESCRIPTION
### Motivation
- Issue #249 requested a consistent maximum length for free-form `notes` fields to prevent oversized payloads and database surprises.
- Apply validation both server-side and client-side so invalid input is rejected at the API boundary and prevented in the UI.

### Description
- Introduced a shared `MAX_NOTES_LENGTH = 2000` in `backend/app/schemas/borrower.py` and applied it to `BorrowerCreate.notes` and `BorrowerUpdate.notes` using `Field(..., max_length=MAX_NOTES_LENGTH)`.
- Imported and reused `MAX_NOTES_LENGTH` in `backend/app/schemas/loan.py` and applied it to `LoanCreate.notes` and `LoanReturn.notes`.
- Added API regression tests in `backend/tests/test_borrowers.py` and `backend/tests/test_loans.py` that assert payloads with `notes` of length 2001 are rejected with HTTP `422`.
- Added `maxLength={2000}` to notes `textarea` elements in `frontend/src/components/EditBorrowerModal.tsx`, `frontend/src/components/LendBookModal.tsx`, and `frontend/src/components/ReturnBookModal.tsx` to limit input client-side.

### Testing
- Ran `cd backend && ruff check app tests` and it passed successfully.
- Ran `cd backend && mypy app tests` and it passed successfully.
- Attempted `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests` but the environment rejected the `--cov`/`--cov-fail-under` options (pytest-cov not available), so full coverage run did not complete.
- Ran `cd frontend && npm run lint` which failed in this environment due to a missing package (`@eslint/js`), so frontend lint/tests were not completed here.
- A targeted `pytest` invocation to exercise the new API tests hit local Python/SQLAlchemy runtime import errors during test collection in this environment, preventing those tests from being collected here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a015c45e1848325af2fa3f0bc4c88a4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added 2,000-character maximum limit for notes fields in borrower and loan management, enforced through frontend input constraints and backend validation.

* **Tests**
  * Added validation tests to verify notes exceeding the 2,000-character limit are properly rejected with error responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/256)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->