### PR TITLE
docs(legal): borrower-aware content audit of Privacy + Terms (#252)

### DIFF
--- a/docs/privacy-policy-audit-2026-05-12.md
+++ b/docs/privacy-policy-audit-2026-05-12.md
@@ -1,0 +1,48 @@
+# Privacy policy + Terms audit — 2026-05-12
+
+Tracks the content audit asked for by issue #252 after the borrowers epic
+(#221) shipped. The previous audit work in PR #258 only DRY-ified the
+legal metadata into `lib/legal.ts`; the actual policy text was unchanged
+and still missed the new data flows introduced by the borrower epic.
+
+## What was checked
+
+| Surface | Files |
+|---|---|
+| Privacy policy | `frontend/src/pages/PrivacyPage.tsx` |
+| Terms of service | `frontend/src/pages/TermsPage.tsx` |
+| Shared legal metadata | `frontend/src/lib/legal.ts` |
+
+## Audit questions vs. resolution
+
+| # | Question | Pre-audit answer | Action |
+|---|---|---|---|
+| 1 | Does the privacy policy describe borrowers as a distinct data category? | No — collapsed under "Data knihovny: výpůjčky" | Added explicit row in §2 with own legal basis. |
+| 2 | Does it describe deletion / anonymization rights for borrower records? | No — only account deletion | §6 expanded: pointer to `/borrowers → Anonymize` for partial erasure, §5 retention table gets a "Údaje dlužníka" row. |
+| 3 | Does it cover what `/auth/me/export` ships? | Generic "JSON export" — no mention of borrower records | §6 export bullet now names the borrower export contents. |
+| 4 | Is the librarian's data-controller role for borrower data described? | No | New §11 "Údaje dlužníků: vztah správce/zpracovatel" — explicitly: librarian is the data controller, Shelfy is the processor. |
+| 5 | Do the Terms reflect the same controller/processor split? | No | §8 expanded with the controller responsibility for librarian. |
+| 6 | Are anonymization + merge semantics covered? | No | §5 + §6 + §11 of Privacy. |
+| 7 | cs/en parity | Pages are cs-only by design; no en variant to keep in sync | No action. If en variant ever lands, mirror these sections. |
+
+## Out of scope
+
+- Formal legal review. Goal here is consistency with what the app actually
+  does. Legal sign-off remains a separate workstream.
+- Restructuring the page layouts or visual design. The audit is a content
+  fix, not a redesign.
+- Cookies / consent banner work.
+- Backend changes — none required; the API surface that exists (anonymize
+  endpoint, GDPR export) already supports what the policy now describes.
+
+## Version bump
+
+- `LEGAL_DOC_VERSION`: `2.0` → `2.1`
+- `LEGAL_DOC_EFFECTIVE_DATE`: `8. dubna 2026` → `12. května 2026`
+
+## Follow-ups not done in this audit
+
+- en-language variants of the policy pages: still missing. File as a
+  separate issue if/when the app gains an English landing.
+- DPIA / record of processing activities (Art. 30 GDPR record): not part
+  of the user-facing policy; tracked separately.

--- a/frontend/src/lib/legal.ts
+++ b/frontend/src/lib/legal.ts
@@ -4,8 +4,8 @@ export const LEGAL_ENTITY_ICO = '24561401'
 // NOTE: Seat address intentionally pending legal confirmation.
 export const LEGAL_ENTITY_SEAT = '—'
 
-export const LEGAL_DOC_VERSION = '2.0'
-export const LEGAL_DOC_EFFECTIVE_DATE = '8. dubna 2026'
+export const LEGAL_DOC_VERSION = '2.1'
+export const LEGAL_DOC_EFFECTIVE_DATE = '12. května 2026'
 
 export const PRIVACY_CONTACT_EMAIL = 'privacy@shelfy.cz'
 export const TERMS_CONTACT_EMAIL = 'info@shelfy.cz'

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -104,6 +104,12 @@ export function PrivacyPage() {
                 <td style={TD}>Plnění smlouvy (čl. 6/1b)</td>
               </tr>
               <tr>
+                <td style={TD}>Údaje dlužníků</td>
+                <td style={TD}>Jméno, kontakt a volitelné poznámky o osobách, kterým Uživatel půjčil knihy</td>
+                <td style={TD}>Vedení historie půjček a evidence dlužníků</td>
+                <td style={TD}>Plnění smlouvy mezi Uživatelem a Poskytovatelem (čl. 6/1b); Uživatel je správcem těchto údajů, Poskytovatel zpracovatelem — viz oddíl 11</td>
+              </tr>
+              <tr>
                 <td style={TD}>Fakturační údaje</td>
                 <td style={TD}>Plán předplatného, Stripe customer ID</td>
                 <td style={TD}>Správa předplatného a fakturace</td>
@@ -184,6 +190,7 @@ export function PrivacyPage() {
             </thead>
             <tbody>
               <tr><td style={TD}>Účet a data knihovny</td><td style={TD}>Po dobu existence účtu</td></tr>
+              <tr><td style={TD}>Údaje dlužníka</td><td style={TD}>Do anonymizace (Uživatel může kdykoli v <em>/borrowers → Anonymizovat</em>) nebo do smazání účtu. Anonymizace je nevratná — smaže jméno, kontakt a poznámky a vyčistí tyto údaje i u všech půjček daného dlužníka. Historie půjček (kniha, data, stav vrácení) zůstává.</td></tr>
               <tr><td style={TD}>Po smazání účtu</td><td style={TD}>Nevratně odstraněno do 30 dnů (zálohy rotovány po 30 dnech)</td></tr>
               <tr><td style={TD}>Technické logy</td><td style={TD}>30 dnů</td></tr>
               <tr><td style={TD}>Chybové záznamy (Sentry)</td><td style={TD}>90 dnů</td></tr>
@@ -203,10 +210,13 @@ export function PrivacyPage() {
             <li>
               <strong>Právo na výmaz (čl. 17)</strong> — můžete smazat účet a všechna data.
               V aplikaci: <em>Nastavení → Nebezpečná zóna → Smazat účet</em>.
+              Pro dílčí výmaz údajů konkrétního dlužníka použijte <em>/borrowers → Anonymizovat</em> —
+              tato akce je nevratná a vyčistí osobní údaje napříč evidencí, historie půjček zůstává.
             </li>
             <li>
               <strong>Právo na přenositelnost (čl. 20)</strong> — můžete si stáhnout kompletní JSON export dat.
-              V aplikaci: <em>Nastavení → Export mých dat</em>.
+              V aplikaci: <em>Nastavení → Export mých dat</em>. Export obsahuje i záznamy dlužníků
+              evidovaných ve vašich knihovnách, protože jsou součástí vašich dat (viz oddíl 11).
             </li>
             <li><strong>Právo na omezení zpracování (čl. 18)</strong> — za podmínek stanovených GDPR.</li>
             <li><strong>Právo vznést námitku (čl. 21)</strong> — proti zpracování na základě oprávněného zájmu.</li>
@@ -262,9 +272,46 @@ export function PrivacyPage() {
           </ul>
         </div>
 
-        {/* ── 10. Změny ── */}
+        {/* ── 11. Údaje dlužníků ── */}
         <div style={SECTION}>
-          <h2 style={H2}>10. Změny těchto zásad</h2>
+          <h2 style={H2}>11. Údaje dlužníků: vztah správce/zpracovatel</h2>
+          <p style={P}>
+            Pokud jako Uživatel v aplikaci evidujete <strong>dlužníky</strong> (osoby, kterým
+            jste půjčili knihy), zadáváte tím osobní údaje třetích osob. V tomto vztahu jste
+            <strong> Vy správcem</strong> osobních údajů těchto dlužníků a Poskytovatel
+            (Shelfy) je <strong>zpracovatelem</strong> ve smyslu čl. 4 odst. 8 GDPR.
+          </p>
+          <p style={P}>Jako správce odpovídáte zejména za:</p>
+          <ul style={UL}>
+            <li>Existenci právního základu pro zpracování (typicky oprávněný zájem věřitele evidovat
+              splatné půjčky, nebo souhlas dlužníka, nebo plnění smlouvy o zápůjčce — čl. 6 GDPR).</li>
+            <li>Splnění informační povinnosti vůči dlužníkům (čl. 13 GDPR) — že o nich vedete
+              záznam, jaké údaje, k jakému účelu a po jakou dobu.</li>
+            <li>Vyřizování práv dlužníků (přístup, oprava, výmaz) — k dílčímu výmazu slouží
+              akce „Anonymizovat dlužníka" v aplikaci.</li>
+          </ul>
+          <p style={P}>
+            Poskytovatel jako zpracovatel:
+          </p>
+          <ul style={UL}>
+            <li>Zpracovává údaje dlužníků pouze v rozsahu nezbytném k provozu Služby (zobrazení
+              v evidenci, propojení s půjčkami, zahrnutí do exportu vašich dat).</li>
+            <li>Neposkytuje údaje dlužníků třetím stranám mimo zpracovatele uvedené v oddíle 3.</li>
+            <li>Uplatňuje stejná technická a organizační opatření jako u ostatních dat Uživatele
+              (oddíl 9).</li>
+          </ul>
+          <p style={P}>
+            <strong>Anonymizace</strong> je nevratný mechanismus, kterým jako správce vymažete
+            identifikující údaje dlužníka (jméno, kontakt, poznámky) z evidence i ze záznamů
+            půjček. Záznam o tom, kdy a co si dlužník půjčil, zůstává jako účetní historie.
+            Pro úplný výmaz včetně historie je nutné smazat celý účet nebo individuálně
+            související záznamy půjček.
+          </p>
+        </div>
+
+        {/* ── 12. Změny ── */}
+        <div style={SECTION}>
+          <h2 style={H2}>12. Změny těchto zásad</h2>
           <p style={P}>
             O podstatných změnách vás budeme informovat e-mailem minimálně 14 dní předem.
             Aktuální verzi vždy najdete na této stránce. Drobné formulační úpravy (bez dopadu

--- a/frontend/src/pages/TermsPage.tsx
+++ b/frontend/src/pages/TermsPage.tsx
@@ -195,6 +195,15 @@ export function TermsPage() {
             <li>Poskytovatel neprodává a nesdílí data Uživatele za účelem reklamy.</li>
             <li>Uživatel může kdykoli exportovat svá data (JSON) nebo smazat celý účet v Nastavení.</li>
           </ul>
+          <p style={P}>
+            <strong>Údaje dlužníků.</strong> Pokud Uživatel ve Službě eviduje dlužníky (osoby,
+            kterým půjčuje knihy), je z hlediska GDPR <strong>správcem</strong> osobních
+            údajů těchto dlužníků; Poskytovatel je zpracovatelem. Uživatel odpovídá za
+            právní základ zpracování (souhlas, oprávněný zájem věřitele nebo plnění smlouvy
+            o zápůjčce), za splnění informační povinnosti vůči dlužníkům a za vyřizování
+            jejich práv. Detaily a odkaz na nástroj pro anonymizaci najdete v oddíle 11
+            Zásad ochrany osobních údajů.
+          </p>
         </div>
 
         {/* ── 9. Dostupnost a zálohy ── */}


### PR DESCRIPTION
Closes #252.

Earlier PR #258 only DRY-ified the legal metadata. The actual policy text was unchanged and still missed the new data flows the borrower epic shipped. This commit does the **content** audit #252 actually asked for.

## Privacy

- §2 "Jaké údaje" — new row for ``Údaje dlužníků`` (name, contact, optional notes). Names the librarian as data controller and Shelfy as processor; pointer to §11.
- §5 retention — names ``/borrowers → Anonymize`` and what it preserves vs. wipes.
- §6 rights — Right-to-erasure now points at anonymize for partial erasure; Right-to-portability now names that the export ships borrower records.
- **New §11** "Údaje dlužníků: vztah správce/zpracovatel" — the headline addition. Spells out: User is the controller, Shelfy is the processor, what each side is responsible for, anonymize as the partial-erasure mechanism.
- §10 (Changes) renumbered to §12.

## Terms

- §8 expanded with an explicit paragraph on the librarian's data-controller role for borrower records.

## Audit log

``docs/privacy-policy-audit-2026-05-12.md`` records what was checked, what changed, what's out of scope.

## Version

``LEGAL_DOC_VERSION 2.0 → 2.1``, ``LEGAL_DOC_EFFECTIVE_DATE`` bumped to 2026-05-12.

Pages are cs-only by design; no en variant to keep in sync (filed follow-up if/when needed).

## Test plan

- [x] ``cd frontend && npm run lint`` (clean)
- [x] ``cd frontend && npx tsc --noEmit`` (clean for touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy policy with detailed borrower data handling information
  * Clarified GDPR controller and processor responsibilities between users and the service
  * Expanded erasure and data portability disclosures
  * Updated legal document version and effective date

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/264)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->