### PR TITLE
fix(billing): read is_first_time before customer create commit (SQLA expire-on-commit)

### DIFF
--- a/backend/app/services/billing.py
+++ b/backend/app/services/billing.py
@@ -262,10 +262,16 @@ async def create_checkout_session(
     from app.services.entitlements import get_or_create_subscription
 
     sub = await get_or_create_subscription(session, user.id)
-    customer_id = await get_or_create_stripe_customer(session, user, settings)
-
-    # Offer a trial only on the very first subscription (no previous Stripe sub ID)
+    # Snapshot ``is_first_time`` BEFORE calling get_or_create_stripe_customer
+    # below: that function commits when it creates a fresh Stripe customer,
+    # which expires every attribute on ``sub`` (SQLAlchemy default
+    # ``expire_on_commit=True``). Reading ``sub.stripe_subscription_id``
+    # after the commit would trigger a lazy reload from inside a non-
+    # greenlet async context → ``MissingGreenlet``. This bug only fires
+    # on the very first checkout per account (path that actually creates
+    # a new Stripe customer), which is why it stayed hidden until prod.
     is_first_time = sub.stripe_subscription_id is None
+    customer_id = await get_or_create_stripe_customer(session, user, settings)
     subscription_data: dict[str, Any] = {"metadata": {"user_id": str(user.id)}}
     if is_first_time:
         subscription_data["trial_period_days"] = _TRIAL_DAYS


### PR DESCRIPTION
## Summary

Production hotfix for 500 on \`POST /api/v1/billing/checkout\` that surfaced immediately after flipping Stripe to live mode (#194). **Not Stripe-specific** — latent async SQLAlchemy footgun in our own code.

## Root cause

\`\`\`python
sub = await get_or_create_subscription(session, user.id)
customer_id = await get_or_create_stripe_customer(...)   # commits when creating
is_first_time = sub.stripe_subscription_id is None       # 💥 MissingGreenlet
\`\`\`

\`get_or_create_stripe_customer\` commits inside when it creates a fresh Stripe customer. Default \`expire_on_commit=True\` then marks every attribute on the outer \`sub\` instance as expired. The next attribute access triggers a lazy reload from a non-greenlet async context → \`MissingGreenlet\`.

## Why hidden

The buggy path only fires when \`sub.stripe_customer_id\` is NULL — exactly once per account, on the very first checkout. Test mode had pre-seeded customer IDs from earlier manual testing. Unit tests mock the Stripe SDK so they don't reach the real commit. After flipping to live mode the DB starts clean for Stripe IDs → first user checkout hits the unseeded branch → 500.

## Fix

One-line reorder: snapshot \`is_first_time\` BEFORE the function that may commit. No schema/semantic change.

\`\`\`python
sub = await get_or_create_subscription(session, user.id)
is_first_time = sub.stripe_subscription_id is None     # ← moved up
customer_id = await get_or_create_stripe_customer(...)
\`\`\`

## Deployment note

Already hot-patched on prod by editing the container source + \`docker compose up -d --build backend\`. This PR lands the same diff so the next auto-deploy doesn't regress.

## Test plan

- [ ] backend / lint + tests (existing tests pass because they don't depend on ordering — verified locally)
- [ ] After merge: auto-deploy redeploys backend with the same fix → no behaviour change on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue affecting checkout completion during the initial purchase process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->