### PR TITLE
docs(changelog): cover #244 borrower undo + #261 audit footer + #250 lend modal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@ Public source for notable Shelfy changes. Keep entries short, dated, and user-fa
 
 The public page at `/changelog` is generated from `frontend/src/content/changelog.ts`. When adding a release note, update both files in the same PR until a markdown-to-page generator exists.
 
+## 2026-05-19 — Vratná anonymizace a undo pro sloučení dlužníků
+
+- Anonymizace dlužníka je teď ve výchozím režimu plánovaná na 30 dnů; během této doby ji můžeš kdykoli zrušit tlačítkem „Vrátit". Po vypršení worker dokončí smazání PII jako dřív (#244).
+- Pro žádost subjektu o smazání (GDPR/DSAR) je v potvrzovacím dialogu zaškrtávátko „Anonymizovat ihned", které okno přeskočí (#244).
+- Žlutý badge „Plánovaná anonymizace" + odpočet (X d Y h) na detailu dlužníka, aby bylo jasné, kolik času na restore zbývá (#244).
+- Filtr „Plánovaná anonymizace" na stránce /borrowers — najdeš dlužníky čekající na smazání bez znalosti URL (#244).
+- Sloučení dvou dlužníků je teď 10 vteřin vratné: po confirm se zobrazí toast s tlačítkem „Vrátit (Xs)". Kliknutí obnoví zdrojový záznam i jeho půjčky (#244).
+- Patička audit trailu na detailu dlužníka: kdo a kdy záznam vytvořil / anonymizoval / sloučil (#261).
+- Disambiguační panel v dialogu Půjčit knihu: pokud existuje víc dlužníků se stejným jménem, místo tichého duplikátu se zobrazí výběr (#250).
+- Půjčování v knihovně s 100+ dlužníky teď dohledá existující záznam server-side místo prvních 100 řádků (#250).
+- Plánované úlohy workeru (denní e-mailové připomínky, retence) teď hlásí výjimky do Sentry. Dříve končily tiše v logu.
+
 ## 2026-05-07 — Dlužníci jako samostatná entita
 
 - Přibyla evidence dlužníků (`/borrowers`) s vyhledáváním a statistikami počtu půjček. Hledání i stránkování běží na serveru a fungují i ve velkých knihovnách (#225, #237).

--- a/frontend/src/content/changelog.ts
+++ b/frontend/src/content/changelog.ts
@@ -14,6 +14,55 @@ export type ChangelogEntry = {
 
 export const changelogEntries: ChangelogEntry[] = [
   {
+    date: '2026-05-19',
+    title: {
+      cs: 'Vratná anonymizace a undo pro sloučení dlužníků',
+      en: 'Reversible anonymization and merge undo for borrowers',
+    },
+    summary: {
+      cs: 'Anonymizace dlužníka se teď dá do 30 dnů vrátit zpět, sloučení duplicit má 10vteřinové undo. Plus drobné UX vylepšení vybírání dlužníka v půjčce.',
+      en: 'Borrower anonymization is now reversible for 30 days, merging duplicates has a 10-second undo. Plus small UX upgrades to the borrower picker in the lend modal.',
+    },
+    added: {
+      cs: [
+        'Anonymizace dlužníka je teď ve výchozím režimu plánovaná na 30 dnů — během této doby se dá kdykoli vrátit tlačítkem „Vrátit". Po vypršení dlužníka tichý worker dokončí anonymizaci jako dřív (#244).',
+        'Pro žádost subjektu o smazání (GDPR/DSAR) zůstává okamžitý režim přístupný přes zaškrtávátko v potvrzovacím dialogu (#244).',
+        'Žlutý štítek „Plánovaná anonymizace" s odpočtem (dny + hodiny) na detailu dlužníka, aby bylo jasné, kolik času na vrácení ještě zbývá (#244).',
+        'Filtr „Plánovaná anonymizace" na stránce /borrowers, abys našel(a) dlužníky čekající na smazání bez znalosti URL (#244).',
+        'Sloučení dvou dlužníků je teď reverzibilní 10 vteřin — po potvrzení se objeví toast s tlačítkem „Vrátit (Xs)". Klik obnoví zdrojový záznam i jeho půjčky (#244).',
+        'Patička auditu na detailu dlužníka: ukazuje, kdo dlužníka vytvořil / anonymizoval / sloučil a kdy (#261).',
+        'Disambiguace v dialogu Půjčit knihu: když existují dva dlužníci se stejným jménem, místo tichého duplikátu se zobrazí inline panel s výběrem konkrétního záznamu (#250).',
+        'Půjčování knihy v knihovně se 100+ dlužníky teď dohledá existující záznam přes server-side hledání místo prvních 100 řádků (#250).',
+      ],
+      en: [
+        'Borrower anonymization now defaults to a 30-day scheduled mode — you can hit "Restore" any time during the window. After it expires, a quiet worker finishes the wipe exactly like before (#244).',
+        'For GDPR data-subject erasure requests the immediate mode stays available via a checkbox in the confirmation dialog (#244).',
+        'Yellow "Anonymization scheduled" badge with a live countdown (days + hours) on the borrower detail page, so the remaining grace window is visible at a glance (#244).',
+        '"Scheduled for deletion" filter on the /borrowers page — find pending borrowers without knowing their URL (#244).',
+        'Merging two borrowers is now reversible for 10 seconds — after confirming, a toast with "Undo (Xs)" surfaces. Clicking restores the source record and re-points its loans (#244).',
+        'Audit footer on the borrower detail page showing who created / anonymized / merged the record, and when (#261).',
+        'Disambiguation in the Lend book dialog: when two borrowers share a name, an inline panel surfaces both so you can pick the right record instead of silently creating a duplicate (#250).',
+        'Lending in a library with 100+ borrowers now finds the existing record via server-side search rather than just the first page of rows (#250).',
+      ],
+    },
+    changed: {
+      cs: [
+        'Potvrzovací dialog při sloučení dvou dlužníků už neříká „nelze vrátit" — místo toho vysvětluje, že akce je 10 vteřin vratná (#244).',
+      ],
+      en: [
+        'Merge confirmation dialog no longer says "this cannot be undone" — it now explains the 10-second undo window (#244).',
+      ],
+    },
+    fixed: {
+      cs: [
+        'Plánované úlohy ve workeru (denní e-mailové připomínky, retence dat) hlásí výjimky do Sentry. Dříve tiše končily v logu a nikdo se o nich nedozvěděl.',
+      ],
+      en: [
+        'Background worker tasks (daily email reminders, retention sweeps) now report exceptions to Sentry. Previously they failed silently in the log.',
+      ],
+    },
+  },
+  {
     date: '2026-05-07',
     title: {
       cs: 'Dlužníci jako samostatná entita',


### PR DESCRIPTION
## Summary

Adds a 2026-05-19 entry to both \`docs/CHANGELOG.md\` and \`frontend/src/content/changelog.ts\` (in-app /changelog page) for the work shipped 2026-05-18 → 2026-05-19:

- #244 anonymize → 30d pending window + DSAR bypass + countdown badge + lifecycle filter + 10s merge undo toast
- #261 audit-trail footer on borrower detail
- #250 disambiguation panel + server-side picker search
- Worker Sentry wire-up mentioned as a reliability fix

Implementation-noise PRs (worker DSN fix, runner pin, service refactor) intentionally omitted per the changelog header rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reversible borrower anonymization with 30-day grace period and immediate cancel option
  * Undo functionality for borrower merges (10-second window)
  * Filter for borrowers pending anonymization
  * Improved duplicate borrower name disambiguation in dialogs

* **Changes**
  * Added UI countdown indicators for scheduled anonymization
  * Enhanced borrower audit trails with actor and timestamp details
  * Improved error reporting from background operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->