### PR TITLE
chore(infra): pin self-hosted runner image to actions-runner 2.334.0

### DIFF
--- a/infra/docker-compose.runner.yml
+++ b/infra/docker-compose.runner.yml
@@ -35,12 +35,18 @@
 
 services:
   github-runner:
-    image: myoung34/github-runner:latest
-    # Tracked at HEAD intentionally for now — GitHub deprecates older
-    # actions-runner versions aggressively (a server-side "this runner is
-    # too old, will not dispatch jobs to it" gate). Re-pin to a specific
-    # tag after observing the runtime version reported in the container
-    # logs and verifying CI works.
+    image: myoung34/github-runner:2.334.0
+    # Pinned to the actions-runner version that's been serving CI without
+    # incident since the runner was first deployed on 2026-05-12 (sha
+    # 4c0228ba…). Tracking ``:latest`` was intentional during bring-up so
+    # GitHub's "runner too old → won't dispatch jobs" server-side gate
+    # couldn't surprise us; now that we've watched the pipeline behave
+    # for a week we want reproducibility instead.
+    #
+    # To upgrade: bump the tag here, ``docker compose pull``, ``up -d``.
+    # Verify the runner shows Online in repo settings before merging.
+    # Don't track ``:latest`` again — re-introduces the unannounced-
+    # upgrade risk that motivated the pin.
     restart: unless-stopped
     environment:
       # Either REPO_URL + ACCESS_TOKEN (PAT) — token is auto-rotated by the


### PR DESCRIPTION
## Summary

Track-``:latest`` was a deliberate choice during #267 bring-up so we wouldn't trip GitHub's "runner too old, won't dispatch jobs" gate. A week of clean CI behaviour later, swap to a specific tag so future restarts are reproducible.

\`2.334.0\` is the actions-runner version the current container was built from (image \`sha256:4c0228ba…\` pulled 2026-05-12).

## Behaviour change

- **No immediate runtime change.** The running container keeps its current image until \`docker compose pull && up -d\` is invoked.
- After re-deploy, the runner pulls the pinned tag instead of head. Same binary as today, just no longer a moving target.

## Test plan

- [ ] CI green on this PR (no runtime change yet — just a YAML edit)
- [ ] After merge, re-deploy runner manually:
  \`\`\`bash
  docker compose --env-file infra/.env.prod.local \\
    -f infra/docker-compose.yml \\
    -f infra/docker-compose.runner.yml \\
    pull github-runner
  docker compose ... up -d github-runner
  \`\`\`
- [ ] Verify runner shows Online in repo settings (label \`self-hosted, shelfy\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions runner infrastructure updated to use a pinned container version for enhanced consistency and reliability of continuous integration processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->