### PR TITLE
Add retention-style bulk borrower anonymization by inactivity date

### DIFF
--- a/backend/app/api/borrowers.py
+++ b/backend/app/api/borrowers.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies.library import get_library_id, require_editor_library
 from app.db.session import get_db_session
 from app.schemas.borrower import (
+    BorrowerBulkAnonymizeByDateRequest,
     BorrowerBulkAnonymizeRequest,
     BorrowerBulkAnonymizeResponse,
     BorrowerCreate,
@@ -22,6 +23,7 @@ from app.services.borrower import (
     create_borrower,
     get_borrower_or_404,
     list_borrowers_with_stats,
+    list_borrower_ids_to_anonymize_by_date,
     list_loans_for_borrower,
     merge_borrowers,
     update_borrower,
@@ -106,6 +108,21 @@ async def bulk_anonymize_borrowers_endpoint(
     library_id: uuid.UUID = Depends(require_editor_library),
 ) -> BorrowerBulkAnonymizeResponse:
     affected = await bulk_anonymize_borrowers(session, payload.ids, library_id)
+    return BorrowerBulkAnonymizeResponse(affected=affected)
+
+
+@router.post("/bulk-anonymize-by-date", response_model=BorrowerBulkAnonymizeResponse)
+async def bulk_anonymize_borrowers_by_date_endpoint(
+    payload: BorrowerBulkAnonymizeByDateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(require_editor_library),
+) -> BorrowerBulkAnonymizeResponse:
+    borrower_ids = await list_borrower_ids_to_anonymize_by_date(
+        session, library_id, payload.inactive_since
+    )
+    if payload.dry_run:
+        return BorrowerBulkAnonymizeResponse(affected=len(borrower_ids))
+    affected = await bulk_anonymize_borrowers(session, borrower_ids, library_id)
     return BorrowerBulkAnonymizeResponse(affected=affected)
 
 

--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -91,3 +91,8 @@ class BorrowerBulkAnonymizeRequest(BaseModel):
 
 class BorrowerBulkAnonymizeResponse(BaseModel):
     affected: int
+
+
+class BorrowerBulkAnonymizeByDateRequest(BaseModel):
+    inactive_since: date
+    dry_run: bool = False

--- a/backend/app/services/borrower.py
+++ b/backend/app/services/borrower.py
@@ -428,3 +428,33 @@ async def bulk_anonymize_borrowers(
         library_id=str(library_id),
     )
     return affected
+
+
+async def list_borrower_ids_to_anonymize_by_date(
+    session: AsyncSession, library_id: uuid.UUID, inactive_since: date
+) -> list[uuid.UUID]:
+    last_activity = (
+        select(func.max(Loan.lent_date))
+        .where(Loan.borrower_id == Borrower.id, Loan.library_id == library_id)
+        .scalar_subquery()
+    )
+    has_active_loan = (
+        select(Loan.id)
+        .where(
+            Loan.borrower_id == Borrower.id,
+            Loan.library_id == library_id,
+            Loan.returned_date.is_(None),
+        )
+        .exists()
+    )
+
+    result = await session.execute(
+        select(Borrower.id)
+        .where(
+            Borrower.library_id == library_id,
+            Borrower.anonymized_at.is_(None),
+            ~has_active_loan,
+            (last_activity.is_(None) | (last_activity < inactive_since)),
+        )
+    )
+    return list(result.scalars().all())

--- a/backend/tests/test_borrower_anonymize.py
+++ b/backend/tests/test_borrower_anonymize.py
@@ -10,7 +10,7 @@ Covers:
 - 401 without auth
 """
 from collections.abc import AsyncIterator, Iterator
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 import uuid
 
 from httpx import ASGITransport, AsyncClient
@@ -402,3 +402,122 @@ async def test_bulk_anonymize_duplicate_ids_rejected(test_session: AsyncSession)
             json={"ids": [str(borrower.id), str(borrower.id)]},
         )
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_bulk_anonymize_by_date_dry_run_counts_without_mutation(test_session: AsyncSession) -> None:
+    _, lib = await _seed_user_with_library(test_session)
+    borrower = Borrower(
+        library_id=lib.id,
+        name="Dry Run",
+        created_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+    )
+    test_session.add(borrower)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        resp = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            headers=headers,
+            json={"inactive_since": "2024-01-01", "dry_run": True},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"affected": 1}
+
+    refreshed = (await test_session.execute(select(Borrower).where(Borrower.id == borrower.id))).scalar_one()
+    assert refreshed.anonymized_at is None
+    assert refreshed.name == "Dry Run"
+
+
+@pytest.mark.asyncio
+async def test_bulk_anonymize_by_date_rules_and_idempotency(test_session: AsyncSession) -> None:
+    user, lib = await _seed_user_with_library(test_session)
+    foreign_lib = Library(name="Foreign", created_by_user_id=user.id)
+    test_session.add(foreign_lib)
+    await test_session.flush()
+
+    today = date(2026, 5, 1)
+    cutoff = "2025-01-01"
+
+    no_loans_old = Borrower(
+        library_id=lib.id,
+        name="NoLoansOld",
+        created_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+    )
+    returned_old = Borrower(library_id=lib.id, name="ReturnedOld")
+    active_old = Borrower(library_id=lib.id, name="ActiveOld")
+    recent_returned = Borrower(library_id=lib.id, name="RecentReturned")
+    already_anonymized = Borrower(
+        library_id=lib.id, name="Already", anonymized_at=datetime.now(timezone.utc)
+    )
+    foreign = Borrower(library_id=foreign_lib.id, name="Foreign")
+    test_session.add_all([no_loans_old, returned_old, active_old, recent_returned, already_anonymized, foreign])
+    await test_session.flush()
+
+    book = _make_book(lib.id, "Book")
+    foreign_book = _make_book(foreign_lib.id, "Foreign Book")
+    test_session.add_all([book, foreign_book])
+    await test_session.flush()
+
+    test_session.add_all([
+        _make_loan(
+            library_id=lib.id, book_id=book.id, borrower_id=returned_old.id,
+            borrower_name="ReturnedOld", borrower_contact=None, lent_date=date(2024, 1, 1),
+            returned_date=date(2024, 1, 10), return_condition="good",
+        ),
+        _make_loan(
+            library_id=lib.id, book_id=book.id, borrower_id=active_old.id,
+            borrower_name="ActiveOld", borrower_contact=None, lent_date=date(2024, 1, 1),
+        ),
+        _make_loan(
+            library_id=lib.id, book_id=book.id, borrower_id=recent_returned.id,
+            borrower_name="RecentReturned", borrower_contact=None, lent_date=today,
+            returned_date=today, return_condition="good",
+        ),
+        _make_loan(
+            library_id=foreign_lib.id, book_id=foreign_book.id, borrower_id=foreign.id,
+            borrower_name="Foreign", borrower_contact=None, lent_date=date(2020, 1, 1),
+            returned_date=date(2020, 1, 2), return_condition="good",
+        ),
+    ])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _auth_headers(client, test_session)
+        first = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            headers=headers,
+            json={"inactive_since": cutoff, "dry_run": False},
+        )
+        second = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            headers=headers,
+            json={"inactive_since": cutoff, "dry_run": False},
+        )
+    assert first.status_code == 200
+    assert first.json() == {"affected": 2}
+    assert second.status_code == 200
+    assert second.json() == {"affected": 0}
+
+    borrowers = (
+        await test_session.execute(
+            select(Borrower).where(
+                Borrower.id.in_([
+                    no_loans_old.id,
+                    returned_old.id,
+                    active_old.id,
+                    recent_returned.id,
+                    already_anonymized.id,
+                    foreign.id,
+                ])
+            )
+        )
+    ).scalars().all()
+    by_id = {row.id: row for row in borrowers}
+    assert by_id[no_loans_old.id].anonymized_at is not None
+    assert by_id[returned_old.id].anonymized_at is not None
+    assert by_id[active_old.id].anonymized_at is None
+    assert by_id[recent_returned.id].anonymized_at is None
+    assert by_id[already_anonymized.id].anonymized_at is not None
+    assert by_id[foreign.id].anonymized_at is None

--- a/frontend/src/hooks/useBorrowers.ts
+++ b/frontend/src/hooks/useBorrowers.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 
-import { anonymizeBorrower, formatApiError, getBorrower, listBorrowerLoans, listBorrowers, mergeBorrowers, updateBorrower } from '../lib/api'
+import { anonymizeBorrower, bulkAnonymizeBorrowersByDate, formatApiError, getBorrower, listBorrowerLoans, listBorrowers, mergeBorrowers, updateBorrower } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
 import { useToastStore } from '../lib/toast-store'
 import type { BorrowerListParams, BorrowerUpdateRequest } from '../lib/types'
@@ -115,6 +115,24 @@ export function useAnonymizeBorrower() {
         queryClient.invalidateQueries({ queryKey: ['books'] }),
       ])
       showSuccess(t('toast.borrower_anonymized', 'Borrower anonymized.'))
+    },
+    onError: (error: unknown) => showError(formatApiError(error)),
+  })
+}
+
+export function useBulkAnonymizeBorrowersByDate() {
+  const queryClient = useQueryClient()
+  const showError = useToastStore((s) => s.showError)
+  return useMutation({
+    mutationFn: bulkAnonymizeBorrowersByDate,
+    onSuccess: async (result, payload) => {
+      if (!payload.dry_run && result.affected > 0) {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: BORROWERS_QUERY_KEY }),
+          queryClient.invalidateQueries({ queryKey: ['loans'] }),
+          queryClient.invalidateQueries({ queryKey: ['books'] }),
+        ])
+      }
     },
     onError: (error: unknown) => showError(formatApiError(error)),
   })

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -772,6 +772,14 @@
     "merge_irreversible": "Tento krok nelze vrátit.",
     "merge_back": "Zpět",
     "merge_confirm": "Sloučit",
-    "merging": "Slučuji…"
+    "merging": "Slučuji…",
+    "bulk_anonymize_open": "Hromadně anonymizovat…",
+    "bulk_anonymize_title": "Hromadná anonymizace neaktivních dlužníků",
+    "bulk_anonymize_body": "Vyberte hraniční datum. Dlužníci neaktivní před tímto datem budou anonymizováni.",
+    "bulk_anonymize_date_label": "Neaktivní od",
+    "bulk_anonymize_preview": "Zobrazit počet",
+    "bulk_anonymize_confirm": "Potvrdit anonymizaci",
+    "bulk_anonymize_warning": "Tento krok nelze vrátit.",
+    "bulk_anonymize_affected": "Dotčeno: {{count}}"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -769,6 +769,14 @@
     "merge_irreversible": "This cannot be undone.",
     "merge_back": "Back",
     "merge_confirm": "Merge",
-    "merging": "Merging…"
+    "merging": "Merging…",
+    "bulk_anonymize_open": "Bulk anonymize…",
+    "bulk_anonymize_title": "Bulk anonymize inactive borrowers",
+    "bulk_anonymize_body": "Choose a cutoff date. Borrowers inactive before that date will be anonymized.",
+    "bulk_anonymize_date_label": "Inactive since",
+    "bulk_anonymize_preview": "Preview affected count",
+    "bulk_anonymize_confirm": "Confirm anonymization",
+    "bulk_anonymize_warning": "This cannot be undone.",
+    "bulk_anonymize_affected": "Affected: {{count}}"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,8 @@ import type {
   BorrowerCreateRequest,
   BorrowerListParams,
   BorrowerListResponse,
+  BorrowerBulkAnonymizeByDateRequest,
+  BorrowerBulkAnonymizeResponse,
   BorrowerLoanItem,
   BorrowerUpdateRequest,
   CheckoutResponse,
@@ -526,6 +528,16 @@ export async function mergeBorrowers(targetId: string, sourceId: string): Promis
 
 export async function anonymizeBorrower(id: string): Promise<Borrower> {
   const response = await apiClient.post<Borrower>(`/api/v1/borrowers/${id}/anonymize`)
+  return response.data
+}
+
+export async function bulkAnonymizeBorrowersByDate(
+  payload: BorrowerBulkAnonymizeByDateRequest,
+): Promise<BorrowerBulkAnonymizeResponse> {
+  const response = await apiClient.post<BorrowerBulkAnonymizeResponse>(
+    '/api/v1/borrowers/bulk-anonymize-by-date',
+    payload,
+  )
   return response.data
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -84,6 +84,13 @@ export interface BorrowerUpdateRequest {
   contact?: string | null
   notes?: string | null
 }
+export interface BorrowerBulkAnonymizeByDateRequest {
+  inactive_since: string
+  dry_run: boolean
+}
+export interface BorrowerBulkAnonymizeResponse {
+  affected: number
+}
 
 export interface Loan {
   id: string

--- a/frontend/src/pages/BorrowersPage.test.tsx
+++ b/frontend/src/pages/BorrowersPage.test.tsx
@@ -10,9 +10,10 @@ vi.mock('../contexts/AuthContext', () => ({
 
 vi.mock('../lib/api', () => ({
   listBorrowers: vi.fn(),
+  bulkAnonymizeBorrowersByDate: vi.fn(),
 }))
 
-import { listBorrowers } from '../lib/api'
+import { bulkAnonymizeBorrowersByDate, listBorrowers } from '../lib/api'
 import type { BorrowerListItem, BorrowerListResponse } from '../lib/types'
 import { BorrowersPage } from './BorrowersPage'
 
@@ -219,6 +220,28 @@ describe('BorrowersPage', () => {
       const lastCall = vi.mocked(listBorrowers).mock.calls[vi.mocked(listBorrowers).mock.calls.length - 1]
       expect(lastCall?.[0]?.page).toBe(1)
       expect(lastCall?.[0]?.search).toBe('q')
+    })
+  })
+
+  it('opens bulk anonymize modal, previews count, and confirms with dry_run false', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue(makePage([]))
+    vi.mocked(bulkAnonymizeBorrowersByDate)
+      .mockResolvedValueOnce({ affected: 3 })
+      .mockResolvedValueOnce({ affected: 3 })
+    renderPage()
+    const user = userEvent.setup()
+    await user.click(await screen.findByTestId('borrowers-bulk-anonymize-open'))
+    await user.type(screen.getByTestId('bulk-anonymize-date'), '2025-01-01')
+    await user.click(screen.getByTestId('bulk-anonymize-preview'))
+    expect(await screen.findByTestId('bulk-anonymize-count')).toBeInTheDocument()
+    expect(bulkAnonymizeBorrowersByDate).toHaveBeenCalledWith({
+      inactive_since: '2025-01-01',
+      dry_run: true,
+    })
+    await user.click(screen.getByTestId('bulk-anonymize-confirm'))
+    expect(bulkAnonymizeBorrowersByDate).toHaveBeenCalledWith({
+      inactive_since: '2025-01-01',
+      dry_run: false,
     })
   })
 })

--- a/frontend/src/pages/BorrowersPage.tsx
+++ b/frontend/src/pages/BorrowersPage.tsx
@@ -3,8 +3,9 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
 import { NoResultsIcon } from '../components/EmptyStateIcons'
+import { Modal } from '../components/Modal'
 import { useDebounce } from '../hooks/useDebounce'
-import { useBorrowers } from '../hooks/useBorrowers'
+import { useBorrowers, useBulkAnonymizeBorrowersByDate } from '../hooks/useBorrowers'
 import { displayBorrowerName } from '../lib/borrowerDisplay'
 import { getBorrowerDetailRoute } from '../lib/routes'
 import type { BorrowerListItem } from '../lib/types'
@@ -24,6 +25,10 @@ export function BorrowersPage() {
   const { t, i18n } = useTranslation()
   const [searchInput, setSearchInput] = useState('')
   const [page, setPage] = useState(1)
+  const [bulkModalOpen, setBulkModalOpen] = useState(false)
+  const [inactiveSince, setInactiveSince] = useState('')
+  const [previewCount, setPreviewCount] = useState<number | null>(null)
+  const bulkAnonymize = useBulkAnonymizeBorrowersByDate()
 
   // Server-side search means the input has to settle before we re-fetch.
   // 250ms is the standard "felt instant but not a query per keystroke" range.
@@ -65,6 +70,9 @@ export function BorrowersPage() {
         <p style={{ margin: '4px 0 0', color: 'var(--sh-text-muted)' }}>
           {t('borrowers.subtitle')}
         </p>
+        <button type="button" className="sh-btn-secondary" data-testid="borrowers-bulk-anonymize-open" onClick={() => setBulkModalOpen(true)}>
+          {t('borrowers.bulk_anonymize_open')}
+        </button>
       </header>
 
       <div style={{ marginBottom: 16, display: 'flex', gap: 12, alignItems: 'center' }}>
@@ -229,6 +237,36 @@ export function BorrowersPage() {
           </button>
         </nav>
       )}
+      <Modal open={bulkModalOpen} onClose={() => setBulkModalOpen(false)} label={t('borrowers.bulk_anonymize_title')} size="md">
+        <h3>{t('borrowers.bulk_anonymize_title')}</h3>
+        <p>{t('borrowers.bulk_anonymize_body')}</p>
+        <label htmlFor="inactive-since">{t('borrowers.bulk_anonymize_date_label')}</label>
+        <input id="inactive-since" data-testid="bulk-anonymize-date" type="date" className="sh-input" value={inactiveSince} onChange={(e) => setInactiveSince(e.target.value)} />
+        <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
+          <button
+            type="button"
+            data-testid="bulk-anonymize-preview"
+            className="sh-btn-secondary"
+            disabled={!inactiveSince || bulkAnonymize.isPending}
+            onClick={async () => {
+              const result = await bulkAnonymize.mutateAsync({ inactive_since: inactiveSince, dry_run: true })
+              setPreviewCount(result.affected)
+            }}
+          >{t('borrowers.bulk_anonymize_preview')}</button>
+          <button
+            type="button"
+            data-testid="bulk-anonymize-confirm"
+            className="sh-btn-danger"
+            disabled={!inactiveSince || bulkAnonymize.isPending}
+            onClick={async () => {
+              await bulkAnonymize.mutateAsync({ inactive_since: inactiveSince, dry_run: false })
+              setBulkModalOpen(false)
+            }}
+          >{t('borrowers.bulk_anonymize_confirm')}</button>
+        </div>
+        <p style={{ color: 'var(--sh-danger)' }}>{t('borrowers.bulk_anonymize_warning')}</p>
+        {previewCount !== null && <p data-testid="bulk-anonymize-count">{t('borrowers.bulk_anonymize_affected', { count: previewCount })}</p>}
+      </Modal>
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Provide a librarian-triggered GDPR retention action that selects borrowers by inactivity date so staff do not need to know specific borrower IDs to anonymize. 
- Reuse the existing bulk-anonymize primitive for actual mutations to keep implementation simple and consistent.

### Description
- Added a new editor-scoped endpoint `POST /api/v1/borrowers/bulk-anonymize-by-date` that accepts `{ "inactive_since": "YYYY-MM-DD", "dry_run": false }` and returns `{ "affected": N }`.
- Implemented selection logic in `app.services.borrower` via `list_borrower_ids_to_anonymize_by_date` which computes each borrower's `last_activity_at` as `max(Loan.lent_date)`, includes borrowers whose `last_activity_at` is `NULL` or `< inactive_since`, and excludes borrowers with any active loan or with `anonymized_at` already set.
- For `dry_run=true` the endpoint returns the affected count without mutating; for `dry_run=false` it delegates to the existing `bulk_anonymize_borrowers` to perform anonymization and loan denormalized-field clearing (idempotent behavior preserved).
- Backend schema additions: `BorrowerBulkAnonymizeByDateRequest` added to `app.schemas.borrower`.
- Frontend: added API client method `bulkAnonymizeBorrowersByDate`, TypeScript types, a React mutation hook `useBulkAnonymizeBorrowersByDate` that invalidates relevant caches on non-dry-run success, and a “Bulk anonymize…” button + modal on the `/borrowers` page with date picker, preview (dry-run) action, confirm action, irreversible warning, and i18n strings (EN + CS).
- Tests: added backend tests exercising dry-run, cutoff rules (no-loan and returned-loan before cutoff), skipping borrowers with an active loan, cross-library isolation, and idempotency; added a frontend test that opens the modal, previews, and confirms.

### Testing
- Ran backend static checks: `cd backend && ruff check app tests` — succeeded.
- Ran backend type checks: `cd backend && mypy app tests` — succeeded.
- Attempted backend unit tests: `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests/test_borrower_anonymize.py` — failed in this environment because coverage plugin/args were not accepted (test runner lacked that plugin), so `--cov` invocation errored.
- Ran targeted backend tests: `cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest tests/test_borrower_anonymize.py` — collection failed in this execution environment with a SQLAlchemy/typing `TypeError` under the available Python/SQLAlchemy runtime, so full test execution could not complete here.
- Frontend automated checks were attempted: `cd frontend && npm run lint` and `npm test` — lint step failed in this environment due to missing dev dependency (`@eslint/js`), so frontend tests were not executed here.

Notes: The change reuses the existing anonymization primitive for mutations to avoid duplication; added tests and frontend coverage are included in the PR but CI in this environment could not run all suites due to missing tooling and a runtime incompatibility during test collection. Please run the full test matrix in CI with the project’s normal Node/Python toolchain to validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02cae4ed1083259d6155d1cd2d8efa)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk anonymization feature with dry-run preview and affected-record count display
  * Implemented modal interface for anonymization workflow with date-based filtering
  * Full internationalization support for English and Czech languages

* **Tests**
  * Added comprehensive test coverage for bulk anonymization operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/260)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->