### PR TITLE
fix(borrowers): retention bulk stamps anonymized_by_user_id (#245 + #246)

### DIFF
--- a/backend/app/api/borrowers.py
+++ b/backend/app/api/borrowers.py
@@ -126,6 +126,7 @@ async def bulk_anonymize_by_date_endpoint(
     payload: BorrowerRetentionAnonymizeRequest,
     session: AsyncSession = Depends(get_db_session),
     library_id: uuid.UUID = Depends(require_editor_library),
+    current_user: User = Depends(get_current_user),
 ) -> BorrowerBulkAnonymizeResponse:
     """Retention-driven bulk anonymize (#246). Anonymizes every borrower
     in the active library whose most recent lending activity is before
@@ -137,6 +138,7 @@ async def bulk_anonymize_by_date_endpoint(
         library_id,
         payload.inactive_since,
         dry_run=payload.dry_run,
+        actor_user_id=current_user.id,
     )
     return BorrowerBulkAnonymizeResponse(affected=affected)
 

--- a/backend/app/services/borrower.py
+++ b/backend/app/services/borrower.py
@@ -515,6 +515,7 @@ async def bulk_anonymize_borrowers_by_inactivity(
     inactive_since: date,
     *,
     dry_run: bool = False,
+    actor_user_id: uuid.UUID | None = None,
 ) -> int:
     """Retention-driven bulk anonymize for a library.
 
@@ -524,10 +525,15 @@ async def bulk_anonymize_borrowers_by_inactivity(
     Otherwise actually anonymizes them and returns the number of newly
     anonymized borrowers (matching the contract of
     ``bulk_anonymize_borrowers``).
+
+    ``actor_user_id`` is threaded into the underlying per-row anonymize
+    so ``anonymized_by_user_id`` is stamped on each affected row (#245).
     """
     candidate_ids = await select_borrowers_for_retention_anonymize(
         session, library_id, inactive_since
     )
     if dry_run or not candidate_ids:
         return len(candidate_ids)
-    return await bulk_anonymize_borrowers(session, candidate_ids, library_id)
+    return await bulk_anonymize_borrowers(
+        session, candidate_ids, library_id, actor_user_id=actor_user_id
+    )

--- a/backend/tests/test_borrower_retention.py
+++ b/backend/tests/test_borrower_retention.py
@@ -404,6 +404,36 @@ async def test_select_retention_candidates_treats_cutoff_as_strict(
 
 
 @pytest.mark.asyncio
+async def test_retention_run_stamps_anonymized_by_user_id(
+    test_session: AsyncSession,
+) -> None:
+    """Retention bulk threads the calling user's id into
+    ``anonymized_by_user_id`` for every row it touches (#245 audit trail
+    + #246 retention compose)."""
+    owner, lib = await _seed_owner_with_library(test_session)
+    cutoff = date.today() - timedelta(days=100)
+    standalone = Borrower(library_id=lib.id, name="To anonymize")
+    test_session.add(standalone)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        resp = await client.post(
+            "/api/v1/borrowers/bulk-anonymize-by-date",
+            json={"inactive_since": cutoff.isoformat()},
+            headers=headers,
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"affected": 1}
+
+    refreshed = (
+        await test_session.execute(select(Borrower).where(Borrower.id == standalone.id))
+    ).scalar_one()
+    assert refreshed.anonymized_at is not None
+    assert refreshed.anonymized_by_user_id == owner.id
+
+
+@pytest.mark.asyncio
 async def test_real_run_with_no_eligible_borrowers_is_a_no_op(
     test_session: AsyncSession,
 ) -> None:


### PR DESCRIPTION
Promised follow-up from #265. The retention bulk endpoint shipped before #245's actor-audit thread landed, so the underlying ``bulk_anonymize_borrowers`` call was unstamped — affected rows had ``anonymized_at`` set but ``anonymized_by_user_id`` left null, inconsistent with every other anonymize path.

Threads ``current_user.id`` through ``bulk_anonymize_borrowers_by_inactivity`` into the underlying primitive. Same keyword-only optional shape as the rest of #245's service signatures.

New test pins the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bulk anonymization operations now track and record which user initiated them.

* **Tests**
  * Added test to validate initiator tracking during bulk anonymization operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/266)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->