### PR TITLE
feat(loans): debounced server-side borrower search in lend modal (#250)

### DIFF
--- a/frontend/src/components/LendBookModal.test.tsx
+++ b/frontend/src/components/LendBookModal.test.tsx
@@ -50,6 +50,28 @@ function mockBorrowersList(items: BorrowerListItem[]): void {
   })
 }
 
+/**
+ * Mock that returns a different subset based on the ``search`` param —
+ * simulates the server-side ``ILIKE %search%`` filter. Used to exercise the
+ * #250 part-2 fix where the typed name is sent to the server instead of
+ * the modal client-side-matching against a fixed first-page slice.
+ */
+function mockServerSideSearch(allBorrowers: BorrowerListItem[]): void {
+  vi.mocked(listBorrowers).mockImplementation(async ({ search } = {}) => {
+    const query = search?.trim().toLowerCase() ?? ''
+    const filtered = query
+      ? allBorrowers.filter((b) => b.name.toLowerCase().includes(query))
+      : allBorrowers
+    const page = filtered.slice(0, 100) // server PAGE_SIZE_CAP
+    return {
+      total: filtered.length,
+      page: 1,
+      page_size: 100,
+      items: page,
+    }
+  })
+}
+
 function makeLoan(): Loan {
   return {
     id: 'loan-1',
@@ -329,5 +351,61 @@ describe('LendBookModal', () => {
 
     expect(await screen.findByText('loans.borrower_name_required')).toBeInTheDocument()
     expect(createLoan).not.toHaveBeenCalled()
+  })
+
+  // ── #250 part 2: server-side debounced search ─────────────────────────
+
+  it('sends the typed name to the server as a search query (debounced)', async () => {
+    mockServerSideSearch([
+      makeBorrower({ id: 'b-alice', name: 'Alice Liddell' }),
+      makeBorrower({ id: 'b-bob', name: 'Bob Builder' }),
+    ])
+    renderModal()
+    await waitFor(() => expect(listBorrowers).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('loans.borrower_name'), 'Alice')
+
+    // After the debounce window elapses, the server is asked for borrowers
+    // matching the typed name. The most recent call carries the typed string
+    // in the ``search`` param — that's the contract that fixes the #250
+    // ">100 borrowers silent duplicate" gap.
+    await waitFor(() => {
+      const calls = vi.mocked(listBorrowers).mock.calls
+      const lastSearch = calls[calls.length - 1]?.[0]?.search
+      expect(lastSearch).toBe('Alice')
+    })
+  })
+
+  it('finds and links a borrower whose record lives beyond the first page (>100 borrowers)', async () => {
+    // Library of 150 borrowers; the one the user wants (id ``b-target``) sits
+    // at index 130 — well past the picker's 100-row page cap. The old
+    // "fetch first 100 once, match client-side" approach would silently fall
+    // back to typed-name and create a duplicate Borrower row. With
+    // server-side search the typed name finds them regardless of position.
+    const sea: BorrowerListItem[] = Array.from({ length: 150 }, (_, i) => {
+      const id = i === 130 ? 'b-target' : `b-${i}`
+      const name = i === 130 ? 'Zelda Page-Three' : `Filler ${i}`
+      return makeBorrower({ id, name, contact: i === 130 ? 'zelda@x.com' : null })
+    })
+    mockServerSideSearch(sea)
+    vi.mocked(createLoan).mockResolvedValue(makeLoan())
+    renderModal()
+    await waitFor(() => expect(listBorrowers).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('loans.borrower_name'), 'Zelda Page-Three')
+
+    // The server-filtered result includes Zelda even though she would have
+    // been at index 130 in the unfiltered list. The matcher sees her and
+    // surfaces the single-match hint.
+    expect(await screen.findByTestId('borrower-existing-match')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'loans.lend_submit' }))
+
+    await waitFor(() => expect(createLoan).toHaveBeenCalledTimes(1))
+    const payload = vi.mocked(createLoan).mock.calls[0][1]
+    expect(payload).toMatchObject({ borrower_id: 'b-target' })
+    expect(payload).not.toHaveProperty('borrower_name')
   })
 })

--- a/frontend/src/components/LendBookModal.tsx
+++ b/frontend/src/components/LendBookModal.tsx
@@ -2,9 +2,12 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useBorrowers } from '../hooks/useBorrowers'
+import { useDebounce } from '../hooks/useDebounce'
 import { useCreateLoan } from '../hooks/useLoans'
 import type { Borrower, LoanCreateRequest } from '../lib/types'
 import { Modal } from './Modal'
+
+const PICKER_PAGE_SIZE = 100
 
 function normalize(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, ' ')
@@ -35,13 +38,24 @@ export function LendBookModal({ bookId, onClose }: { bookId: string; onClose: ()
   const [error, setError] = useState<string | null>(null)
   const createLoan = useCreateLoan(bookId)
   const { t } = useTranslation()
-  // The picker grabs up to the page-size cap (100) of borrowers in one shot.
-  // This is a deliberate trade-off vs. live server-side search: the typed-name
-  // fallback in `create_loan` still produces a correct loan even when the
-  // exact match isn't on the first page, so the only downside in a >100-row
-  // library is occasional duplicate Borrower creation. If that turns out to
-  // matter, swap this for a debounced ``search`` query.
-  const borrowersQuery = useBorrowers({ pageSize: 100 })
+  // Server-side search-as-you-type (#250 follow-up). Mirrors the merge picker:
+  // 250 ms debounce on the typed name, fetch one page of up to 100 results.
+  // The empty-string case is handled by ``listBorrowers`` (passes
+  // ``search=undefined`` so the server returns the unfiltered first page,
+  // which keeps the open-the-modal-and-glance UX intact).
+  //
+  // Why this matters: with the old "load first 100 once" approach, a library
+  // with >100 borrowers could silently produce duplicate Borrower rows for a
+  // borrower that happened to land on page 2+ — the matcher never saw them,
+  // fell through to the typed-name flow, and ``create_loan`` happily made a
+  // new record. With debounced search the typed name is sent to the server,
+  // which finds the match regardless of pagination position.
+  const debouncedName = useDebounce(borrowerName, 250)
+  const borrowersQuery = useBorrowers({
+    search: debouncedName,
+    page: 1,
+    pageSize: PICKER_PAGE_SIZE,
+  })
   // Anonymized borrowers are excluded from the picker — there's no sensible
   // reason to lend a new book to one (and they all carry the same sentinel
   // name, which would clutter the suggestions).


### PR DESCRIPTION
## Summary

Closes the second failure mode from #250 (the disambiguation UX from #271 covered the first).

**Old:** ``useBorrowers({ pageSize: 100 })`` fetched the first 100 rows once at modal open. In a library with >100 borrowers, anyone past row 100 was invisible to the matcher — typing their exact name fell through to the typed-name flow and ``create_loan`` made a duplicate ``Borrower`` row.

**New:** ``useDebounce(typedName, 250ms)`` → ``useBorrowers({ search: debouncedName, pageSize: 100 })``. The server runs ``ILIKE %query%`` so the match is found regardless of pagination position.

Same pattern as ``MergeBorrowerModal`` (#240) — two related modals now follow one search idiom.

## Behaviour preserved

- Empty input → trimmed to ``search=undefined`` → server returns unfiltered first page → datalist autocompletes on open.
- Disambiguation panel still fires for >1 exact match.
- Typed-name escape hatch still creates new Borrower on submit-without-pick.

## Tests

- +1: debounced ``search`` query reaches the server with the typed name.
- +1: 150-borrower fixture, target at index 130 — the exact regression the old flow couldn't catch (silent duplicate).

New helper ``mockServerSideSearch`` simulates ``ILIKE %search%`` filtering so tests exercise the real narrowing, not a static slice.

Closes #250 entirely (part 1 was #271).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Borrower search in the lending modal now provides live, server-side filtered suggestions as you type with optimized performance.

* **Bug Fixes**
  * Fixed borrower selection to correctly locate and link borrowers regardless of their position in the full borrower list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->