### PR TITLE
chore(worker): wire Sentry SDK so task exceptions stop vanishing

### DIFF
--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -50,6 +50,38 @@ _configure_structlog()
 logger = structlog.get_logger()
 
 
+def _init_sentry() -> None:
+    """Initialize Sentry SDK in the worker process when ``SENTRY_DSN``
+    is set. Mirrors the backend bootstrap in ``app/main.py:_init_sentry``.
+
+    Imports are lazy so the overhead is zero when Sentry is disabled
+    (e.g. local dev without a DSN). ``CeleryIntegration`` adds breadcrumbs
+    + automatic capture for every task exception — exactly what would
+    have flagged the ``+psycopg2`` DSN bug (PR #277) the moment it fired
+    in prod instead of waiting for someone to grep the worker log.
+    """
+    if not worker_settings.sentry_dsn:
+        return
+    import sentry_sdk
+    from sentry_sdk.integrations.celery import CeleryIntegration
+    from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
+    sentry_sdk.init(
+        dsn=worker_settings.sentry_dsn,
+        environment=worker_settings.environment,
+        integrations=[CeleryIntegration(), SqlalchemyIntegration()],
+        # Conservative trace sampling — worker is mostly cron-style, the
+        # interesting signal is exceptions, not p95 latency. Backend has
+        # 0.1 because user-facing requests benefit more from tracing.
+        traces_sample_rate=0.05,
+        send_default_pii=False,
+    )
+    logger.info("sentry_initialized", environment=worker_settings.environment)
+
+
+_init_sentry()
+
+
 class Base(DeclarativeBase):
     pass
 

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -9,3 +9,4 @@ numpy==2.2.3
 httpx==0.28.1
 structlog==24.4.0
 pydantic-settings==2.10.1
+sentry-sdk>=2.0.0

--- a/worker/settings.py
+++ b/worker/settings.py
@@ -15,6 +15,14 @@ class WorkerSettings(BaseSettings):
     celery_result_backend: str = "redis://redis:6379/1"
     gemini_api_key: str | None = None
 
+    # Sentry. ``SENTRY_DSN`` was already being passed to the worker
+    # container in infra/docker-compose.prod.yml, but the worker had no
+    # ``sentry-sdk`` dependency and never called ``sentry_sdk.init`` —
+    # task exceptions silently vanished into the journal. Adding the
+    # field here so pydantic stops silently dropping it on ``extra=ignore``.
+    sentry_dsn: str | None = None
+    environment: str = "production"
+
     # Enrichment rate limiting (SaaS-friendly defaults)
     enrichment_delay_seconds: float = 1.5         # delay between API calls per book
     enrichment_max_per_minute: int = 30           # max enrichment API calls per minute


### PR DESCRIPTION
## Summary

Prod has been passing \`SENTRY_DSN\` to the worker + beat containers since the Sentry project was set up — but the worker had no \`sentry-sdk\` dependency and never called \`sentry_sdk.init\`. Every task exception was caught by structlog and written to the journal, then forgotten until someone manually grepped the worker log.

That's exactly how the \`+psycopg2\` DSN bug (PR #277) stayed hidden — Sentry would have paged within seconds of the first beat tick if it had been wired up.

## Changes

- \`worker/settings.py\` — add \`sentry_dsn\` + \`environment\` fields (previously \`extra=ignore\` was silently dropping the env var).
- \`worker/requirements.txt\` — \`sentry-sdk>=2.0.0\`.
- \`worker/celery_app.py\` — lazy \`_init_sentry\` mirroring \`backend/app/main.py:_init_sentry\`. \`CeleryIntegration\` for task-level capture + breadcrumbs, \`SqlalchemyIntegration\` for SQL spans. \`traces_sample_rate=0.05\` since worker is mostly cron-style (exceptions matter more than p95).

## Deferred

- Telegram weekly worker summary
- \`/health/workers\` backend endpoint

Both pending a baseline of what Sentry captures in normal operation. If the volume is noisy (autoretry storms, transient DB hiccups), we'll either filter or revisit. If it's quiet, Sentry alone is sufficient.

## Test plan

- [ ] CI green (no worker test suite in CI; e2e will boot the worker with the new container)
- [ ] After auto-deploy: \`docker compose logs worker --since=2m\` shows \`sentry_initialized\` line on startup
- [ ] Trigger a synthetic failure (or wait for one) and verify it lands in Sentry within ~1 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Sentry for error monitoring and performance tracking in the worker, enabling real-time issue diagnostics.
  * Worker configuration now supports Sentry DSN settings for flexible monitoring deployment.

* **Chores**
  * Added Sentry SDK dependency to worker environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->