### PR TITLE
fix: resolve privacy and terms metadata drift

### DIFF
--- a/frontend/src/lib/legal.ts
+++ b/frontend/src/lib/legal.ts
@@ -1,0 +1,11 @@
+export const LEGAL_ENTITY_NAME = 'Patrik Šušlík'
+export const LEGAL_ENTITY_ICO = '24561401'
+
+// NOTE: Seat address intentionally pending legal confirmation.
+export const LEGAL_ENTITY_SEAT = '—'
+
+export const LEGAL_DOC_VERSION = '2.0'
+export const LEGAL_DOC_EFFECTIVE_DATE = '8. dubna 2026'
+
+export const PRIVACY_CONTACT_EMAIL = 'privacy@shelfy.cz'
+export const TERMS_CONTACT_EMAIL = 'info@shelfy.cz'

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { LEGAL_DOC_EFFECTIVE_DATE, LEGAL_DOC_VERSION, LEGAL_ENTITY_ICO, LEGAL_ENTITY_NAME, LEGAL_ENTITY_SEAT, PRIVACY_CONTACT_EMAIL } from '../lib/legal'
 
 const SECTION: CSSProperties = { marginBottom: 32 }
 const H2: CSSProperties = { fontSize: 18, fontWeight: 700, margin: '0 0 8px' }
@@ -8,10 +9,6 @@ const UL: CSSProperties = { paddingLeft: 20, color: 'var(--sh-text-secondary)', 
 const TABLE: CSSProperties = { width: '100%', borderCollapse: 'collapse', margin: '10px 0 16px', fontSize: 14 }
 const TH: CSSProperties = { textAlign: 'left', padding: '8px 12px', borderBottom: '2px solid var(--sh-border)', fontWeight: 600, fontSize: 13 }
 const TD: CSSProperties = { padding: '8px 12px', borderBottom: '1px solid var(--sh-border)', verticalAlign: 'top', color: 'var(--sh-text-secondary)' }
-
-const EFFECTIVE_DATE = '8. dubna 2026'
-const VERSION = '2.0'
-const CONTACT_EMAIL = 'privacy@shelfy.cz'
 
 export function PrivacyPage() {
   const navigate = useNavigate()
@@ -40,7 +37,7 @@ export function PrivacyPage() {
       <main style={{ maxWidth: 720, margin: '0 auto', padding: '48px 24px 80px' }}>
         <h1 style={{ fontSize: 28, fontWeight: 800, marginBottom: 4 }}>Zásady ochrany osobních údajů</h1>
         <p style={{ ...P, fontSize: 13, marginBottom: 8 }}>
-          Verze {VERSION} · Účinnost od {EFFECTIVE_DATE}
+          Verze {LEGAL_DOC_VERSION} · Účinnost od {LEGAL_DOC_EFFECTIVE_DATE}
         </p>
 
         {/* ── Human-friendly summary ── */}
@@ -66,11 +63,11 @@ export function PrivacyPage() {
           <h2 style={H2}>1. Správce osobních údajů</h2>
           <table style={TABLE}>
             <tbody>
-              <tr><td style={{ ...TD, fontWeight: 600, width: 160 }}>Správce</td><td style={TD}>Patrik Šušlík</td></tr>
-              <tr><td style={{ ...TD, fontWeight: 600 }}>IČO</td><td style={TD}>24561401</td></tr>
+              <tr><td style={{ ...TD, fontWeight: 600, width: 160 }}>Správce</td><td style={TD}>{LEGAL_ENTITY_NAME}</td></tr>
+              <tr><td style={{ ...TD, fontWeight: 600 }}>IČO</td><td style={TD}>{LEGAL_ENTITY_ICO}</td></tr>
               {/* TODO: doplnit sídlo po ověření s právníkem */}
-              <tr><td style={{ ...TD, fontWeight: 600 }}>Sídlo</td><td style={TD}>—</td></tr>
-              <tr><td style={{ ...TD, fontWeight: 600 }}>E-mail</td><td style={TD}><a href={`mailto:${CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{CONTACT_EMAIL}</a></td></tr>
+              <tr><td style={{ ...TD, fontWeight: 600 }}>Sídlo</td><td style={TD}>{LEGAL_ENTITY_SEAT}</td></tr>
+              <tr><td style={{ ...TD, fontWeight: 600 }}>E-mail</td><td style={TD}><a href={`mailto:${PRIVACY_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{PRIVACY_CONTACT_EMAIL}</a></td></tr>
               <tr><td style={{ ...TD, fontWeight: 600 }}>Web</td><td style={TD}>https://shelfy.cz</td></tr>
             </tbody>
           </table>
@@ -217,7 +214,7 @@ export function PrivacyPage() {
           </ul>
           <p style={P}>
             Práva, která nelze uplatnit přímo v aplikaci, vyřídíme na základě žádosti zaslané na{' '}
-            <a href={`mailto:${CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{CONTACT_EMAIL}</a>.
+            <a href={`mailto:${PRIVACY_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{PRIVACY_CONTACT_EMAIL}</a>.
             Na žádost odpovíme nejpozději do 30 dnů.
           </p>
         </div>

--- a/frontend/src/pages/TermsPage.tsx
+++ b/frontend/src/pages/TermsPage.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { LEGAL_DOC_EFFECTIVE_DATE, LEGAL_DOC_VERSION, LEGAL_ENTITY_ICO, LEGAL_ENTITY_NAME, LEGAL_ENTITY_SEAT, TERMS_CONTACT_EMAIL } from '../lib/legal'
 import { ROUTES } from '../lib/routes'
 
 const SECTION: CSSProperties = { marginBottom: 32 }
@@ -8,10 +9,6 @@ const P: CSSProperties = { margin: '0 0 10px', lineHeight: 1.7, color: 'var(--sh
 const UL: CSSProperties = { paddingLeft: 20, color: 'var(--sh-text-secondary)', lineHeight: 1.7, margin: '0 0 10px' }
 const TABLE: CSSProperties = { width: '100%', borderCollapse: 'collapse', margin: '10px 0 16px', fontSize: 14 }
 const TD: CSSProperties = { padding: '8px 12px', borderBottom: '1px solid var(--sh-border)', verticalAlign: 'top', color: 'var(--sh-text-secondary)' }
-
-const EFFECTIVE_DATE = '8. dubna 2026'
-const VERSION = '2.0'
-const CONTACT_EMAIL = 'info@shelfy.cz'
 
 export function TermsPage() {
   const navigate = useNavigate()
@@ -40,7 +37,7 @@ export function TermsPage() {
       <main style={{ maxWidth: 720, margin: '0 auto', padding: '48px 24px 80px' }}>
         <h1 style={{ fontSize: 28, fontWeight: 800, marginBottom: 4 }}>Obchodní podmínky</h1>
         <p style={{ ...P, fontSize: 13, marginBottom: 8 }}>
-          Verze {VERSION} · Účinnost od {EFFECTIVE_DATE}
+          Verze {LEGAL_DOC_VERSION} · Účinnost od {LEGAL_DOC_EFFECTIVE_DATE}
         </p>
 
         {/* ── Human-friendly summary ── */}
@@ -56,7 +53,7 @@ export function TermsPage() {
             <li>Shelfy je aplikace na správu osobní knihovny. Základní verze je zdarma.</li>
             <li>Placené plány se platí měsíčně přes Stripe. Zrušit můžete kdykoliv v Nastavení.</li>
             <li>Vaše knihy a data patří vám. Můžete si je kdykoliv exportovat nebo smazat účet.</li>
-            <li>Nesnažíme se nic skrývat — jestli máte otázku, napište na {CONTACT_EMAIL}.</li>
+            <li>Nesnažíme se nic skrývat — jestli máte otázku, napište na {TERMS_CONTACT_EMAIL}.</li>
           </ul>
         </div>
 
@@ -65,10 +62,10 @@ export function TermsPage() {
           <h2 style={H2}>1. Úvodní ustanovení</h2>
           <table style={TABLE}>
             <tbody>
-              <tr><td style={{ ...TD, fontWeight: 600, width: 160 }}>Poskytovatel</td><td style={TD}>Patrik Šušlík, IČO: 24561401</td></tr>
+              <tr><td style={{ ...TD, fontWeight: 600, width: 160 }}>Poskytovatel</td><td style={TD}>{LEGAL_ENTITY_NAME}, IČO: {LEGAL_ENTITY_ICO}</td></tr>
               {/* TODO: doplnit sídlo */}
-              <tr><td style={{ ...TD, fontWeight: 600 }}>Sídlo</td><td style={TD}>—</td></tr>
-              <tr><td style={{ ...TD, fontWeight: 600 }}>E-mail</td><td style={TD}><a href={`mailto:${CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{CONTACT_EMAIL}</a></td></tr>
+              <tr><td style={{ ...TD, fontWeight: 600 }}>Sídlo</td><td style={TD}>{LEGAL_ENTITY_SEAT}</td></tr>
+              <tr><td style={{ ...TD, fontWeight: 600 }}>E-mail</td><td style={TD}><a href={`mailto:${TERMS_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{TERMS_CONTACT_EMAIL}</a></td></tr>
               <tr><td style={{ ...TD, fontWeight: 600 }}>Web</td><td style={TD}>https://shelfy.cz</td></tr>
             </tbody>
           </table>
@@ -139,7 +136,7 @@ export function TermsPage() {
           </p>
           <p style={P}>
             <strong>Vrácení peněz:</strong> Požádejte e-mailem na{' '}
-            <a href={`mailto:${CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{CONTACT_EMAIL}</a>{' '}
+            <a href={`mailto:${TERMS_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{TERMS_CONTACT_EMAIL}</a>{' '}
             do 14 dnů od platby. Žádost posoudíme individuálně.
           </p>
         </div>
@@ -160,7 +157,7 @@ export function TermsPage() {
           </p>
           <p style={P}>
             Pro odstoupení od smlouvy zašlete jednoznačné prohlášení na{' '}
-            <a href={`mailto:${CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{CONTACT_EMAIL}</a>.
+            <a href={`mailto:${TERMS_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{TERMS_CONTACT_EMAIL}</a>.
           </p>
         </div>
 
@@ -235,7 +232,7 @@ export function TermsPage() {
           <h2 style={H2}>11. Reklamace a řešení sporů</h2>
           <p style={P}>
             Reklamace a stížnosti zasílejte na{' '}
-            <a href={`mailto:${CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{CONTACT_EMAIL}</a>.
+            <a href={`mailto:${TERMS_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{TERMS_CONTACT_EMAIL}</a>.
             Reklamaci vyřídíme nejpozději do 30 dnů od jejího obdržení.
           </p>
           <p style={P}>
@@ -278,7 +275,7 @@ export function TermsPage() {
 
         <p style={{ ...P, fontSize: 13, fontStyle: 'italic', marginTop: 24 }}>
           Otázky? Napište nám na{' '}
-          <a href={`mailto:${CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{CONTACT_EMAIL}</a>.
+          <a href={`mailto:${TERMS_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{TERMS_CONTACT_EMAIL}</a>.
         </p>
 
         <button


### PR DESCRIPTION
### Motivation
- Reduce duplicated legal metadata between the Privacy and Terms pages to prevent drift when details (contacts, entity info, version, effective date) change.

### Description
- Add a shared constants module `frontend/src/lib/legal.ts` exposing `LEGAL_*` values and contact emails for centralised legal metadata.
- Update `PrivacyPage` to import and use `LEGAL_DOC_VERSION`, `LEGAL_DOC_EFFECTIVE_DATE`, `LEGAL_ENTITY_*` and `PRIVACY_CONTACT_EMAIL` instead of inline literals.
- Update `TermsPage` to import and use the same shared constants and `TERMS_CONTACT_EMAIL`, and replace hardcoded values with the shared ones.
- Preserve the placeholder seat value (`'—'`) in the shared module so the address can be updated in one place after legal confirmation.

### Testing
- Ran `cd frontend && npm run lint`, which failed in this environment due to a missing dependency (`@eslint/js`).
- Ran `cd frontend && npm test -- --run`, which failed in this environment because `vitest` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0170c65c0c832592ece15fd44ace57)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized legal entity information, document versions, and contact details into a unified configuration for easier maintenance across privacy and terms documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/258)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->