### PR TITLE
docs(readme): refresh feature list + engineering highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,74 @@
 # Shelfy
 
-Shelfy is an AI-assisted home library manager focused on practical day-to-day use:
-scan shelves, keep book metadata tidy, and navigate a digital twin of your physical shelves.
+> AI-assisted home library manager: scan shelves, keep book metadata tidy,
+> lend books to people, and navigate a digital twin of your physical shelves.
 
-## What you can do (today)
-
-- 📚 Manage books with metadata (title, author, ISBN, publisher, language, year, notes).
-- 🧭 Organize books by room / furniture / shelf and reorder shelf positions.
-- 📸 Scan shelf photos and review extracted books before confirming.
-- ➕ Extend an existing shelf scan from a selected anchor book (append-right mode).
-- 🔎 Search with typo-tolerant matching (PostgreSQL FTS + trigram similarity).
-- 🎛 Filter books by reading status, language, publisher, and publication year range.
-- 🧱 Open a book in the digital twin and highlight/autoscroll to its spine.
-- 🔁 Background enrichment and processing via Celery workers.
+![Shelfy home](frontend/public/landing/demo-poster.webp)
 
 ---
 
-## Architecture (high level)
+## Features
+
+### Library management
+
+- 📚 Books with rich metadata (title, author, ISBN, publisher, language, year, notes, reading status)
+- 🧭 Organize by room / furniture / shelf with reorderable positions
+- 🔎 Typo-tolerant search (PostgreSQL FTS + `pg_trgm` similarity)
+- 🎛 Filter by reading status, language, publisher, publication-year range
+- 🧱 Digital twin view — open a book and autoscroll to its spine
+- 📥 CSV import / export
+
+### Scanning & enrichment
+
+- 📸 Shelf-photo scanning with review-before-confirm flow
+- ➕ Append-right scans anchored to an existing book
+- 🔁 Background enrichment via Celery (barcode, Gemini Vision, external metadata providers)
+
+### Collaboration & accounts
+
+- 👥 Shared libraries with per-user isolation
+- 🤝 Lend books to borrowers; merge, anonymize, audit trail
+- 🔐 Email + password auth, Google OAuth, password reset, HttpOnly cookies + CSRF
+- 🧑‍🏫 First-run onboarding wizard
+- 📤 GDPR data-export endpoint (`/auth/me/export`)
+
+### Operations
+
+- 💳 Stripe-backed subscriptions with plan limits and usage metering
+- ✉️ Transactional email via Resend
+- 📊 Prometheus metrics + structlog JSON logs
+- 🩹 Health / readiness probes
+- 🗄 Scheduled backup tasks via Celery beat
+
+---
+
+## Engineering highlights
+
+A few things worth a closer look while reading the code:
+
+- **Service-layer discipline.** FastAPI routers stay thin; business logic lives under `backend/app/services/`. Routers do not touch the DB directly. Codified in `docs/coding-standards.md` and `AGENTS.md`.
+- **OpenAPI drift gate.** `scripts/check-openapi-drift.sh` regenerates the spec from the live FastAPI app and fails CI if `docs/openapi.yaml` diverges — schema changes can't ship silently.
+- **Bundle-size + leaked-secret gates.** `scripts/check_bundle_budget.mjs` enforces a size budget; `scripts/check_bundle_secrets.mjs` scans the built frontend bundle for accidentally-shipped credentials.
+- **Real DB semantics in tests.** Tests run on SQLite for speed, but `conftest.py` forces `PRAGMA foreign_keys=ON` on every connection and `test_sqlite_pragma.py` asserts that dangling-FK inserts raise. Stops a class of "green in CI, broken in prod" bugs.
+- **Async end-to-end.** SQLAlchemy 2.x async, async services, Celery for background work, httpx for outbound. No sync DB calls in the request path.
+- **Coverage gate.** Backend tests run with `--cov-fail-under=80` in CI.
+- **Typed frontend.** TypeScript strict, no `any`. React Query for server state, Zustand for UI state only — never mixed.
+- **Migrations as a source of truth.** 24 Alembic migrations document the schema's evolution, including the borrower-anonymization audit trail and the `pg_trgm` extension for fuzzy search.
+- **Decision trail.** 8 ADRs under `docs/adr/` cover the non-obvious choices: FastAPI over Django, Celery for async image processing, MinIO for object storage, React over Next.js, Docker Swarm + Traefik over Kubernetes, Gemini Vision for spine recognition, HttpOnly cookies + CSRF over localStorage tokens, and the deliberate retention of legacy loan fields.
+- **Domain invariant checks.** `scripts/check_shelf_ordering_integrity.py` verifies the shelf-position invariant on demand — handy after migrations that touch ordering.
+
+---
+
+## Architecture
 
 ![Shelfy architecture](docs/assets/architecture-diagram.svg)
 
-- **Frontend**: React + Vite + React Query + React Router
-- **Backend**: FastAPI + async SQLAlchemy + Alembic + JWT auth
-- **Workers**: Celery (barcode / Gemini Vision / enrichment pipelines)
-- **Data & infra**: PostgreSQL, Redis, MinIO
-- **Observability**: structlog JSON logs + Prometheus metrics (`/metrics`)
+- **Frontend** — React 18 + Vite + React Query + React Router + Tailwind
+- **Backend** — FastAPI + async SQLAlchemy 2.x + Alembic + JWT/cookie auth
+- **Workers** — Celery (barcode, Gemini Vision, enrichment, email, backups)
+- **Data & infra** — PostgreSQL 16, Redis 7, MinIO
+- **Observability** — structlog JSON logs + Prometheus metrics at `/metrics`
+- **Deployment** — Docker Compose for dev, Docker Swarm + Traefik for production
 
 ---
 
@@ -44,13 +88,40 @@ When services are healthy:
 - Metrics: http://localhost:8000/metrics
 - MinIO Console: http://localhost:9001
 
-> Note: Shelf scan quality depends on `GEMINI_API_KEY`. Without it, OCR/vision fallback is limited.
+> Shelf-scan quality depends on `GEMINI_API_KEY`. Without it, the vision fallback is limited.
 
 ---
 
-## Environment variables (most important)
+## Developer checks
 
-The app reads from `.env` (see `.env.example`).
+```bash
+# Backend
+cd backend
+pip install -r requirements.txt -r requirements-dev.txt
+ruff check app tests
+mypy app tests
+TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests
+
+# Frontend
+cd ../frontend
+npm ci
+npm run lint
+npm test -- --run
+
+# End-to-end (Playwright)
+cd ../e2e
+npm ci
+npm run e2e
+```
+
+---
+
+## Environment variables
+
+The app reads from `.env` — see `.env.example` for the full list with defaults and comments.
+
+<details>
+<summary>Reference table of the most important variables</summary>
 
 ### Core runtime
 
@@ -103,11 +174,13 @@ The app reads from `.env` (see `.env.example`).
 |---|---|---:|---|
 | `VITE_API_BASE_URL` | `http://localhost:8000` | No | Base URL used by frontend API client. |
 
+</details>
+
 ---
 
 ## Troubleshooting
 
-### “Could not extract books from photo”
+### "Could not extract books from photo"
 
 Usually provider timeout or temporary Vision API failure.
 
@@ -117,7 +190,7 @@ Usually provider timeout or temporary Vision API failure.
 
 ### Frontend white/blank screen
 
-Most often runtime JS error in a recent UI change.
+Most often a runtime JS error in a recent UI change.
 
 ```bash
 cd infra
@@ -148,38 +221,23 @@ Swarm-specific vars are documented in `.env.example` and `docs/deployment.md`.
 
 ---
 
-## Developer checks
-
-```bash
-# Backend
-cd backend
-pip install -r requirements.txt -r requirements-dev.txt
-ruff check app tests
-mypy app tests
-TEST_DATABASE_URL=sqlite+aiosqlite:///./test.db pytest --cov=app --cov-fail-under=80 tests
-
-# Frontend
-cd ../frontend
-npm ci
-npm run lint
-npm test -- --run
-
-# End-to-end tests
-cd ../e2e
-npm ci
-npm run e2e
-```
-
----
-
 ## AI-assisted workflow
 
-Shelfy is intentionally developed with AI guardrails:
+Shelfy is built with an explicit AI operating model:
 
-1. Requirements are codified in `docs/project-spec.md` and `docs/implementation-phases.md`.
-2. `AGENTS.md` defines architectural constraints and code quality expectations.
-3. Changes are validated by static analysis/tests before merge.
-4. Key decisions are captured in `docs/adr/`.
+- **Codex** handles routine implementation (features, fixes, tests).
+- **Claude Code** designs architecture, reviews complex PRs, writes ADRs.
+- **CodeRabbit** reviews every PR automatically against coding standards.
+- **Human** owns direction, final review, and merges.
+
+Guardrails:
+
+1. Requirements live in `docs/project-spec.md` and `docs/implementation-phases.md`.
+2. `AGENTS.md` (root) defines architectural constraints; `.coderabbit.yaml` codifies review rules.
+3. Static analysis (ruff, mypy, eslint), tests, OpenAPI drift, and bundle-size/secret gates run on every PR.
+4. Non-obvious decisions go into `docs/adr/`.
+
+See `docs/ai-operating-model.md` for the full operating model.
 
 ---
 
@@ -191,6 +249,9 @@ Shelfy is intentionally developed with AI guardrails:
 - Implementation roadmap: `docs/implementation-phases.md`
 - Coding standards: `docs/coding-standards.md`
 - Deployment guide: `docs/deployment.md`
+- Incident runbook: `docs/runbooks/incidents.md`
+- AI operating model: `docs/ai-operating-model.md`
+
 ---
 
 ## Release readiness checklist
@@ -205,7 +266,13 @@ Before each production release:
 - [ ] No unresolved `frontend_runtime_error` bursts in monitoring
 
 Useful references:
+
 - Incident runbook: `docs/runbooks/incidents.md`
 - Monitoring and alerts: `docs/monitoring/README.md`
 - Prometheus rules: `docs/monitoring/alerts.prometheus.yml`
 
+---
+
+## License
+
+MIT — see [`LICENSE`](LICENSE).


### PR DESCRIPTION
## Summary

README's feature list was significantly behind reality. Borrowers/loans, shared libraries, onboarding wizard, CSV import/export, GDPR export, Google OAuth, password reset, Stripe billing and email notifications are all shipped but were unmentioned — which made the project look smaller than it is when viewed cold (e.g., by a recruiter landing on the public repo).

## Changes

- **Hero**: open with `frontend/public/landing/demo-poster.webp` instead of jumping straight from the title into the feature bullets.
- **Features**: regrouped into four sections (library, scanning, collaboration, operations) and added the missing capabilities.
- **Engineering highlights (new)**: short section calling out the non-obvious code-quality choices a reviewer would otherwise miss — service-layer rule, OpenAPI drift gate, bundle-size + leaked-secret gates, the SQLite FK pragma trick in `conftest.py`, async end-to-end, 80% coverage gate, React Query / Zustand split, 24-migration Alembic trail, 8 ADRs.
- **Env vars**: moved the table into `<details>` — useful as reference but it was pushing the interesting content way below the fold.
- **License section**: added, pointing at `LICENSE` from PR #268.
- Minor: smart quotes in troubleshooting, list polish.

No code changes.

## Test plan

- [ ] README renders on GitHub with the hero image visible at the top
- [ ] All `docs/...` links resolve
- [ ] `<details>` block expands to show env tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Restructured README with clearer product overview and improved navigation
* Reorganized feature categories and expanded "Engineering highlights" and "Architecture" sections
* Enhanced setup and developer guidance with explicit commands and coverage thresholds
* Added "AI-assisted workflow" section detailing operating model and guardrails
* Updated troubleshooting guidance and key documentation references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/269)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->