### PR TITLE
feat(borrowers): add bulk anonymize endpoint (issue #246)

### DIFF
--- a/backend/app/api/borrowers.py
+++ b/backend/app/api/borrowers.py
@@ -99,16 +99,6 @@ async def read_borrower_loans(
     return [BorrowerLoanItem.model_validate(row) for row in rows]
 
 
-@router.post("/{borrower_id}/anonymize", response_model=BorrowerResponse)
-async def anonymize_borrower_endpoint(
-    borrower_id: uuid.UUID,
-    session: AsyncSession = Depends(get_db_session),
-    library_id: uuid.UUID = Depends(require_editor_library),
-) -> BorrowerResponse:
-    borrower = await anonymize_borrower(session, borrower_id, library_id)
-    return BorrowerResponse.model_validate(borrower)
-
-
 @router.post("/bulk/anonymize", response_model=BorrowerBulkAnonymizeResponse)
 async def bulk_anonymize_borrowers_endpoint(
     payload: BorrowerBulkAnonymizeRequest,
@@ -117,6 +107,16 @@ async def bulk_anonymize_borrowers_endpoint(
 ) -> BorrowerBulkAnonymizeResponse:
     affected = await bulk_anonymize_borrowers(session, payload.ids, library_id)
     return BorrowerBulkAnonymizeResponse(affected=affected)
+
+
+@router.post("/{borrower_id}/anonymize", response_model=BorrowerResponse)
+async def anonymize_borrower_endpoint(
+    borrower_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(require_editor_library),
+) -> BorrowerResponse:
+    borrower = await anonymize_borrower(session, borrower_id, library_id)
+    return BorrowerResponse.model_validate(borrower)
 
 
 @router.post("/{target_id}/merge", response_model=BorrowerResponse)

--- a/backend/app/api/borrowers.py
+++ b/backend/app/api/borrowers.py
@@ -6,6 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies.library import get_library_id, require_editor_library
 from app.db.session import get_db_session
 from app.schemas.borrower import (
+    BorrowerBulkAnonymizeRequest,
+    BorrowerBulkAnonymizeResponse,
     BorrowerCreate,
     BorrowerListItem,
     BorrowerListResponse,
@@ -16,6 +18,7 @@ from app.schemas.borrower import (
 )
 from app.services.borrower import (
     anonymize_borrower,
+    bulk_anonymize_borrowers,
     create_borrower,
     get_borrower_or_404,
     list_borrowers_with_stats,
@@ -104,6 +107,16 @@ async def anonymize_borrower_endpoint(
 ) -> BorrowerResponse:
     borrower = await anonymize_borrower(session, borrower_id, library_id)
     return BorrowerResponse.model_validate(borrower)
+
+
+@router.post("/bulk/anonymize", response_model=BorrowerBulkAnonymizeResponse)
+async def bulk_anonymize_borrowers_endpoint(
+    payload: BorrowerBulkAnonymizeRequest,
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(require_editor_library),
+) -> BorrowerBulkAnonymizeResponse:
+    affected = await bulk_anonymize_borrowers(session, payload.ids, library_id)
+    return BorrowerBulkAnonymizeResponse(affected=affected)
 
 
 @router.post("/{target_id}/merge", response_model=BorrowerResponse)

--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -82,6 +82,12 @@ class BorrowerLoanItem(BaseModel):
 class BorrowerBulkAnonymizeRequest(BaseModel):
     ids: list[uuid.UUID] = Field(min_length=1, max_length=200)
 
+    @model_validator(mode="after")
+    def reject_duplicate_ids(self) -> "BorrowerBulkAnonymizeRequest":
+        if len(set(self.ids)) != len(self.ids):
+            raise ValueError("ids must be unique")
+        return self
+
 
 class BorrowerBulkAnonymizeResponse(BaseModel):
     affected: int

--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -77,3 +77,11 @@ class BorrowerLoanItem(BaseModel):
     returned_date: date | None
     return_condition: str | None
     notes: str | None = Field(max_length=MAX_NOTES_LENGTH)
+
+
+class BorrowerBulkAnonymizeRequest(BaseModel):
+    ids: list[uuid.UUID] = Field(min_length=1, max_length=200)
+
+
+class BorrowerBulkAnonymizeResponse(BaseModel):
+    affected: int

--- a/backend/app/services/borrower.py
+++ b/backend/app/services/borrower.py
@@ -381,3 +381,50 @@ async def anonymize_borrower(
         library_id=str(library_id),
     )
     return borrower
+
+
+async def bulk_anonymize_borrowers(
+    session: AsyncSession, borrower_ids: list[uuid.UUID], library_id: uuid.UUID
+) -> int:
+    """Anonymize many borrowers in one request.
+
+    Strict ownership semantics: every id must exist in ``library_id``.
+    """
+    if not borrower_ids:
+        return 0
+
+    rows = (
+        await session.execute(
+            select(Borrower).where(Borrower.id.in_(borrower_ids), Borrower.library_id == library_id)
+        )
+    ).scalars().all()
+    if len(rows) != len(set(borrower_ids)):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Borrower not found",
+        )
+
+    affected = 0
+    for borrower in rows:
+        if borrower.anonymized_at is not None:
+            continue
+        borrower.name = ANONYMIZED_BORROWER_NAME
+        borrower.contact = None
+        borrower.notes = None
+        borrower.anonymized_at = datetime.now(timezone.utc)
+        affected += 1
+
+    await session.execute(
+        update(Loan)
+        .where(Loan.borrower_id.in_(borrower_ids), Loan.library_id == library_id)
+        .values(borrower_name=ANONYMIZED_BORROWER_NAME, borrower_contact=None)
+    )
+
+    await session.commit()
+    logger.info(
+        "borrowers_bulk_anonymized",
+        borrower_ids_count=len(borrower_ids),
+        affected=affected,
+        library_id=str(library_id),
+    )
+    return affected

--- a/backend/tests/test_borrower_anonymize.py
+++ b/backend/tests/test_borrower_anonymize.py
@@ -385,3 +385,20 @@ async def test_bulk_anonymize_foreign_borrower_returns_404(test_session: AsyncSe
             json={"ids": [str(own.id), str(foreign.id)]},
         )
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_bulk_anonymize_duplicate_ids_rejected(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    borrower = Borrower(library_id=lib.id, name="Dup")
+    test_session.add(borrower)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            "/api/v1/borrowers/bulk/anonymize",
+            headers=headers,
+            json={"ids": [str(borrower.id), str(borrower.id)]},
+        )
+    assert resp.status_code == 422

--- a/backend/tests/test_borrower_anonymize.py
+++ b/backend/tests/test_borrower_anonymize.py
@@ -338,4 +338,50 @@ async def test_anonymize_requires_editor_role(test_session: AsyncSession) -> Non
 async def test_anonymize_requires_authentication() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(f"/api/v1/borrowers/{uuid.uuid4()}/anonymize")
-        assert resp.status_code == 401
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_bulk_anonymize_success(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    first = Borrower(library_id=lib.id, name="Alice", contact="alice@example.com", notes="a")
+    second = Borrower(library_id=lib.id, name="Bob", contact="bob@example.com", notes="b")
+    test_session.add_all([first, second])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            "/api/v1/borrowers/bulk/anonymize",
+            headers=headers,
+            json={"ids": [str(first.id), str(second.id)]},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"affected": 2}
+
+    refreshed = (
+        await test_session.execute(select(Borrower).where(Borrower.id.in_([first.id, second.id])))
+    ).scalars().all()
+    assert all(row.name == "Deleted borrower" for row in refreshed)
+    assert all(row.contact is None for row in refreshed)
+    assert all(row.notes is None for row in refreshed)
+    assert all(row.anonymized_at is not None for row in refreshed)
+
+
+@pytest.mark.asyncio
+async def test_bulk_anonymize_foreign_borrower_returns_404(test_session: AsyncSession) -> None:
+    _, own_lib = await _seed_user_with_library(test_session)
+    _, foreign_lib = await _seed_user_with_library(test_session, email="other@example.com")
+    own = Borrower(library_id=own_lib.id, name="Own")
+    foreign = Borrower(library_id=foreign_lib.id, name="Foreign")
+    test_session.add_all([own, foreign])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            "/api/v1/borrowers/bulk/anonymize",
+            headers=headers,
+            json={"ids": [str(own.id), str(foreign.id)]},
+        )
+    assert resp.status_code == 404

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2254,6 +2254,70 @@
         }
       }
     },
+    "/api/v1/borrowers/bulk/anonymize": {
+      "post": {
+        "tags": [
+          "borrowers"
+        ],
+        "summary": "Bulk Anonymize Borrowers Endpoint",
+        "operationId": "bulk_anonymize_borrowers_endpoint_api_v1_borrowers_bulk_anonymize_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BorrowerBulkAnonymizeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BorrowerBulkAnonymizeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/borrowers/{target_id}/merge": {
       "post": {
         "tags": [
@@ -4479,6 +4543,38 @@
         },
         "type": "object",
         "title": "BookUpdateRequest"
+      },
+      "BorrowerBulkAnonymizeRequest": {
+        "properties": {
+          "ids": {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array",
+            "maxItems": 200,
+            "minItems": 1,
+            "title": "Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ids"
+        ],
+        "title": "BorrowerBulkAnonymizeRequest"
+      },
+      "BorrowerBulkAnonymizeResponse": {
+        "properties": {
+          "affected": {
+            "type": "integer",
+            "title": "Affected"
+          }
+        },
+        "type": "object",
+        "required": [
+          "affected"
+        ],
+        "title": "BorrowerBulkAnonymizeResponse"
       },
       "BorrowerCreate": {
         "properties": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2190,70 +2190,6 @@
         }
       }
     },
-    "/api/v1/borrowers/{borrower_id}/anonymize": {
-      "post": {
-        "tags": [
-          "borrowers"
-        ],
-        "summary": "Anonymize Borrower Endpoint",
-        "operationId": "anonymize_borrower_endpoint_api_v1_borrowers__borrower_id__anonymize_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "borrower_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Borrower Id"
-            }
-          },
-          {
-            "name": "X-Library-Id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Library-Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BorrowerResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/borrowers/bulk/anonymize": {
       "post": {
         "tags": [
@@ -2301,6 +2237,70 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BorrowerBulkAnonymizeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/borrowers/{borrower_id}/anonymize": {
+      "post": {
+        "tags": [
+          "borrowers"
+        ],
+        "summary": "Anonymize Borrower Endpoint",
+        "operationId": "anonymize_borrower_endpoint_api_v1_borrowers__borrower_id__anonymize_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "borrower_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Borrower Id"
+            }
+          },
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BorrowerResponse"
                 }
               }
             }


### PR DESCRIPTION
### Motivation
- Provide a server-side API to anonymize many borrowers in one operation (issue #246) while preserving lending history and enforcing library ownership. 
- Ensure the anonymization cascades to denormalized loan snapshot fields so PII is removed from loan history as well.

### Description
- Added `BorrowerBulkAnonymizeRequest` and `BorrowerBulkAnonymizeResponse` schemas. 
- Added `POST /api/v1/borrowers/bulk/anonymize` router that requires editor privileges and delegates to the service layer. 
- Implemented `bulk_anonymize_borrowers(session, borrower_ids, library_id)` to validate same-library ownership (404 if any id is missing/foreign), perform idempotent anonymization, update `Loan.borrower_name`/`Loan.borrower_contact` for matching loans, and return the count of affected rows. 
- Added backend tests verifying successful bulk anonymization and rejection when the payload includes a foreign-library borrower.

### Testing
- Ran `cd backend && ruff check app tests` and `cd backend && mypy app tests`; both passed. 
- Attempted `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests` but the environment rejected `--cov` args (pytest-cov not available). 
- Ran `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest tests/test_borrower_anonymize.py` but test collection failed in this environment due to a Python 3.14 / SQLAlchemy typing compatibility issue unrelated to this change. 
- Frontend checks `cd frontend && npm run lint` and `cd frontend && npm test -- --run` succeeded (lint warnings only; vitest tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a018c97c8008325b7e01f2dadeb49ae)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk borrower anonymization (1–200 IDs) that clears personal and related transaction fields and returns an affected count.

* **Validation**
  * Requests must contain 1–200 unique IDs; duplicate IDs are rejected. IDs from other libraries return not found.

* **Tests**
  * Added tests for auth, successful bulk anonymization, cross-library rejection, and duplicate-ID validation.

* **Documentation**
  * OpenAPI updated with the new endpoint and request/response schemas.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/259)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->