### PR TITLE
feat(borrowers): retention-driven bulk anonymize by inactivity date (#246)

### DIFF
--- a/backend/app/api/borrowers.py
+++ b/backend/app/api/borrowers.py
@@ -14,11 +14,13 @@ from app.schemas.borrower import (
     BorrowerLoanItem,
     BorrowerMergeRequest,
     BorrowerResponse,
+    BorrowerRetentionAnonymizeRequest,
     BorrowerUpdate,
 )
 from app.services.borrower import (
     anonymize_borrower,
     bulk_anonymize_borrowers,
+    bulk_anonymize_borrowers_by_inactivity,
     create_borrower,
     get_borrower_or_404,
     list_borrowers_with_stats,
@@ -106,6 +108,28 @@ async def bulk_anonymize_borrowers_endpoint(
     library_id: uuid.UUID = Depends(require_editor_library),
 ) -> BorrowerBulkAnonymizeResponse:
     affected = await bulk_anonymize_borrowers(session, payload.ids, library_id)
+    return BorrowerBulkAnonymizeResponse(affected=affected)
+
+
+@router.post(
+    "/bulk-anonymize-by-date", response_model=BorrowerBulkAnonymizeResponse
+)
+async def bulk_anonymize_by_date_endpoint(
+    payload: BorrowerRetentionAnonymizeRequest,
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(require_editor_library),
+) -> BorrowerBulkAnonymizeResponse:
+    """Retention-driven bulk anonymize (#246). Anonymizes every borrower
+    in the active library whose most recent lending activity is before
+    ``inactive_since`` AND who has no active loan. Send ``dry_run=true``
+    to see the affected count without mutating any row.
+    """
+    affected = await bulk_anonymize_borrowers_by_inactivity(
+        session,
+        library_id,
+        payload.inactive_since,
+        dry_run=payload.dry_run,
+    )
     return BorrowerBulkAnonymizeResponse(affected=affected)
 
 

--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -91,3 +91,15 @@ class BorrowerBulkAnonymizeRequest(BaseModel):
 
 class BorrowerBulkAnonymizeResponse(BaseModel):
     affected: int
+
+
+class BorrowerRetentionAnonymizeRequest(BaseModel):
+    """Body for ``POST /api/v1/borrowers/bulk-anonymize-by-date`` (#246).
+
+    Anonymizes every borrower in the active library whose most recent
+    lending activity is before ``inactive_since`` AND who has no active
+    loan. Pass ``dry_run=True`` to get the count without mutating.
+    """
+
+    inactive_since: date
+    dry_run: bool = False

--- a/backend/app/services/borrower.py
+++ b/backend/app/services/borrower.py
@@ -428,3 +428,70 @@ async def bulk_anonymize_borrowers(
         library_id=str(library_id),
     )
     return affected
+
+
+async def select_borrowers_for_retention_anonymize(
+    session: AsyncSession, library_id: uuid.UUID, inactive_since: date
+) -> list[uuid.UUID]:
+    """Return ids of borrowers in ``library_id`` eligible for retention-driven
+    anonymization given ``inactive_since`` as the cutoff date.
+
+    A borrower is eligible when **all** of the following hold:
+
+    - They are not already anonymized.
+    - They have no active loans (any loan with ``returned_date IS NULL``).
+    - Their most recent ``lent_date`` is strictly before ``inactive_since``,
+      OR they have no loans at all. (Borrowers added through the API but
+      never lent to are also retention candidates — their record carries
+      personal data without serving any active purpose.)
+
+    Loan rows are scoped to the same library on both sides of every check
+    (defense in depth, mirroring the pattern in
+    ``list_borrowers_with_stats``).
+    """
+    has_active_loan = select(Loan.id).where(
+        Loan.borrower_id == Borrower.id,
+        Loan.library_id == library_id,
+        Loan.returned_date.is_(None),
+    )
+    has_recent_loan = select(Loan.id).where(
+        Loan.borrower_id == Borrower.id,
+        Loan.library_id == library_id,
+        Loan.lent_date >= inactive_since,
+    )
+
+    stmt = (
+        select(Borrower.id)
+        .where(
+            Borrower.library_id == library_id,
+            Borrower.anonymized_at.is_(None),
+            ~has_active_loan.exists(),
+            ~has_recent_loan.exists(),
+        )
+    )
+    result = await session.execute(stmt)
+    return [row[0] for row in result.all()]
+
+
+async def bulk_anonymize_borrowers_by_inactivity(
+    session: AsyncSession,
+    library_id: uuid.UUID,
+    inactive_since: date,
+    *,
+    dry_run: bool = False,
+) -> int:
+    """Retention-driven bulk anonymize for a library.
+
+    Wraps ``select_borrowers_for_retention_anonymize`` plus
+    ``bulk_anonymize_borrowers`` — issue #246. When ``dry_run`` is True,
+    returns the count that *would* be anonymized without mutating any row.
+    Otherwise actually anonymizes them and returns the number of newly
+    anonymized borrowers (matching the contract of
+    ``bulk_anonymize_borrowers``).
+    """
+    candidate_ids = await select_borrowers_for_retention_anonymize(
+        session, library_id, inactive_since
+    )
+    if dry_run or not candidate_ids:
+        return len(candidate_ids)
+    return await bulk_anonymize_borrowers(session, candidate_ids, library_id)

--- a/backend/tests/test_borrower_retention.py
+++ b/backend/tests/test_borrower_retention.py
@@ -1,0 +1,313 @@
+"""Tests for the retention-driven bulk anonymize endpoint (#246).
+
+``POST /api/v1/borrowers/bulk-anonymize-by-date`` body
+``{ inactive_since, dry_run? }`` selects every borrower in the active
+library whose most recent ``lent_date`` is strictly before
+``inactive_since`` AND who has no active loan, then anonymizes them.
+``dry_run=true`` returns the count without mutating.
+"""
+from collections.abc import AsyncIterator, Iterator
+from datetime import date, timedelta
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.book import Book
+from app.models.borrower import Borrower
+from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.loan import Loan
+from app.models.user import User
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url="sqlite+aiosqlite:///:memory:",
+        jwt_secret_key="test-secret",
+        jwt_algorithm="HS256",
+        access_token_expire_minutes=15,
+        refresh_token_expire_days=7,
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(test_session: AsyncSession, test_settings: Settings) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        yield test_session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _seed_owner_with_library(
+    session: AsyncSession, email: str = "owner@example.com"
+) -> tuple[User, Library]:
+    user = User(email=email, hashed_password=get_password_hash("secret"))
+    session.add(user)
+    await session.flush()
+    lib = Library(name=f"Library of {email}", created_by_user_id=user.id)
+    session.add(lib)
+    await session.flush()
+    session.add(LibraryMember(library_id=lib.id, user_id=user.id, role=LibraryRole.OWNER))
+    await session.commit()
+    await session.refresh(lib)
+    return user, lib
+
+
+async def _login(client: AsyncClient, email: str) -> dict[str, str]:
+    resp = await client.post(
+        "/api/v1/auth/login", json={"email": email, "password": "secret"}
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _book(library_id: uuid.UUID, title: str = "B") -> Book:
+    return Book(library_id=library_id, title=title)
+
+
+def _loan(
+    *,
+    library_id: uuid.UUID,
+    book_id: uuid.UUID,
+    borrower_id: uuid.UUID,
+    borrower_name: str,
+    lent_date: date,
+    returned_date: date | None = None,
+) -> Loan:
+    return Loan(
+        library_id=library_id,
+        book_id=book_id,
+        borrower_id=borrower_id,
+        borrower_name=borrower_name,
+        lent_date=lent_date,
+        returned_date=returned_date,
+        return_condition="good" if returned_date else None,
+    )
+
+
+# ── Selection rules ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dry_run_counts_eligible_borrowers_without_mutating(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_owner_with_library(test_session)
+    cutoff = date.today() - timedelta(days=365)
+
+    # Eligible: no loans at all, never lent to.
+    test_session.add(Borrower(library_id=lib.id, name="Standalone old"))
+    # Eligible: last loan ended way before the cutoff and is returned.
+    eligible_returned = Borrower(library_id=lib.id, name="Returned long ago")
+    test_session.add(eligible_returned)
+    await test_session.flush()
+    book = _book(lib.id)
+    test_session.add(book)
+    await test_session.flush()
+    test_session.add(_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=eligible_returned.id,
+        borrower_name="Returned long ago",
+        lent_date=cutoff - timedelta(days=400),
+        returned_date=cutoff - timedelta(days=380),
+    ))
+    # NOT eligible: lent to recently (within the cutoff window).
+    recent = Borrower(library_id=lib.id, name="Lent recently")
+    test_session.add(recent)
+    await test_session.flush()
+    test_session.add(_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=recent.id,
+        borrower_name="Lent recently",
+        lent_date=cutoff + timedelta(days=10),
+        returned_date=cutoff + timedelta(days=20),
+    ))
+    # NOT eligible: has an active loan (returned_date IS NULL).
+    has_active = Borrower(library_id=lib.id, name="Still has book")
+    test_session.add(has_active)
+    await test_session.flush()
+    test_session.add(_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=has_active.id,
+        borrower_name="Still has book",
+        lent_date=cutoff - timedelta(days=10),
+    ))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        resp = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": cutoff.isoformat(), "dry_run": True},
+            headers=headers,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"affected": 2}
+
+    # Nothing actually anonymized.
+    everyone = (await test_session.execute(select(Borrower))).scalars().all()
+    assert all(b.anonymized_at is None for b in everyone)
+
+
+@pytest.mark.asyncio
+async def test_real_run_anonymizes_only_eligible_rows(
+    test_session: AsyncSession,
+) -> None:
+    _, lib = await _seed_owner_with_library(test_session)
+    cutoff = date.today() - timedelta(days=180)
+
+    standalone = Borrower(library_id=lib.id, name="Standalone")
+    returned_old = Borrower(library_id=lib.id, name="Returned long ago")
+    recent = Borrower(library_id=lib.id, name="Lent recently")
+    has_active = Borrower(library_id=lib.id, name="Still has book")
+    test_session.add_all([standalone, returned_old, recent, has_active])
+    await test_session.flush()
+    book = _book(lib.id)
+    test_session.add(book)
+    await test_session.flush()
+
+    # returned_old: loan well before cutoff
+    test_session.add(_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=returned_old.id,
+        borrower_name="Returned long ago",
+        lent_date=cutoff - timedelta(days=200),
+        returned_date=cutoff - timedelta(days=190),
+    ))
+    # recent: loan within cutoff window
+    test_session.add(_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=recent.id,
+        borrower_name="Lent recently",
+        lent_date=cutoff + timedelta(days=1),
+        returned_date=cutoff + timedelta(days=10),
+    ))
+    # has_active: open loan
+    test_session.add(_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=has_active.id,
+        borrower_name="Still has book",
+        lent_date=cutoff - timedelta(days=50),
+    ))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        resp = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": cutoff.isoformat()},
+            headers=headers,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"affected": 2}
+
+    refreshed = {
+        row.id: row
+        for row in (await test_session.execute(select(Borrower))).scalars().all()
+    }
+    assert refreshed[standalone.id].anonymized_at is not None
+    assert refreshed[returned_old.id].anonymized_at is not None
+    # Untouched.
+    assert refreshed[recent.id].anonymized_at is None
+    assert refreshed[has_active.id].anonymized_at is None
+
+
+@pytest.mark.asyncio
+async def test_idempotent_re_run_returns_zero(test_session: AsyncSession) -> None:
+    _, lib = await _seed_owner_with_library(test_session)
+    cutoff = date.today()
+    test_session.add(Borrower(library_id=lib.id, name="Lonely"))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        first = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": cutoff.isoformat()},
+            headers=headers,
+        )
+        second = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": cutoff.isoformat()},
+            headers=headers,
+        )
+
+    assert first.json() == {"affected": 1}
+    assert second.json() == {"affected": 0}
+
+
+@pytest.mark.asyncio
+async def test_does_not_touch_other_libraries(test_session: AsyncSession) -> None:
+    _, own_lib = await _seed_owner_with_library(test_session, "own@example.com")
+    _, foreign_lib = await _seed_owner_with_library(test_session, "foreign@example.com")
+
+    own = Borrower(library_id=own_lib.id, name="Mine")
+    other = Borrower(library_id=foreign_lib.id, name="Theirs")
+    test_session.add_all([own, other])
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "own@example.com")
+        resp = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": date.today().isoformat()},
+            headers=headers,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"affected": 1}
+
+    refreshed = {
+        row.id: row
+        for row in (await test_session.execute(select(Borrower))).scalars().all()
+    }
+    assert refreshed[own.id].anonymized_at is not None
+    assert refreshed[other.id].anonymized_at is None
+
+
+@pytest.mark.asyncio
+async def test_requires_editor_role(test_session: AsyncSession) -> None:
+    _, lib = await _seed_owner_with_library(test_session)
+    # Add a viewer to that library.
+    viewer = User(email="viewer@example.com", hashed_password=get_password_hash("secret"))
+    test_session.add(viewer)
+    await test_session.flush()
+    test_session.add(LibraryMember(library_id=lib.id, user_id=viewer.id, role=LibraryRole.VIEWER))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "viewer@example.com")
+        resp = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": date.today().isoformat()},
+            headers=headers,
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_requires_authentication() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": date.today().isoformat()},
+        )
+    assert resp.status_code == 401

--- a/backend/tests/test_borrower_retention.py
+++ b/backend/tests/test_borrower_retention.py
@@ -351,6 +351,59 @@ async def test_dry_run_returns_zero_when_no_eligible_borrowers(
 
 
 @pytest.mark.asyncio
+async def test_bulk_anonymize_empty_id_list_is_a_no_op(test_session: AsyncSession) -> None:
+    """Service-level: ``bulk_anonymize_borrowers`` short-circuits cleanly when
+    given an empty id list. Previously only tested via the API which always
+    sends ≥1 id (the request schema rejects empty), so this branch had no
+    direct coverage."""
+    from app.services.borrower import bulk_anonymize_borrowers
+
+    _, lib = await _seed_owner_with_library(test_session)
+    affected = await bulk_anonymize_borrowers(test_session, [], lib.id)
+    assert affected == 0
+
+
+@pytest.mark.asyncio
+async def test_select_retention_candidates_treats_cutoff_as_strict(
+    test_session: AsyncSession,
+) -> None:
+    """``inactive_since`` is the open lower bound — a loan whose ``lent_date``
+    is exactly at the cutoff counts as "recent activity", so the borrower
+    stays ineligible."""
+    from app.services.borrower import select_borrowers_for_retention_anonymize
+
+    _, lib = await _seed_owner_with_library(test_session)
+    cutoff = date.today() - timedelta(days=100)
+
+    borrower_at_cutoff = Borrower(library_id=lib.id, name="At cutoff")
+    borrower_before = Borrower(library_id=lib.id, name="Before cutoff")
+    test_session.add_all([borrower_at_cutoff, borrower_before])
+    await test_session.flush()
+    book = _book(lib.id)
+    test_session.add(book)
+    await test_session.flush()
+    # Loan exactly on the cutoff date → recent → NOT eligible
+    test_session.add(_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=borrower_at_cutoff.id,
+        borrower_name="At cutoff",
+        lent_date=cutoff,
+        returned_date=cutoff + timedelta(days=1),
+    ))
+    # Loan strictly before → eligible
+    test_session.add(_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=borrower_before.id,
+        borrower_name="Before cutoff",
+        lent_date=cutoff - timedelta(days=1),
+        returned_date=cutoff,
+    ))
+    await test_session.commit()
+
+    ids = await select_borrowers_for_retention_anonymize(test_session, lib.id, cutoff)
+    assert borrower_before.id in ids
+    assert borrower_at_cutoff.id not in ids
+
+
+@pytest.mark.asyncio
 async def test_real_run_with_no_eligible_borrowers_is_a_no_op(
     test_session: AsyncSession,
 ) -> None:

--- a/backend/tests/test_borrower_retention.py
+++ b/backend/tests/test_borrower_retention.py
@@ -311,3 +311,70 @@ async def test_requires_authentication() -> None:
             json={"inactive_since": date.today().isoformat()},
         )
     assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_dry_run_returns_zero_when_no_eligible_borrowers(
+    test_session: AsyncSession,
+) -> None:
+    """Dry-run with no eligible borrowers must return affected=0 — covers
+    the short-circuit branch in ``bulk_anonymize_borrowers_by_inactivity``
+    where ``candidate_ids`` is empty and we skip the call into the
+    explicit-list primitive."""
+    _, lib = await _seed_owner_with_library(test_session)
+    cutoff = date.today() - timedelta(days=365)
+
+    # Seed a borrower with an active loan — never eligible for retention.
+    borrower = Borrower(library_id=lib.id, name="Has open loan")
+    test_session.add(borrower)
+    await test_session.flush()
+    book = _book(lib.id)
+    test_session.add(book)
+    await test_session.flush()
+    test_session.add(_loan(
+        library_id=lib.id, book_id=book.id, borrower_id=borrower.id,
+        borrower_name="Has open loan",
+        lent_date=cutoff - timedelta(days=10),
+    ))
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        resp = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": cutoff.isoformat(), "dry_run": True},
+            headers=headers,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"affected": 0}
+
+
+@pytest.mark.asyncio
+async def test_real_run_with_no_eligible_borrowers_is_a_no_op(
+    test_session: AsyncSession,
+) -> None:
+    """Real run (dry_run=false) with no eligible borrowers also short-circuits
+    and returns affected=0 without touching any row."""
+    _, lib = await _seed_owner_with_library(test_session)
+    cutoff = date.today() - timedelta(days=365)
+    # Seed an already-anonymized borrower; ``select_borrowers_for_retention``
+    # filters those out, so candidate list is empty.
+    pre_anon = Borrower(
+        library_id=lib.id,
+        name="Deleted borrower",
+        anonymized_at=date.today(),
+    )
+    test_session.add(pre_anon)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        resp = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": cutoff.isoformat()},
+            headers=headers,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"affected": 0}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2254,6 +2254,71 @@
         }
       }
     },
+    "/api/v1/borrowers/bulk-anonymize-by-date": {
+      "post": {
+        "tags": [
+          "borrowers"
+        ],
+        "summary": "Bulk Anonymize By Date Endpoint",
+        "description": "Retention-driven bulk anonymize (#246). Anonymizes every borrower\nin the active library whose most recent lending activity is before\n``inactive_since`` AND who has no active loan. Send ``dry_run=true``\nto see the affected count without mutating any row.",
+        "operationId": "bulk_anonymize_by_date_endpoint_api_v1_borrowers_bulk_anonymize_by_date_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BorrowerRetentionAnonymizeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BorrowerBulkAnonymizeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/borrowers/{borrower_id}/anonymize": {
       "post": {
         "tags": [
@@ -4918,6 +4983,26 @@
           "updated_at"
         ],
         "title": "BorrowerResponse"
+      },
+      "BorrowerRetentionAnonymizeRequest": {
+        "properties": {
+          "inactive_since": {
+            "type": "string",
+            "format": "date",
+            "title": "Inactive Since"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "inactive_since"
+        ],
+        "title": "BorrowerRetentionAnonymizeRequest",
+        "description": "Body for ``POST /api/v1/borrowers/bulk-anonymize-by-date`` (#246).\n\nAnonymizes every borrower in the active library whose most recent\nlending activity is before ``inactive_since`` AND who has no active\nloan. Pass ``dry_run=True`` to get the count without mutating."
       },
       "BorrowerUpdate": {
         "properties": {

--- a/frontend/src/components/BulkAnonymizeModal.test.tsx
+++ b/frontend/src/components/BulkAnonymizeModal.test.tsx
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/api', () => ({
+  bulkAnonymizeBorrowersByDate: vi.fn(),
+  formatApiError: (e: unknown) => String(e),
+}))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: (selector: (s: { showError: () => void; showSuccess: () => void }) => unknown) =>
+    selector({ showError: vi.fn(), showSuccess: vi.fn() }),
+}))
+
+import { bulkAnonymizeBorrowersByDate } from '../lib/api'
+import { BulkAnonymizeModal } from './BulkAnonymizeModal'
+
+function renderModal(onClose = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <BulkAnonymizeModal onClose={onClose} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('BulkAnonymizeModal', () => {
+  it('rejects an empty cutoff date with an inline error', async () => {
+    renderModal()
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('bulk-anon-preview'))
+    expect(screen.getByText('borrowers.bulk_anon_cutoff_required')).toBeInTheDocument()
+    expect(bulkAnonymizeBorrowersByDate).not.toHaveBeenCalled()
+  })
+
+  it('preview step calls the endpoint with dry_run=true and reveals the count', async () => {
+    vi.mocked(bulkAnonymizeBorrowersByDate).mockResolvedValueOnce({ affected: 7 })
+
+    renderModal()
+    const user = userEvent.setup()
+    await user.type(screen.getByTestId('bulk-anon-cutoff'), '2025-01-01')
+    await user.click(screen.getByTestId('bulk-anon-preview'))
+
+    await waitFor(() => {
+      expect(bulkAnonymizeBorrowersByDate).toHaveBeenCalledWith({
+        inactive_since: '2025-01-01',
+        dry_run: true,
+      })
+    })
+    expect(await screen.findByTestId('bulk-anon-summary')).toBeInTheDocument()
+    expect(screen.getByTestId('bulk-anon-confirm')).toBeInTheDocument()
+  })
+
+  it('confirm step calls the endpoint with dry_run=false and closes the modal on success', async () => {
+    vi.mocked(bulkAnonymizeBorrowersByDate)
+      .mockResolvedValueOnce({ affected: 3 })  // dry-run
+      .mockResolvedValueOnce({ affected: 3 })  // real run
+
+    const onClose = vi.fn()
+    renderModal(onClose)
+
+    const user = userEvent.setup()
+    await user.type(screen.getByTestId('bulk-anon-cutoff'), '2025-06-01')
+    await user.click(screen.getByTestId('bulk-anon-preview'))
+
+    await screen.findByTestId('bulk-anon-summary')
+    await user.click(screen.getByTestId('bulk-anon-confirm'))
+
+    await waitFor(() => {
+      const calls = vi.mocked(bulkAnonymizeBorrowersByDate).mock.calls
+      const lastCall = calls[calls.length - 1]
+      expect(lastCall?.[0]).toEqual({ inactive_since: '2025-06-01', dry_run: false })
+    })
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+
+  it('disables the confirm button when preview returns zero (nothing to do)', async () => {
+    vi.mocked(bulkAnonymizeBorrowersByDate).mockResolvedValueOnce({ affected: 0 })
+
+    renderModal()
+    const user = userEvent.setup()
+    await user.type(screen.getByTestId('bulk-anon-cutoff'), '2025-01-01')
+    await user.click(screen.getByTestId('bulk-anon-preview'))
+
+    const confirm = await screen.findByTestId('bulk-anon-confirm')
+    expect(confirm).toBeDisabled()
+    expect(confirm).toHaveTextContent('borrowers.bulk_anon_nothing_to_do')
+  })
+})

--- a/frontend/src/components/BulkAnonymizeModal.tsx
+++ b/frontend/src/components/BulkAnonymizeModal.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+
+import { bulkAnonymizeBorrowersByDate, formatApiError } from '../lib/api'
+import { useToastStore } from '../lib/toast-store'
+import { Modal } from './Modal'
+
+interface Props {
+  onClose: () => void
+}
+
+/**
+ * Retention-driven bulk anonymize (#246). Two-step flow:
+ *
+ *   step 1 — pick the ``inactive_since`` cutoff date, then call the
+ *            endpoint with ``dry_run: true`` to preview how many borrowers
+ *            would be anonymized.
+ *   step 2 — explicit "this cannot be undone" confirmation; calling the
+ *            endpoint again with ``dry_run: false`` runs the action and
+ *            invalidates the caches that carry borrower data.
+ *
+ * The user cannot reach step 2 without seeing the preview count first —
+ * a deliberate guardrail because the action is irreversible at scale.
+ */
+export function BulkAnonymizeModal({ onClose }: Props) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const showError = useToastStore((s) => s.showError)
+  const showSuccess = useToastStore((s) => s.showSuccess)
+
+  const [cutoff, setCutoff] = useState<string>('')
+  const [previewCount, setPreviewCount] = useState<number | null>(null)
+  const [isPreviewing, setIsPreviewing] = useState(false)
+  const [isConfirming, setIsConfirming] = useState(false)
+  const [confirmStep, setConfirmStep] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handlePreview() {
+    if (!cutoff) {
+      setError(t('borrowers.bulk_anon_cutoff_required'))
+      return
+    }
+    setError(null)
+    setIsPreviewing(true)
+    try {
+      const result = await bulkAnonymizeBorrowersByDate({
+        inactive_since: cutoff,
+        dry_run: true,
+      })
+      setPreviewCount(result.affected)
+      setConfirmStep(true)
+    } catch (err) {
+      setError(formatApiError(err))
+    } finally {
+      setIsPreviewing(false)
+    }
+  }
+
+  async function handleConfirm() {
+    if (!cutoff) return
+    setError(null)
+    setIsConfirming(true)
+    try {
+      const result = await bulkAnonymizeBorrowersByDate({
+        inactive_since: cutoff,
+        dry_run: false,
+      })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['borrowers'] }),
+        queryClient.invalidateQueries({ queryKey: ['borrower'] }),
+        queryClient.invalidateQueries({ queryKey: ['loans'] }),
+        queryClient.invalidateQueries({ queryKey: ['books'] }),
+      ])
+      showSuccess(
+        t('toast.bulk_anonymized', { count: result.affected }),
+      )
+      onClose()
+    } catch (err) {
+      showError(formatApiError(err))
+      setError(formatApiError(err))
+    } finally {
+      setIsConfirming(false)
+    }
+  }
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      label={t('borrowers.bulk_anon_title')}
+      maxWidth={520}
+    >
+      <div style={{ display: 'grid', gap: 12 }}>
+        <h3 style={{ margin: 0 }}>{t('borrowers.bulk_anon_title')}</h3>
+
+        {!confirmStep && (
+          <>
+            <p style={{ margin: 0, color: 'var(--sh-text-muted)', fontSize: 13 }}>
+              {t('borrowers.bulk_anon_picker_hint')}
+            </p>
+            <label
+              style={{
+                display: 'grid',
+                gap: 4,
+                fontSize: 14,
+                fontWeight: 500,
+                color: 'var(--sh-text-muted)',
+              }}
+            >
+              {t('borrowers.bulk_anon_cutoff_label')}
+              <input
+                className="sh-input"
+                type="date"
+                value={cutoff}
+                onChange={(event) => setCutoff(event.target.value)}
+                data-testid="bulk-anon-cutoff"
+              />
+            </label>
+            {error && (
+              <p style={{ margin: 0, color: 'var(--sh-red)', fontSize: 14 }}>{error}</p>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+              <button
+                type="button"
+                className="sh-btn-secondary"
+                onClick={onClose}
+                disabled={isPreviewing}
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                type="button"
+                className="sh-btn-primary"
+                onClick={handlePreview}
+                disabled={isPreviewing}
+                data-testid="bulk-anon-preview"
+              >
+                {isPreviewing
+                  ? t('borrowers.bulk_anon_previewing')
+                  : t('borrowers.bulk_anon_preview')}
+              </button>
+            </div>
+          </>
+        )}
+
+        {confirmStep && previewCount !== null && (
+          <>
+            <p data-testid="bulk-anon-summary" style={{ margin: 0 }}>
+              {t('borrowers.bulk_anon_summary', {
+                count: previewCount,
+                date: cutoff,
+              })}
+            </p>
+            {previewCount > 0 && (
+              <p
+                style={{ margin: 0, color: 'var(--sh-red)', fontWeight: 500 }}
+              >
+                {t('borrowers.bulk_anon_irreversible')}
+              </p>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+              <button
+                type="button"
+                className="sh-btn-secondary"
+                onClick={() => {
+                  setConfirmStep(false)
+                  setPreviewCount(null)
+                }}
+                disabled={isConfirming}
+              >
+                {t('borrowers.bulk_anon_back')}
+              </button>
+              <button
+                type="button"
+                data-testid="bulk-anon-confirm"
+                className="sh-btn-primary"
+                style={previewCount > 0 ? { background: 'var(--sh-red)' } : undefined}
+                onClick={handleConfirm}
+                disabled={isConfirming || previewCount === 0}
+              >
+                {isConfirming
+                  ? t('borrowers.bulk_anon_running')
+                  : previewCount === 0
+                    ? t('borrowers.bulk_anon_nothing_to_do')
+                    : t('borrowers.bulk_anon_confirm')}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -28,7 +28,10 @@
     "enrich_started": "Obohacování zahájeno. Data se brzy aktualizují.",
     "borrower_anonymized": "Dlužník anonymizován.",
     "borrower_saved": "Dlužník uložen.",
-    "borrowers_merged": "Dlužníci sloučeni."
+    "borrowers_merged": "Dlužníci sloučeni.",
+    "bulk_anonymized_one": "Anonymizován 1 dlužník.",
+    "bulk_anonymized_few": "Anonymizováni {{count}} dlužníci.",
+    "bulk_anonymized_other": "Anonymizováno {{count}} dlužníků."
   },
   "bulk": {
     "selected": "{{count}} vybráno",
@@ -772,6 +775,21 @@
     "merge_irreversible": "Tento krok nelze vrátit.",
     "merge_back": "Zpět",
     "merge_confirm": "Sloučit",
-    "merging": "Slučuji…"
+    "merging": "Slučuji…",
+    "bulk_anon_button": "Hromadně anonymizovat…",
+    "bulk_anon_title": "Hromadně anonymizovat neaktivní dlužníky",
+    "bulk_anon_picker_hint": "Zvol datum hranice. Dlužníci, jejichž nejnovější půjčka je starší — a kteří nemají žádnou aktivní půjčku — budou anonymizováni. Záznamy bez půjček jsou rovněž způsobilé.",
+    "bulk_anon_cutoff_label": "Neaktivní od",
+    "bulk_anon_cutoff_required": "Zvol datum hranice.",
+    "bulk_anon_preview": "Náhled počtu",
+    "bulk_anon_previewing": "Počítám…",
+    "bulk_anon_summary_one": "Bude anonymizován 1 dlužník (neaktivní od {{date}}).",
+    "bulk_anon_summary_few": "Budou anonymizováni {{count}} dlužníci (neaktivní od {{date}}).",
+    "bulk_anon_summary_other": "Bude anonymizováno {{count}} dlužníků (neaktivní od {{date}}).",
+    "bulk_anon_irreversible": "Tento krok nelze vrátit.",
+    "bulk_anon_back": "Zpět",
+    "bulk_anon_confirm": "Anonymizovat",
+    "bulk_anon_nothing_to_do": "Není koho anonymizovat",
+    "bulk_anon_running": "Anonymizuji…"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -28,7 +28,9 @@
     "enrich_started": "Enrichment started. Data will update shortly.",
     "borrower_anonymized": "Borrower anonymized.",
     "borrower_saved": "Borrower saved.",
-    "borrowers_merged": "Borrowers merged."
+    "borrowers_merged": "Borrowers merged.",
+    "bulk_anonymized_one": "1 borrower anonymized.",
+    "bulk_anonymized_other": "{{count}} borrowers anonymized."
   },
   "bulk": {
     "selected": "{{count}} selected",
@@ -769,6 +771,20 @@
     "merge_irreversible": "This cannot be undone.",
     "merge_back": "Back",
     "merge_confirm": "Merge",
-    "merging": "Merging…"
+    "merging": "Merging…",
+    "bulk_anon_button": "Bulk anonymize…",
+    "bulk_anon_title": "Bulk anonymize inactive borrowers",
+    "bulk_anon_picker_hint": "Pick a cutoff date. Borrowers whose most recent loan is older — and who have no active loans — will be anonymized. Records with no loans at all are also eligible.",
+    "bulk_anon_cutoff_label": "Inactive since",
+    "bulk_anon_cutoff_required": "Pick a cutoff date.",
+    "bulk_anon_preview": "Preview affected",
+    "bulk_anon_previewing": "Previewing…",
+    "bulk_anon_summary_one": "1 borrower will be anonymized (inactive since {{date}}).",
+    "bulk_anon_summary_other": "{{count}} borrowers will be anonymized (inactive since {{date}}).",
+    "bulk_anon_irreversible": "This cannot be undone.",
+    "bulk_anon_back": "Back",
+    "bulk_anon_confirm": "Anonymize",
+    "bulk_anon_nothing_to_do": "Nothing to anonymize",
+    "bulk_anon_running": "Anonymizing…"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -529,6 +529,25 @@ export async function anonymizeBorrower(id: string): Promise<Borrower> {
   return response.data
 }
 
+export interface BorrowerRetentionAnonymizeRequest {
+  inactive_since: string  // ISO date 'YYYY-MM-DD'
+  dry_run?: boolean
+}
+
+export interface BorrowerBulkAnonymizeResponse {
+  affected: number
+}
+
+export async function bulkAnonymizeBorrowersByDate(
+  payload: BorrowerRetentionAnonymizeRequest,
+): Promise<BorrowerBulkAnonymizeResponse> {
+  const response = await apiClient.post<BorrowerBulkAnonymizeResponse>(
+    '/api/v1/borrowers/bulk-anonymize-by-date',
+    payload,
+  )
+  return response.data
+}
+
 export async function uploadBookImage(file: File): Promise<UploadJobResponse> {
   const formData = new FormData()
   formData.append('image', file)

--- a/frontend/src/pages/BorrowersPage.tsx
+++ b/frontend/src/pages/BorrowersPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
+import { BulkAnonymizeModal } from '../components/BulkAnonymizeModal'
 import { NoResultsIcon } from '../components/EmptyStateIcons'
 import { useDebounce } from '../hooks/useDebounce'
 import { useBorrowers } from '../hooks/useBorrowers'
@@ -28,6 +29,7 @@ export function BorrowersPage() {
   // Server-side search means the input has to settle before we re-fetch.
   // 250ms is the standard "felt instant but not a query per keystroke" range.
   const debouncedSearch = useDebounce(searchInput, 250)
+  const [bulkAnonOpen, setBulkAnonOpen] = useState(false)
 
   // Reset to page 1 whenever the search query changes — otherwise typing on
   // page 4 could leave the user on an empty page that doesn't exist for the
@@ -60,12 +62,35 @@ export function BorrowersPage() {
 
   return (
     <main className="sh-main" style={{ padding: 24, maxWidth: 960, margin: '0 auto' }}>
-      <header style={{ marginBottom: 16 }}>
-        <h1 className="text-h2" style={{ margin: 0 }}>{t('borrowers.title')}</h1>
-        <p style={{ margin: '4px 0 0', color: 'var(--sh-text-muted)' }}>
-          {t('borrowers.subtitle')}
-        </p>
+      <header
+        style={{
+          marginBottom: 16,
+          display: 'flex',
+          gap: 12,
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <h1 className="text-h2" style={{ margin: 0 }}>{t('borrowers.title')}</h1>
+          <p style={{ margin: '4px 0 0', color: 'var(--sh-text-muted)' }}>
+            {t('borrowers.subtitle')}
+          </p>
+        </div>
+        <button
+          type="button"
+          data-testid="bulk-anonymize-button"
+          className="sh-btn-secondary"
+          onClick={() => setBulkAnonOpen(true)}
+        >
+          {t('borrowers.bulk_anon_button')}
+        </button>
       </header>
+
+      {bulkAnonOpen && (
+        <BulkAnonymizeModal onClose={() => setBulkAnonOpen(false)} />
+      )}
 
       <div style={{ marginBottom: 16, display: 'flex', gap: 12, alignItems: 'center' }}>
         <input


### PR DESCRIPTION
Closes #246. Supersedes the closed PR #260.

Codex's earlier #259 shipped a useful primitive (explicit-ID list bulk endpoint). This PR adds the **retention** feature on top of it — the "anonymize everyone inactive since X" action that #246's GDPR brief actually asks for.

## Backend

- New schema ``BorrowerRetentionAnonymizeRequest`` (``inactive_since``, ``dry_run``).
- New service ``select_borrowers_for_retention_anonymize`` — picks eligible borrowers: not yet anonymized, no active loan, every loan's ``lent_date`` strictly before cutoff (or no loans at all).
- New service ``bulk_anonymize_borrowers_by_inactivity`` — glues the selector to the existing ``bulk_anonymize_borrowers``. Honors ``dry_run``.
- New endpoint ``POST /api/v1/borrowers/bulk-anonymize-by-date`` (editor role, library-scoped).
- 7 backend tests: dry-run, real run picks only eligible rows, idempotent, no cross-library leakage, viewer 403, unauth 401.

## Frontend

- ``bulkAnonymizeBorrowersByDate`` API helper.
- ``BulkAnonymizeModal`` — two-step flow: pick cutoff → preview count (dry_run) → confirm (real run with explicit "cannot be undone" warning, red button). Preview count of 0 disables confirm with a "nothing to anonymize" label.
- "Bulk anonymize…" button added to the ``BorrowersPage`` header.
- 4 frontend tests.
- Full i18n cs+en (with ICU plurals).

## Out of scope

- Automatic nightly worker / ``retention_policy_months`` library setting. Manual-trigger only.
- Actor stamping (#245 introduces ``actor_user_id``; will flow into this endpoint via a one-line follow-up once #245 lands).

## Test plan

- [x] ``cd frontend && npm run lint`` (clean)
- [x] ``cd frontend && npx tsc --noEmit`` (clean for touched files)
- [x] ``cd frontend && npm test`` — 171/171
- [ ] ``cd backend && ruff check app tests``
- [ ] ``cd backend && mypy app tests``
- [ ] ``cd backend && TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests``
- [ ] OpenAPI regen — CI will flag; will sync in a follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retention-driven bulk anonymization of inactive borrowers added: two-step preview + confirm modal on the Borrowers page, a secondary “bulk anonymize” button, and a dry-run preview mode. Frontend API to preview/perform anonymization included.

* **Tests**
  * Expanded backend and frontend tests for preview, real run, idempotency, scoping, auth, and UI flows.

* **Localization**
  * Added Czech and English UI/toast strings for the flow.

* **Documentation**
  * OpenAPI updated with the new anonymization endpoint.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/265)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->