### PR TITLE
feat(borrowers): render audit trail on detail page (#261)

### DIFF
--- a/backend/app/api/borrowers.py
+++ b/backend/app/api/borrowers.py
@@ -11,6 +11,7 @@ from app.schemas.borrower import (
     BorrowerBulkAnonymizeRequest,
     BorrowerBulkAnonymizeResponse,
     BorrowerCreate,
+    BorrowerDetailResponse,
     BorrowerListItem,
     BorrowerListResponse,
     BorrowerLoanItem,
@@ -24,7 +25,7 @@ from app.services.borrower import (
     bulk_anonymize_borrowers,
     bulk_anonymize_borrowers_by_inactivity,
     create_borrower,
-    get_borrower_or_404,
+    get_borrower_detail_or_404,
     list_borrowers_with_stats,
     list_loans_for_borrower,
     merge_borrowers,
@@ -75,14 +76,27 @@ async def create_borrower_endpoint(
     return BorrowerResponse.model_validate(borrower)
 
 
-@router.get("/{borrower_id}", response_model=BorrowerResponse)
+@router.get("/{borrower_id}", response_model=BorrowerDetailResponse)
 async def read_borrower(
     borrower_id: uuid.UUID,
     session: AsyncSession = Depends(get_db_session),
     library_id: uuid.UUID = Depends(get_library_id),
-) -> BorrowerResponse:
-    borrower = await get_borrower_or_404(session, borrower_id, library_id)
-    return BorrowerResponse.model_validate(borrower)
+) -> BorrowerDetailResponse:
+    # Detail endpoint enriches the base response with resolved audit-actor
+    # emails (#261). The three LEFT JOINs live in
+    # ``get_borrower_detail_or_404`` and are deliberately *not* in the cheap
+    # list endpoint.
+    borrower = await get_borrower_detail_or_404(session, borrower_id, library_id)
+    return BorrowerDetailResponse(
+        **BorrowerResponse.model_validate(borrower).model_dump(),
+        created_by_email=borrower.created_by.email if borrower.created_by else None,
+        anonymized_by_email=(
+            borrower.anonymized_by.email if borrower.anonymized_by else None
+        ),
+        merged_into_by_email=(
+            borrower.merged_into_by.email if borrower.merged_into_by else None
+        ),
+    )
 
 
 @router.patch("/{borrower_id}", response_model=BorrowerResponse)

--- a/backend/app/models/borrower.py
+++ b/backend/app/models/borrower.py
@@ -11,6 +11,7 @@ from app.db.base import Base
 
 if TYPE_CHECKING:
     from app.models.loan import Loan
+    from app.models.user import User
 
 
 class Borrower(Base):
@@ -53,3 +54,28 @@ class Borrower(Base):
     )
 
     loans: Mapped[list[Loan]] = relationship(back_populates="borrower")
+
+    # ── Audit-trail relationships (read-only) ────────────────────────────────
+    # ``selectinload``-able resolvers for ``BorrowerDetailResponse`` (#261).
+    # ``viewonly=True`` because writes go through the *_user_id columns
+    # directly in services.borrower; ``lazy="raise"`` keeps the list view
+    # cheap by failing loud if anyone tries to lazy-load these without
+    # eager-loading them first.
+    created_by: Mapped[User | None] = relationship(
+        "User",
+        foreign_keys=[created_by_user_id],
+        viewonly=True,
+        lazy="raise",
+    )
+    anonymized_by: Mapped[User | None] = relationship(
+        "User",
+        foreign_keys=[anonymized_by_user_id],
+        viewonly=True,
+        lazy="raise",
+    )
+    merged_into_by: Mapped[User | None] = relationship(
+        "User",
+        foreign_keys=[merged_into_by_user_id],
+        viewonly=True,
+        lazy="raise",
+    )

--- a/backend/app/schemas/borrower.py
+++ b/backend/app/schemas/borrower.py
@@ -41,6 +41,21 @@ class BorrowerResponse(BaseModel):
     updated_at: datetime
 
 
+class BorrowerDetailResponse(BorrowerResponse):
+    """Borrower detail response with audit actors resolved to user emails (#261).
+
+    Used only by ``GET /api/v1/borrowers/{borrower_id}`` to avoid paying the
+    cost of 3 extra JOINs on the cheap list endpoint. Each field is the
+    resolved email of the user pointed to by the corresponding ``*_user_id``
+    column, or ``None`` when the column is NULL (legacy rows, deleted users,
+    or actions performed without an authenticated user context).
+    """
+
+    created_by_email: str | None = None
+    anonymized_by_email: str | None = None
+    merged_into_by_email: str | None = None
+
+
 class BorrowerListItem(BorrowerResponse):
     """Borrower record enriched with lending-activity stats for the overview page."""
 

--- a/backend/app/services/borrower.py
+++ b/backend/app/services/borrower.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timezone
 from fastapi import HTTPException, status
 from sqlalchemy import and_, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 import structlog
 
 from app.models.book import Book
@@ -221,6 +222,32 @@ async def get_borrower_or_404(
 ) -> Borrower:
     result = await session.execute(
         select(Borrower).where(Borrower.id == borrower_id, Borrower.library_id == library_id)
+    )
+    borrower = result.scalar_one_or_none()
+    if borrower is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Borrower not found")
+    return borrower
+
+
+async def get_borrower_detail_or_404(
+    session: AsyncSession, borrower_id: uuid.UUID, library_id: uuid.UUID
+) -> Borrower:
+    """Fetch a borrower with audit-trail user relationships eager-loaded (#261).
+
+    Same 404 semantics as :func:`get_borrower_or_404` but the returned row
+    has ``.created_by``, ``.anonymized_by`` and ``.merged_into_by`` populated
+    so the detail endpoint can render audit actor emails without a second
+    round-trip. Three LEFT JOINs at read time — acceptable on a single-row
+    fetch, deliberately not paid by the list endpoint.
+    """
+    result = await session.execute(
+        select(Borrower)
+        .where(Borrower.id == borrower_id, Borrower.library_id == library_id)
+        .options(
+            selectinload(Borrower.created_by),
+            selectinload(Borrower.anonymized_by),
+            selectinload(Borrower.merged_into_by),
+        )
     )
     borrower = result.scalar_one_or_none()
     if borrower is None:

--- a/backend/tests/test_borrower_audit.py
+++ b/backend/tests/test_borrower_audit.py
@@ -386,6 +386,45 @@ async def test_detail_endpoint_returns_404_for_unknown_borrower(
 
 
 @pytest.mark.asyncio
+async def test_patch_borrower_updates_contact_without_touching_audit_columns(
+    test_session: AsyncSession,
+) -> None:
+    """``PATCH /api/v1/borrowers/{id}`` is the editor's "fix a typo" path —
+    it must update non-identity fields (contact / notes) without resetting
+    or stamping any of the audit-trail columns. Previously had no direct
+    API-level coverage in the test suite, surfacing as a hole during the
+    #261 coverage push."""
+    owner, lib = await _seed_user_with_library(test_session)
+    borrower = Borrower(
+        library_id=lib.id,
+        name="Alice",
+        contact="old@example.com",
+        created_by_user_id=owner.id,
+    )
+    test_session.add(borrower)
+    await test_session.commit()
+    await test_session.refresh(borrower)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        resp = await client.patch(
+            f"/api/v1/borrowers/{borrower.id}",
+            json={"contact": "new@example.com"},
+            headers=headers,
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["contact"] == "new@example.com"
+    assert body["name"] == "Alice"
+    # Audit columns survive a PATCH untouched — the editor is fixing
+    # contact data, not performing an identity-touching mutation.
+    assert body["created_by_user_id"] == str(owner.id)
+    assert body["anonymized_by_user_id"] is None
+    assert body["merged_into_by_user_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_detail_endpoint_returns_404_for_cross_library_borrower(
     test_session: AsyncSession,
 ) -> None:

--- a/backend/tests/test_borrower_audit.py
+++ b/backend/tests/test_borrower_audit.py
@@ -228,3 +228,139 @@ async def test_audit_fields_are_null_for_legacy_rows(test_session: AsyncSession)
     assert body["created_by_user_id"] is None
     assert body["anonymized_by_user_id"] is None
     assert body["merged_into_by_user_id"] is None
+    # #261: legacy rows ship null *_email resolvers too.
+    assert body["created_by_email"] is None
+    assert body["anonymized_by_email"] is None
+    assert body["merged_into_by_email"] is None
+
+
+# ── #261: detail endpoint resolves audit user IDs to emails ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_detail_endpoint_resolves_created_by_email(
+    test_session: AsyncSession,
+) -> None:
+    """Creating a borrower then fetching the detail page surfaces the
+    creator's email under ``created_by_email`` (#261)."""
+    owner, _lib = await _seed_user_with_library(test_session)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        created = await client.post(
+            "/api/v1/borrowers", json={"name": "Alice"}, headers=headers
+        )
+        assert created.status_code == 201
+        borrower_id = created.json()["id"]
+
+        detail = await client.get(f"/api/v1/borrowers/{borrower_id}", headers=headers)
+
+    assert detail.status_code == 200
+    body = detail.json()
+    assert body["created_by_user_id"] == str(owner.id)
+    assert body["created_by_email"] == "owner@example.com"
+    # The other two actors haven't acted yet — both columns and resolvers null.
+    assert body["anonymized_by_email"] is None
+    assert body["merged_into_by_email"] is None
+
+
+@pytest.mark.asyncio
+async def test_detail_endpoint_resolves_all_three_audit_emails(
+    test_session: AsyncSession,
+) -> None:
+    """When a borrower has gone through create → merge → anonymize by
+    different editors, all three resolver fields point at the right users."""
+    _owner, lib = await _seed_user_with_library(test_session)
+    editor_a = await _add_editor(test_session, lib.id, "editor-a@example.com")
+    editor_b = await _add_editor(test_session, lib.id, "editor-b@example.com")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        owner_headers = await _login(client, "owner@example.com")
+        # Owner creates a source + target.
+        target = await client.post(
+            "/api/v1/borrowers", json={"name": "Alice Liddell"}, headers=owner_headers
+        )
+        source = await client.post(
+            "/api/v1/borrowers", json={"name": "Alice (dup)"}, headers=owner_headers
+        )
+        target_id = target.json()["id"]
+        source_id = source.json()["id"]
+
+        # Editor A merges source into target.
+        editor_a_headers = await _login(client, "editor-a@example.com")
+        merged = await client.post(
+            f"/api/v1/borrowers/{target_id}/merge",
+            json={"source_id": source_id},
+            headers=editor_a_headers,
+        )
+        assert merged.status_code == 200
+
+        # Editor B anonymizes the merged target.
+        editor_b_headers = await _login(client, "editor-b@example.com")
+        anonymized = await client.post(
+            f"/api/v1/borrowers/{target_id}/anonymize", headers=editor_b_headers
+        )
+        assert anonymized.status_code == 200
+
+        detail = await client.get(
+            f"/api/v1/borrowers/{target_id}", headers=owner_headers
+        )
+
+    assert detail.status_code == 200
+    body = detail.json()
+    assert body["created_by_email"] == "owner@example.com"
+    assert body["merged_into_by_email"] == "editor-a@example.com"
+    assert body["anonymized_by_email"] == "editor-b@example.com"
+
+
+@pytest.mark.asyncio
+async def test_detail_endpoint_resolves_null_when_user_deleted(
+    test_session: AsyncSession,
+) -> None:
+    """``ondelete=SET NULL`` on the FK means an actor who later deletes their
+    account leaves the audit columns at NULL — the resolver must mirror that
+    by returning ``None`` for the email (no fallback string, no exception)."""
+    _, lib = await _seed_user_with_library(test_session)
+    # Simulate a row whose creator's account was deleted: column is NULL.
+    borrower = Borrower(
+        library_id=lib.id, name="Orphan", created_by_user_id=None
+    )
+    test_session.add(borrower)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        detail = await client.get(f"/api/v1/borrowers/{borrower.id}", headers=headers)
+
+    assert detail.status_code == 200
+    body = detail.json()
+    assert body["created_by_user_id"] is None
+    assert body["created_by_email"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_endpoint_does_not_include_resolved_emails(
+    test_session: AsyncSession,
+) -> None:
+    """The list endpoint stays on ``BorrowerResponse`` (no audit resolver
+    fields). Confirms the separation between the cheap list path and the
+    detail path — list must not pay for 3 JOINs per row."""
+    owner, _lib = await _seed_user_with_library(test_session)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        await client.post(
+            "/api/v1/borrowers", json={"name": "Alice"}, headers=headers
+        )
+        listing = await client.get("/api/v1/borrowers", headers=headers)
+
+    assert listing.status_code == 200
+    items = listing.json()["items"]
+    assert len(items) == 1
+    item = items[0]
+    # ID columns survive into list (cheap, no JOIN).
+    assert item["created_by_user_id"] == str(owner.id)
+    # Resolved-email fields are NOT shipped on list rows.
+    assert "created_by_email" not in item
+    assert "anonymized_by_email" not in item
+    assert "merged_into_by_email" not in item

--- a/backend/tests/test_borrower_audit.py
+++ b/backend/tests/test_borrower_audit.py
@@ -271,8 +271,10 @@ async def test_detail_endpoint_resolves_all_three_audit_emails(
     """When a borrower has gone through create → merge → anonymize by
     different editors, all three resolver fields point at the right users."""
     _owner, lib = await _seed_user_with_library(test_session)
-    editor_a = await _add_editor(test_session, lib.id, "editor-a@example.com")
-    editor_b = await _add_editor(test_session, lib.id, "editor-b@example.com")
+    # Seed two editors with logins; we identify them later by their email
+    # in the resolver assertions, so we don't need the User return values.
+    await _add_editor(test_session, lib.id, "editor-a@example.com")
+    await _add_editor(test_session, lib.id, "editor-b@example.com")
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         owner_headers = await _login(client, "owner@example.com")
@@ -364,3 +366,41 @@ async def test_list_endpoint_does_not_include_resolved_emails(
     assert "created_by_email" not in item
     assert "anonymized_by_email" not in item
     assert "merged_into_by_email" not in item
+
+
+@pytest.mark.asyncio
+async def test_detail_endpoint_returns_404_for_unknown_borrower(
+    test_session: AsyncSession,
+) -> None:
+    """Missing detail-id path through ``get_borrower_detail_or_404`` — exercises
+    the 404 branch added in #261. Without this the new function's
+    ``raise HTTPException`` line stays uncovered."""
+    await _seed_user_with_library(test_session)
+    bogus = uuid.uuid4()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        headers = await _login(client, "owner@example.com")
+        resp = await client.get(f"/api/v1/borrowers/{bogus}", headers=headers)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_detail_endpoint_returns_404_for_cross_library_borrower(
+    test_session: AsyncSession,
+) -> None:
+    """A borrower that exists but lives in a different library is reported
+    as 404 — same path as a truly missing id. Confirms the library scope
+    is enforced on the new detail endpoint, mirroring the contract of
+    ``get_borrower_or_404`` it parallels."""
+    _, _ = await _seed_user_with_library(test_session, "own@example.com")
+    _, foreign_lib = await _seed_user_with_library(test_session, "foreign@example.com")
+    foreign = Borrower(library_id=foreign_lib.id, name="Foreign borrower")
+    test_session.add(foreign)
+    await test_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        own_headers = await _login(client, "own@example.com")
+        resp = await client.get(f"/api/v1/borrowers/{foreign.id}", headers=own_headers)
+
+    assert resp.status_code == 404

--- a/backend/tests/test_borrower_audit.py
+++ b/backend/tests/test_borrower_audit.py
@@ -385,6 +385,19 @@ async def test_detail_endpoint_returns_404_for_unknown_borrower(
     assert resp.status_code == 404
 
 
+def test_normalize_name_handles_none_input() -> None:
+    """``_normalize_name`` is called by ``link_loans_to_borrowers`` which
+    always passes a non-null ``loan.borrower_name`` (the column is
+    ``Mapped[str]``), so the ``None`` branch sits unreached in production.
+    Pin it with a direct unit test — protects the contract for any
+    future caller that legitimately needs to normalize a nullable
+    string."""
+    from app.services.borrower import _normalize_name
+
+    assert _normalize_name(None) == ""
+    assert _normalize_name("  alice   liddell  ") == "alice liddell"
+
+
 @pytest.mark.asyncio
 async def test_patch_borrower_updates_contact_without_touching_audit_columns(
     test_session: AsyncSession,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2032,7 +2032,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BorrowerResponse"
+                  "$ref": "#/components/schemas/BorrowerDetailResponse"
                 }
               }
             }
@@ -4679,6 +4679,145 @@
           "name"
         ],
         "title": "BorrowerCreate"
+      },
+      "BorrowerDetailResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "contact": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contact"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "anonymized_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Anonymized At"
+          },
+          "created_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By User Id"
+          },
+          "anonymized_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Anonymized By User Id"
+          },
+          "merged_into_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merged Into By User Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "created_by_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By Email"
+          },
+          "anonymized_by_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Anonymized By Email"
+          },
+          "merged_into_by_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merged Into By Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "contact",
+          "notes",
+          "anonymized_at",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "BorrowerDetailResponse",
+        "description": "Borrower detail response with audit actors resolved to user emails (#261).\n\nUsed only by ``GET /api/v1/borrowers/{borrower_id}`` to avoid paying the\ncost of 3 extra JOINs on the cheap list endpoint. Each field is the\nresolved email of the user pointed to by the corresponding ``*_user_id``\ncolumn, or ``None`` when the column is NULL (legacy rows, deleted users,\nor actions performed without an authenticated user context)."
       },
       "BorrowerListItem": {
         "properties": {

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -790,6 +790,11 @@
     "bulk_anon_back": "Zpět",
     "bulk_anon_confirm": "Anonymizovat",
     "bulk_anon_nothing_to_do": "Není koho anonymizovat",
-    "bulk_anon_running": "Anonymizuji…"
+    "bulk_anon_running": "Anonymizuji…",
+    "audit_section_title": "Auditní stopa",
+    "audit_created_by": "Vytvořil(a) {{email}} — {{date}}",
+    "audit_anonymized_by": "Anonymizoval(a) {{email}} — {{date}}",
+    "audit_merged_into_by": "Sloučení provedl(a) {{email}}",
+    "audit_actor_unknown": "neznámý uživatel"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -785,6 +785,11 @@
     "bulk_anon_back": "Back",
     "bulk_anon_confirm": "Anonymize",
     "bulk_anon_nothing_to_do": "Nothing to anonymize",
-    "bulk_anon_running": "Anonymizing…"
+    "bulk_anon_running": "Anonymizing…",
+    "audit_section_title": "Audit trail",
+    "audit_created_by": "Created by {{email}} on {{date}}",
+    "audit_anonymized_by": "Anonymized by {{email}} on {{date}}",
+    "audit_merged_into_by": "Merged by {{email}}",
+    "audit_actor_unknown": "unknown user"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   BillingStatus,
   Borrower,
   BorrowerCreateRequest,
+  BorrowerDetail,
   BorrowerListParams,
   BorrowerListResponse,
   BorrowerLoanItem,
@@ -496,8 +497,11 @@ export async function listBorrowers(params: BorrowerListParams = {}): Promise<Bo
   return response.data
 }
 
-export async function getBorrower(id: string): Promise<Borrower> {
-  const response = await apiClient.get<Borrower>(`/api/v1/borrowers/${id}`)
+export async function getBorrower(id: string): Promise<BorrowerDetail> {
+  // Detail endpoint enriches the base shape with resolved audit-actor
+  // emails (#261). Mutation endpoints below still return ``Borrower`` —
+  // the audit footer re-fetches via this query on success.
+  const response = await apiClient.get<BorrowerDetail>(`/api/v1/borrowers/${id}`)
   return response.data
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -47,6 +47,15 @@ export interface Borrower {
   updated_at: string
 }
 
+/** Detail-page borrower (#261). Adds resolved user emails for each of
+ *  the audit-trail FKs. Only shipped by ``GET /api/v1/borrowers/{id}``;
+ *  list rows stay on the cheap ``Borrower`` shape (no extra JOINs). */
+export interface BorrowerDetail extends Borrower {
+  created_by_email: string | null
+  anonymized_by_email: string | null
+  merged_into_by_email: string | null
+}
+
 export interface BorrowerListItem extends Borrower {
   active_loans: number
   total_loans: number

--- a/frontend/src/pages/BorrowerDetailPage.test.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.test.tsx
@@ -24,10 +24,10 @@ vi.mock('../lib/toast-store', () => ({
 }))
 
 import { anonymizeBorrower, getBorrower, listBorrowerLoans, listBorrowers, mergeBorrowers, updateBorrower } from '../lib/api'
-import type { Borrower, BorrowerLoanItem } from '../lib/types'
+import type { BorrowerDetail, BorrowerLoanItem } from '../lib/types'
 import { BorrowerDetailPage } from './BorrowerDetailPage'
 
-function makeBorrower(overrides: Partial<Borrower> = {}): Borrower {
+function makeBorrower(overrides: Partial<BorrowerDetail> = {}): BorrowerDetail {
   return {
     id: 'b-alice',
     name: 'Alice Liddell',
@@ -37,6 +37,12 @@ function makeBorrower(overrides: Partial<Borrower> = {}): Borrower {
     created_by_user_id: null,
     anonymized_by_user_id: null,
     merged_into_by_user_id: null,
+    // #261: detail-only resolved emails. Defaulted to null so legacy-row
+    // tests don't need to set them; populate via ``overrides`` when testing
+    // the audit footer.
+    created_by_email: null,
+    anonymized_by_email: null,
+    merged_into_by_email: null,
     created_at: '2026-05-01T00:00:00Z',
     updated_at: '2026-05-01T00:00:00Z',
     ...overrides,
@@ -436,5 +442,100 @@ describe('BorrowerDetailPage', () => {
       expect(screen.queryByText('borrowers.anonymize_irreversible')).not.toBeInTheDocument()
     })
     expect(anonymizeBorrower).not.toHaveBeenCalled()
+  })
+
+  // ── Audit footer (#261) ─────────────────────────────────────────────────
+  //
+  // The i18n test mock (src/test/setup.ts) returns bare keys and does NOT
+  // run param interpolation, so these tests assert on testid presence
+  // rather than the interpolated email/date strings. The interpolation
+  // itself is exercised by the live i18next runtime in e2e.
+
+  it('hides the audit footer entirely when every audit FK is null (legacy row)', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(makeBorrower())
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    await screen.findByText('Alice Liddell')
+    expect(screen.queryByTestId('borrower-audit-footer')).not.toBeInTheDocument()
+  })
+
+  it('renders the "created by …" line when the creator is set', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(
+      makeBorrower({
+        created_by_user_id: 'u-owner',
+        created_by_email: 'owner@example.com',
+      }),
+    )
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    expect(await screen.findByTestId('borrower-audit-footer')).toBeInTheDocument()
+    expect(screen.getByTestId('audit-created-by')).toBeInTheDocument()
+    // The other two lines stay hidden because their columns are NULL.
+    expect(screen.queryByTestId('audit-anonymized-by')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('audit-merged-into-by')).not.toBeInTheDocument()
+  })
+
+  it('renders all three audit lines for a borrower with full audit history', async () => {
+    vi.mocked(getBorrower).mockResolvedValue(
+      makeBorrower({
+        name: 'Deleted borrower',
+        contact: null,
+        notes: null,
+        anonymized_at: '2026-05-07T00:00:00Z',
+        created_by_user_id: 'u-owner',
+        created_by_email: 'owner@example.com',
+        anonymized_by_user_id: 'u-editor-b',
+        anonymized_by_email: 'editor-b@example.com',
+        merged_into_by_user_id: 'u-editor-a',
+        merged_into_by_email: 'editor-a@example.com',
+      }),
+    )
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    await screen.findByTestId('borrower-audit-footer')
+    expect(screen.getByTestId('audit-created-by')).toBeInTheDocument()
+    expect(screen.getByTestId('audit-anonymized-by')).toBeInTheDocument()
+    expect(screen.getByTestId('audit-merged-into-by')).toBeInTheDocument()
+  })
+
+  it('still renders the line when the actor user_id is set but the email is null', async () => {
+    // ondelete=SET NULL nulls both column and email in the normal case, but
+    // if a partial state ever shipped (transient backend bug, schema drift),
+    // the section must still render — the UI falls back to a localized
+    // "unknown user" label via the audit_actor_unknown key.
+    vi.mocked(getBorrower).mockResolvedValue(
+      makeBorrower({
+        created_by_user_id: 'u-vanished',
+        created_by_email: null,
+      }),
+    )
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    expect(await screen.findByTestId('audit-created-by')).toBeInTheDocument()
+  })
+
+  it('does not render the anonymized-by line when anonymized_at is unset (mid-state safety)', async () => {
+    // The anonymized line is gated on BOTH the user_id AND the timestamp.
+    // A row with user_id set but anonymized_at NULL should never happen
+    // (services always stamp both together) — but if it does, the line stays
+    // hidden so the user isn't shown "anonymized by X on —".
+    vi.mocked(getBorrower).mockResolvedValue(
+      makeBorrower({
+        created_by_user_id: 'u-owner',
+        created_by_email: 'owner@example.com',
+        anonymized_by_user_id: 'u-editor',
+        anonymized_by_email: 'editor@example.com',
+        anonymized_at: null,
+      }),
+    )
+    vi.mocked(listBorrowerLoans).mockResolvedValue([])
+    renderPage()
+
+    await screen.findByTestId('borrower-audit-footer')
+    expect(screen.queryByTestId('audit-anonymized-by')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/BorrowerDetailPage.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.tsx
@@ -20,6 +20,91 @@ function formatDate(value: string | null, locale: string): string {
   }
 }
 
+interface AuditFooterProps {
+  /** Audit data sourced from BorrowerDetailResponse (#261). */
+  createdByUserId: string | null
+  createdByEmail: string | null
+  createdAt: string
+  anonymizedByUserId: string | null
+  anonymizedByEmail: string | null
+  anonymizedAt: string | null
+  mergedIntoByUserId: string | null
+  mergedIntoByEmail: string | null
+  locale: string
+}
+
+function AuditFooter({
+  createdByUserId,
+  createdByEmail,
+  createdAt,
+  anonymizedByUserId,
+  anonymizedByEmail,
+  anonymizedAt,
+  mergedIntoByUserId,
+  mergedIntoByEmail,
+  locale,
+}: AuditFooterProps) {
+  const { t } = useTranslation()
+
+  // Hide entirely on legacy rows where every audit FK is NULL. Once at least
+  // one column is populated, render the section with whichever lines apply.
+  if (createdByUserId === null && anonymizedByUserId === null && mergedIntoByUserId === null) {
+    return null
+  }
+
+  const unknown = t('borrowers.audit_actor_unknown')
+
+  return (
+    <aside
+      data-testid="borrower-audit-footer"
+      style={{
+        marginTop: 32,
+        paddingTop: 16,
+        borderTop: '1px solid var(--sh-border)',
+        fontSize: 12,
+        color: 'var(--sh-text-muted)',
+      }}
+    >
+      <h3
+        style={{
+          margin: '0 0 4px',
+          fontSize: 12,
+          fontWeight: 600,
+          letterSpacing: '0.04em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {t('borrowers.audit_section_title')}
+      </h3>
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 2 }}>
+        {createdByUserId !== null && (
+          <li data-testid="audit-created-by">
+            {t('borrowers.audit_created_by', {
+              email: createdByEmail ?? unknown,
+              date: formatDate(createdAt, locale),
+            })}
+          </li>
+        )}
+        {anonymizedByUserId !== null && anonymizedAt !== null && (
+          <li data-testid="audit-anonymized-by">
+            {t('borrowers.audit_anonymized_by', {
+              email: anonymizedByEmail ?? unknown,
+              date: formatDate(anonymizedAt, locale),
+            })}
+          </li>
+        )}
+        {mergedIntoByUserId !== null && (
+          <li data-testid="audit-merged-into-by">
+            {t('borrowers.audit_merged_into_by', {
+              email: mergedIntoByEmail ?? unknown,
+            })}
+          </li>
+        )}
+      </ul>
+    </aside>
+  )
+}
+
 interface LoanRowProps {
   loan: BorrowerLoanItem
   locale: string
@@ -262,6 +347,18 @@ export function BorrowerDetailPage() {
           </ul>
         )}
       </section>
+
+      <AuditFooter
+        createdByUserId={borrower.created_by_user_id}
+        createdByEmail={borrower.created_by_email ?? null}
+        createdAt={borrower.created_at}
+        anonymizedByUserId={borrower.anonymized_by_user_id}
+        anonymizedByEmail={borrower.anonymized_by_email ?? null}
+        anonymizedAt={borrower.anonymized_at}
+        mergedIntoByUserId={borrower.merged_into_by_user_id}
+        mergedIntoByEmail={borrower.merged_into_by_email ?? null}
+        locale={i18n.language}
+      />
 
       {confirmOpen && (
         <Modal


### PR DESCRIPTION
## Summary

Closes the loop opened by #245 — the actor-audit columns
(`created_by_user_id`, `anonymized_by_user_id`, `merged_into_by_user_id`)
are now visible on the borrower detail page as a small "Audit trail"
footer.

- **Backend:** `BorrowerDetailResponse` extends `BorrowerResponse` with three resolved `*_email` fields. Detail endpoint uses `selectinload` on three viewonly `User` relationships — 3 LEFT JOINs at read time, paid only on the single-row detail endpoint. List endpoint stays on `BorrowerResponse` (cheap path stays cheap).
- **Frontend:** `AuditFooter` component on `BorrowerDetailPage`. Each line gated on the corresponding `*_user_id` being set; falls back to a localized "unknown user" when email is null. Hidden entirely for legacy rows.
- **i18n:** cs + en strings.
- **Tests:** +5 backend (resolver returns email, all three lines, null-when-deleted, list shape unchanged) + +5 frontend (legacy hidden, single line, full history, fallback label, mid-state safety).

## Design notes

- Picked Option A from the issue spec (enrich response) over Option B (`GET /api/v1/users/{id}` resolver) because the audit footer is the only consumer right now. If a second resolver use case shows up, splitting it out is a one-PR refactor.
- `lazy="raise"` on the new viewonly relationships ensures the list endpoint screams loud if anyone ever forgets to selectinload — defense against silent JOIN bloat regressing the list view.
- Mutation endpoints (anonymize / merge / update) still return the base `BorrowerResponse`. The frontend invalidates the detail query on success, which refetches via the enriched endpoint.

## Test plan

- [ ] backend / lint
- [ ] backend / tests (new tests in `test_borrower_audit.py`)
- [ ] frontend (vitest suite, 21 tests pass locally)
- [ ] OpenAPI artifact regenerated (CI verifies — will pull diff from logs if drift fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Borrower detail pages now display an audit trail section showing who created, anonymized, and merged borrower records, with resolved email addresses and action timestamps.
  * Audit trail information is available in Czech and English localization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->