### PR TITLE
fix(worker): strip any SQLAlchemy driver suffix from DATABASE_URL

### DIFF
--- a/worker/borrower_maintenance_tasks.py
+++ b/worker/borrower_maintenance_tasks.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 
 import psycopg2
 import psycopg2.extras
@@ -42,10 +43,17 @@ log = logging.getLogger(__name__)
 # package — same trade-off as the other worker tasks).
 _ANONYMIZED_NAME = "Deleted borrower"
 
-_DATABASE_URL = (
-    os.environ.get("DATABASE_URL", "postgresql://shelfy:shelfy@postgres:5432/shelfy")
-    .replace("postgresql+asyncpg://", "postgresql://")
-    .replace("+asyncpg", "")
+# Strip any SQLAlchemy driver suffix (``postgresql+psycopg2://`` /
+# ``postgresql+asyncpg://`` / etc.) before handing the URL to psycopg2,
+# which only understands the bare ``postgresql://`` DSN form.
+#
+# Necessary because prod compose passes ``DATABASE_URL=postgresql+psycopg2://…``
+# (see infra/docker-compose.prod.yml) — the explicit driver suffix made
+# initial debugging easier but psycopg2 itself doesn't parse it.
+_DATABASE_URL = re.sub(
+    r"^postgresql\+\w+://",
+    "postgresql://",
+    os.environ.get("DATABASE_URL", "postgresql://shelfy:shelfy@postgres:5432/shelfy"),
 )
 
 

--- a/worker/email_tasks.py
+++ b/worker/email_tasks.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import datetime
 import logging
 import os
+import re
 
 import httpx
 import psycopg2
@@ -30,10 +31,14 @@ log = logging.getLogger(__name__)
 
 # ── Config ─────────────────────────────────────────────────────────────────────
 
-_DATABASE_URL = os.environ.get(
-    "DATABASE_URL",
-    "postgresql://shelfy:shelfy@postgres:5432/shelfy",
-).replace("postgresql+asyncpg://", "postgresql://").replace("+asyncpg", "")
+# Strip any SQLAlchemy driver suffix before handing the URL to psycopg2 —
+# prod compose passes ``postgresql+psycopg2://…`` which psycopg2 itself
+# cannot parse. Prior chain only handled ``+asyncpg``.
+_DATABASE_URL = re.sub(
+    r"^postgresql\+\w+://",
+    "postgresql://",
+    os.environ.get("DATABASE_URL", "postgresql://shelfy:shelfy@postgres:5432/shelfy"),
+)
 
 _REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
 _RESEND_API_KEY = os.environ.get("RESEND_API_KEY", "")


### PR DESCRIPTION
## Summary

Production-incident fix. After the #244 PR #3 deploy, the new \`borrowers.gc_merge_undo_logs\` Celery task fired on its first beat tick and raised:

\`\`\`
ProgrammingError('invalid dsn: missing "=" after
"postgresql+psycopg2://shelfy:...@postgres:5432/shelfy"
in connection info string')
\`\`\`

## Root cause

\`infra/docker-compose.prod.yml\` passes \`DATABASE_URL=postgresql+psycopg2://...\` to the worker + beat containers. psycopg2 doesn't understand the \`+psycopg2\` driver-suffix segment — it expects a bare \`postgresql://\` DSN.

The existing worker chain only stripped the async variant:

\`\`\`python
.replace("postgresql+asyncpg://", "postgresql://").replace("+asyncpg", "")
\`\`\`

…so \`+psycopg2\` slipped through.

## Fix

Switch to a regex that strips *any* SQLAlchemy driver suffix (matches the pattern \`backup_tasks.py\` already uses):

\`\`\`python
_DATABASE_URL = re.sub(
    r"^postgresql\\+\\w+://",
    "postgresql://",
    os.environ.get("DATABASE_URL", "..."),
)
\`\`\`

Applied to both files that had the broken chain:
- \`worker/borrower_maintenance_tasks.py\` — broke immediately (new task fires every 5/30 min)
- \`worker/email_tasks.py\` — latent bug, would have surfaced at the next 08:00 UTC trial-reminder cron

\`backup_tasks.py\` already handled this correctly. \`celery_app.py\` uses a different code path (SQLAlchemy \`create_engine\`, which accepts the driver suffix).

## Test plan

- [ ] CI green
- [ ] After merge + auto-deploy: \`docker compose logs worker\` shows the next beat fire of \`gc_merge_undo_logs\` succeeding (returns \`{"removed": 0}\` if no expired rows, no \`ProgrammingError\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)