### PR TITLE
fix: add missing notes maxLength constraints for borrower/loan response schemas

### DIFF
--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -30,7 +30,7 @@ class BorrowerResponse(BaseModel):
     id: uuid.UUID
     name: str
     contact: str | None
-    notes: str | None
+    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)
     anonymized_at: datetime | None
     created_at: datetime
     updated_at: datetime
@@ -76,4 +76,4 @@ class BorrowerLoanItem(BaseModel):
     due_date: date | None
     returned_date: date | None
     return_condition: str | None
-    notes: str | None
+    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)

--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -30,7 +30,7 @@ class BorrowerResponse(BaseModel):
     id: uuid.UUID
     name: str
     contact: str | None
-    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)
+    notes: str | None = Field(max_length=MAX_NOTES_LENGTH)
     anonymized_at: datetime | None
     created_at: datetime
     updated_at: datetime
@@ -76,4 +76,4 @@ class BorrowerLoanItem(BaseModel):
     due_date: date | None
     returned_date: date | None
     return_condition: str | None
-    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)
+    notes: str | None = Field(max_length=MAX_NOTES_LENGTH)

--- a/backend/app/schemas/loan.py
+++ b/backend/app/schemas/loan.py
@@ -41,7 +41,7 @@ class LoanResponse(BaseModel):
     due_date: date | None
     returned_date: date | None
     return_condition: str | None
-    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)
+    notes: str | None = Field(max_length=MAX_NOTES_LENGTH)
     created_at: datetime
 
     @computed_field

--- a/backend/app/schemas/loan.py
+++ b/backend/app/schemas/loan.py
@@ -41,7 +41,7 @@ class LoanResponse(BaseModel):
     due_date: date | None
     returned_date: date | None
     return_condition: str | None
-    notes: str | None
+    notes: str | None = Field(None, max_length=MAX_NOTES_LENGTH)
     created_at: datetime
 
     @computed_field

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4503,7 +4503,8 @@
           "notes": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 2000
               },
               {
                 "type": "null"
@@ -4543,7 +4544,8 @@
           "notes": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 2000
               },
               {
                 "type": "null"
@@ -4712,7 +4714,8 @@
           "notes": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 2000
               },
               {
                 "type": "null"
@@ -4776,7 +4779,8 @@
           "notes": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 2000
               },
               {
                 "type": "null"
@@ -4849,7 +4853,8 @@
           "notes": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 2000
               },
               {
                 "type": "null"
@@ -5766,7 +5771,8 @@
           "notes": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 2000
               },
               {
                 "type": "null"
@@ -5870,7 +5876,8 @@
           "notes": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 2000
               },
               {
                 "type": "null"
@@ -5928,7 +5935,8 @@
           "notes": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 2000
               },
               {
                 "type": "null"


### PR DESCRIPTION
### Motivation
- Ensure `notes` has the same max-length validation on response schemas as it already has on request schemas to keep runtime validation consistent.
- Fix OpenAPI diff failures in CI by making the generated `docs/openapi.yaml` match the backend schema metadata (resolves issue #243).

### Description
- Added `Field(None, max_length=MAX_NOTES_LENGTH)` to `BorrowerResponse.notes`, `BorrowerLoanItem.notes`, and `LoanResponse.notes` in `backend/app/schemas/`.
- Updated `docs/openapi.yaml` so the affected `notes` schema entries include `maxLength: 2000`.
- Committed the changes and updated the OpenAPI artifact to keep docs and runtime schemas in sync.

### Testing
- Ran `cd backend && ruff check app tests` and it passed.
- Ran `cd backend && mypy app tests` and it passed.
- Ran `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests` and it failed in this environment because `pytest` complained about unrecognized `--cov` args (missing `pytest-cov` plugin), not because of code validation.
- Ran `cd frontend && npm run lint && npm test -- --run` and it failed in this environment due to a missing frontend dependency (`@eslint/js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016171605c8325bbba24fc1107d01b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 2000-character maximum length limit for notes fields across borrower and loan records to improve data validation and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/257)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->