### PR TITLE
chore(scripts): add local OpenAPI drift check (#243)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ npm run lint
 npm test -- --run
 ```
 
+**Backend schema changes?** Also run `scripts/check-openapi-drift.sh`
+and commit any `docs/openapi.yaml` diff in the same PR. The script
+regenerates the spec from the live FastAPI app and exits non-zero on
+drift, so it doubles as a one-line pre-push check. The CI `backend /
+lint` job runs the same check — running it locally just saves the cycle.
+
 ## Test-DB contract
 
 The backend test suite runs against SQLite (`sqlite+aiosqlite`). Production

--- a/scripts/check-openapi-drift.sh
+++ b/scripts/check-openapi-drift.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Local pre-push check for OpenAPI spec drift (#243).
+#
+# Runs the same two steps the CI ``backend / lint`` job runs:
+#   1. regenerate ``docs/openapi.yaml`` from the live FastAPI app
+#   2. ``git diff --exit-code`` on that file
+#
+# Exit codes:
+#   0 — spec is up to date
+#   1 — drift detected; the regenerated file is left in place for staging
+#   2 — environment problem (script could not even run the generator)
+#
+# Why this exists: every backend schema change that touches a Pydantic
+# model also has to refresh ``docs/openapi.yaml``. Forgetting to do that
+# costs one CI cycle per affected PR. Running this script before pushing
+# catches the drift locally and shaves ~3–5 minutes per occurrence.
+#
+# Usage:
+#   scripts/check-openapi-drift.sh
+#
+# Requires python3 on PATH plus the backend Python deps importable
+# (i.e. you ran ``pip install -r backend/requirements.txt`` in the
+# environment the script invokes). The script does **not** create a
+# venv — it deliberately reuses whatever the existing ``AGENTS.md``
+# workflow already set up.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GENERATOR="${REPO_ROOT}/scripts/generate_openapi.py"
+TARGET="${REPO_ROOT}/docs/openapi.yaml"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 not found on PATH" >&2
+  echo "       this script reuses your existing backend env; see AGENTS.md" >&2
+  exit 2
+fi
+
+if [[ ! -f "$GENERATOR" ]]; then
+  echo "error: generator script missing at $GENERATOR" >&2
+  exit 2
+fi
+
+if ! python3 "$GENERATOR" >/dev/null; then
+  echo "error: scripts/generate_openapi.py failed — likely a missing backend dependency." >&2
+  echo "       install backend deps and retry: cd backend && pip install -r requirements.txt" >&2
+  exit 2
+fi
+
+if git -C "$REPO_ROOT" diff --exit-code -- "$TARGET" >/dev/null; then
+  echo "openapi.yaml is up to date."
+  exit 0
+fi
+
+echo "drift detected in docs/openapi.yaml — regenerated copy is staged for review."
+echo "review the diff and commit:"
+echo "    git add docs/openapi.yaml"
+echo "    git commit -m 'chore(openapi): regenerate spec'"
+exit 1


### PR DESCRIPTION
Closes #243.

Every backend schema change that touches a Pydantic model also has to refresh ``docs/openapi.yaml``. Forgetting costs one CI cycle on ``backend / lint`` per affected PR — recurring tax that bit several of the borrower-epic PRs.

This adds ``scripts/check-openapi-drift.sh`` that runs the same two steps the CI lint job runs:

1. ``python scripts/generate_openapi.py``
2. ``git diff --exit-code -- docs/openapi.yaml``

Exit codes are explicit (0 = up to date, 1 = drift, 2 = env problem) so it's friendly to git hooks or shell wrappers.

``AGENTS.md`` gets a one-line pointer next to the existing required verification commands.

Intentionally simple: no pre-commit framework, no venv setup. Reuses whatever Python env runs ``pytest`` / ``mypy`` already. If deps are missing it exits 2 with a clear message instead of pretending to pass.

## Test plan

- [x] ``bash -n scripts/check-openapi-drift.sh`` syntax check
- [ ] CI runs the same drift check; this PR will be a no-op there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines with explicit backend schema verification requirements to ensure consistent API documentation.

* **Chores**
  * Added automated validation tool to detect inconsistencies between API specifications and live backend implementation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/263)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->