### PR TITLE
feat(demo): client-side seed dataset + in-memory store (#284)

### DIFF
--- a/frontend/src/features/demo/DemoContext.tsx
+++ b/frontend/src/features/demo/DemoContext.tsx
@@ -1,0 +1,21 @@
+/**
+ * DemoContext — a one-bit flag that tells data hooks whether they are running
+ * inside the public client-side demo (`/demo/*`, wired up in #285).
+ *
+ * Default is `false`, so nothing changes for the authenticated app. The
+ * `DemoModeProvider` wraps only the demo routes and flips it on; the
+ * demo-aware hooks read {@link useIsDemoMode} to decide between the real API
+ * and the in-memory `useDemoStore`.
+ */
+import { createContext, useContext, type ReactNode } from 'react'
+
+const DemoModeContext = createContext<boolean>(false)
+
+export function DemoModeProvider({ children }: { children: ReactNode }) {
+  return <DemoModeContext.Provider value={true}>{children}</DemoModeContext.Provider>
+}
+
+/** True only inside the demo subtree. */
+export function useIsDemoMode(): boolean {
+  return useContext(DemoModeContext)
+}

--- a/frontend/src/features/demo/demoSeed.ts
+++ b/frontend/src/features/demo/demoSeed.ts
@@ -1,0 +1,96 @@
+/**
+ * Demo seed data — a self-contained, client-side mirror of the backend sample
+ * library (`backend/app/services/library.py` `_SAMPLE_LOCATIONS` / `_SAMPLE_BOOKS`).
+ *
+ * The on-landing demo (#284–#287) runs entirely in the browser so that
+ * unauthenticated visitors generate **zero** data/AI/upload load on the server.
+ * This module is the single source of truth for that seeded library.
+ *
+ * Fidelity notes (see #284):
+ *  - Every required field of `Book` / `Location` (`lib/types.ts`) is populated
+ *    with an explicit value — no `as any`, no missing fields.
+ *  - IDs are deterministic (`demo-loc-1`, `demo-book-01`, …) so React keys and
+ *    `/demo/:id` links stay stable across reloads.
+ *  - Timestamps are a fixed constant (not `Date.now()`) so snapshots/tests are
+ *    deterministic.
+ *  - The factory functions return **fresh** arrays/objects on every call, so a
+ *    `reset()` can never be polluted by in-place demo mutations.
+ */
+import type { Book, Location, ReadingStatus } from '../../lib/types'
+
+/** Fixed timestamp for all seed rows — keeps demo snapshots deterministic. */
+export const DEMO_SEED_TS = '2026-01-01T00:00:00.000Z'
+
+interface SeedLocation {
+  id: string
+  room: string
+  furniture: string
+  shelf: string
+  display_order: number
+}
+
+const SEED_LOCATIONS: readonly SeedLocation[] = [
+  { id: 'demo-loc-1', room: 'Living room', furniture: 'Bookcase', shelf: 'Shelf 1', display_order: 1 },
+  { id: 'demo-loc-2', room: 'Living room', furniture: 'Bookcase', shelf: 'Shelf 2', display_order: 2 },
+  { id: 'demo-loc-3', room: 'Bedroom', furniture: 'Nightstand', shelf: 'To read', display_order: 1 },
+] as const
+
+/** [title, author, language, year, reading_status, locationIndex, shelf_position] */
+type SeedBook = readonly [string, string, string, number, ReadingStatus, number, number]
+
+const SEED_BOOKS: readonly SeedBook[] = [
+  ['Proměna', 'Franz Kafka', 'cs', 1915, 'read', 0, 0],
+  ['R.U.R.', 'Karel Čapek', 'cs', 1920, 'read', 0, 1],
+  ['Ostře sledované vlaky', 'Bohumil Hrabal', 'cs', 1965, 'read', 0, 2],
+  ['Báječná léta pod psa', 'Michal Viewegh', 'cs', 1992, 'reading', 0, 3],
+  ['Zaklínač I: Poslední přání', 'Andrzej Sapkowski', 'cs', 1990, 'reading', 0, 4],
+  ['Hobit', 'J.R.R. Tolkien', 'cs', 1937, 'read', 0, 5],
+  ['Nesnesitelná lehkost bytí', 'Milan Kundera', 'cs', 1984, 'read', 1, 0],
+  ['Osudy dobrého vojáka Švejka', 'Jaroslav Hašek', 'cs', 1923, 'read', 1, 1],
+  ['1984', 'George Orwell', 'en', 1949, 'read', 1, 2],
+  ['Stopařův průvodce po galaxii', 'Douglas Adams', 'en', 1979, 'read', 1, 3],
+  ['Malý princ', 'Antoine de Saint-Exupéry', 'cs', 1943, 'read', 1, 4],
+  ['Zločin a trest', 'Fjodor Michajlovič Dostojevský', 'cs', 1866, 'unread', 2, 0],
+  ['Sto roků samoty', 'Gabriel García Márquez', 'cs', 1967, 'unread', 2, 1],
+  ['Mistr a Markétka', 'Michail Bulgakov', 'cs', 1967, 'unread', 2, 2],
+  ['Duna', 'Frank Herbert', 'cs', 1965, 'unread', 2, 3],
+  ['Pán prstenů: Společenstvo prstenu', 'J.R.R. Tolkien', 'cs', 1954, 'unread', 2, 4],
+] as const
+
+/** Build a fresh array of seed locations (new objects every call). */
+export function createDemoLocations(): Location[] {
+  return SEED_LOCATIONS.map((loc) => ({
+    id: loc.id,
+    room: loc.room,
+    furniture: loc.furniture,
+    shelf: loc.shelf,
+    display_order: loc.display_order,
+    is_sample: true,
+    created_at: DEMO_SEED_TS,
+    updated_at: DEMO_SEED_TS,
+  }))
+}
+
+/** Build a fresh array of seed books (new objects every call). */
+export function createDemoBooks(): Book[] {
+  return SEED_BOOKS.map(([title, author, language, year, readingStatus, locIdx, shelfPos], index) => ({
+    id: `demo-book-${String(index + 1).padStart(2, '0')}`,
+    title,
+    author,
+    isbn: null,
+    publisher: null,
+    language,
+    description: null,
+    publication_year: year,
+    cover_image_url: null,
+    location_id: SEED_LOCATIONS[locIdx].id,
+    shelf_position: shelfPos,
+    processing_status: 'done',
+    reading_status: readingStatus,
+    is_currently_lent: false,
+    active_loan: null,
+    is_sample: true,
+    created_at: DEMO_SEED_TS,
+    updated_at: DEMO_SEED_TS,
+  }))
+}

--- a/frontend/src/store/useDemoStore.test.ts
+++ b/frontend/src/store/useDemoStore.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { createDemoBooks, createDemoLocations } from '../features/demo/demoSeed'
+import { DEMO_STORAGE_KEY, filterBooks, useDemoStore } from './useDemoStore'
+
+function freshStore() {
+  // Each test starts from a pristine, isolated seed.
+  sessionStorage.clear()
+  useDemoStore.getState().reset()
+  return useDemoStore.getState
+}
+
+beforeEach(() => {
+  freshStore()
+})
+
+describe('demoSeed', () => {
+  it('mirrors the backend sample set (3 shelves, 16 books) with full type fidelity', () => {
+    const locations = createDemoLocations()
+    const books = createDemoBooks()
+    expect(locations).toHaveLength(3)
+    expect(books).toHaveLength(16)
+    // Every book has all required fields populated (no undefined holes).
+    for (const b of books) {
+      expect(b.id).toMatch(/^demo-book-\d{2}$/)
+      expect(b.is_sample).toBe(true)
+      expect(b.processing_status).toBe('done')
+      expect(typeof b.created_at).toBe('string')
+      expect(b.location_id).toBeTruthy()
+      expect(typeof b.shelf_position).toBe('number')
+    }
+  })
+
+  it('returns fresh objects each call (no shared mutable references)', () => {
+    const a = createDemoBooks()
+    const b = createDemoBooks()
+    expect(a).not.toBe(b)
+    expect(a[0]).not.toBe(b[0])
+    a[0].title = 'mutated'
+    expect(b[0].title).not.toBe('mutated')
+  })
+})
+
+describe('filterBooks', () => {
+  const books = createDemoBooks()
+
+  it('searches title / author case-insensitively', () => {
+    expect(filterBooks(books, { search: 'tolkien' })).toHaveLength(2)
+    expect(filterBooks(books, { search: 'HOBIT' }).map((b) => b.title)).toContain('Hobit')
+  })
+
+  it('filters by reading status and location', () => {
+    expect(filterBooks(books, { readingStatus: 'reading' })).toHaveLength(2)
+    expect(filterBooks(books, { locationId: 'demo-loc-3' })).toHaveLength(5)
+  })
+
+  it('filters by language and publication-year range', () => {
+    expect(filterBooks(books, { language: 'en' })).toHaveLength(2)
+    expect(filterBooks(books, { yearFrom: 1980 }).every((b) => (b.publication_year ?? 0) >= 1980)).toBe(true)
+  })
+})
+
+describe('useDemoStore', () => {
+  it('queryBooks paginates and reports total', () => {
+    const get = useDemoStore.getState
+    const page1 = get().queryBooks({ pageSize: 10, page: 1 })
+    expect(page1.total).toBe(16)
+    expect(page1.items).toHaveLength(10)
+    expect(page1.has_sample_books).toBe(true)
+    const page2 = get().queryBooks({ pageSize: 10, page: 2 })
+    expect(page2.items).toHaveLength(6)
+  })
+
+  it('counts reflects reading statuses', () => {
+    const c = useDemoStore.getState().counts()
+    expect(c.total).toBe(16)
+    expect(c.read).toBe(9)
+    expect(c.reading).toBe(2)
+    expect(c.lent).toBe(0)
+  })
+
+  it('addBook appends to the end of the target shelf', () => {
+    const get = useDemoStore.getState
+    const created = get().addBook({ title: 'New Book', location_id: 'demo-loc-3' })
+    expect(created.id).toContain('demo-book-')
+    expect(created.is_sample).toBe(false)
+    expect(get().counts().total).toBe(17)
+    // demo-loc-3 had positions 0..4 → new one is 5.
+    expect(created.shelf_position).toBe(5)
+  })
+
+  it('updateBook patches only provided fields', () => {
+    const get = useDemoStore.getState
+    const updated = get().updateBook('demo-book-01', { reading_status: 'reading' })
+    expect(updated?.reading_status).toBe('reading')
+    expect(updated?.title).toBe('Proměna')
+    expect(get().counts().reading).toBe(3)
+  })
+
+  it('deleteBook and bulkDelete remove rows', () => {
+    const get = useDemoStore.getState
+    get().deleteBook('demo-book-01')
+    expect(get().counts().total).toBe(15)
+    get().bulkDelete(['demo-book-02', 'demo-book-03'])
+    expect(get().counts().total).toBe(13)
+  })
+
+  it('bulkMove and bulkUpdateStatus mutate in place', () => {
+    const get = useDemoStore.getState
+    get().bulkMove(['demo-book-01'], 'demo-loc-3')
+    expect(get().booksByLocation('demo-loc-3').some((b) => b.id === 'demo-book-01')).toBe(true)
+    get().bulkUpdateStatus(['demo-book-12'], 'lent')
+    expect(get().counts().lent).toBe(1)
+  })
+
+  it('reorder applies new location and shelf_position', () => {
+    const get = useDemoStore.getState
+    get().reorder([{ id: 'demo-book-16', location_id: 'demo-loc-1', shelf_position: 99 }])
+    const moved = get().books.find((b) => b.id === 'demo-book-16')
+    expect(moved?.location_id).toBe('demo-loc-1')
+    expect(moved?.shelf_position).toBe(99)
+  })
+
+  it('booksForShelf orders by location display_order then shelf_position', () => {
+    const shelf = useDemoStore.getState().booksForShelf()
+    expect(shelf[0].location_id).toBe('demo-loc-1')
+    expect(shelf[0].shelf_position).toBe(0)
+  })
+
+  it('persists to sessionStorage and reset() returns to pristine seed', () => {
+    const get = useDemoStore.getState
+    get().addBook({ title: 'Throwaway' })
+    expect(get().counts().total).toBe(17)
+    // Persisted as text-only data under the demo key.
+    const raw = sessionStorage.getItem(DEMO_STORAGE_KEY)
+    expect(raw).toBeTruthy()
+    expect(raw).toContain('Throwaway')
+    get().reset()
+    expect(get().counts().total).toBe(16)
+    expect(get().books.every((b) => b.is_sample)).toBe(true)
+  })
+})

--- a/frontend/src/store/useDemoStore.ts
+++ b/frontend/src/store/useDemoStore.ts
@@ -1,0 +1,274 @@
+/**
+ * useDemoStore — in-memory library for the client-side landing demo (#284).
+ *
+ * Holds a sandboxed copy of the seed library (`features/demo/demoSeed.ts`) and
+ * exposes read selectors + write actions that mirror the shapes the real
+ * TanStack Query hooks return, so the demo-aware hooks in #285 can swap data
+ * sources without the pages noticing.
+ *
+ * Persistence (see #284):
+ *  - Backed by `sessionStorage` under {@link DEMO_STORAGE_KEY}.
+ *  - Survives in-app navigation within the same tab.
+ *  - A fresh tab / new session starts from the pristine seed (empty storage
+ *    falls back to the initializer).
+ *  - `reset()` re-seeds from `demoSeed` (pristine) and rewrites storage.
+ *  - Only the data (`books`, `locations`) is persisted — never the action
+ *    functions — and it is text-only (no blobs) to stay well under quota.
+ *
+ * Everything here is pure in-memory: NO network calls, ever. That is the whole
+ * point of the demo (zero backend/AI load for unauthenticated visitors).
+ */
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+import { createDemoBooks, createDemoLocations } from '../features/demo/demoSeed'
+import type {
+  Book,
+  BookCreateRequest,
+  BookListParams,
+  BookListResponse,
+  BookUpdateRequest,
+  Location,
+  ReadingStatus,
+} from '../lib/types'
+
+export const DEMO_STORAGE_KEY = 'shelfy:demo:v1'
+
+const DEFAULT_PAGE_SIZE = 20
+
+export interface DemoBookCounts {
+  total: number
+  read: number
+  reading: number
+  lent: number
+}
+
+export interface ReorderItem {
+  id: string
+  location_id: string | null
+  shelf_position: number
+}
+
+interface DemoData {
+  books: Book[]
+  locations: Location[]
+}
+
+interface DemoActions {
+  // ── Read selectors (mirror lib/api.ts response shapes) ──
+  queryBooks: (params?: BookListParams) => BookListResponse
+  booksForShelf: () => Book[]
+  booksByLocation: (locationId: string) => Book[]
+  counts: () => DemoBookCounts
+  // ── Write actions (all in-memory) ──
+  addBook: (payload: BookCreateRequest) => Book
+  updateBook: (id: string, payload: BookUpdateRequest) => Book | null
+  deleteBook: (id: string) => void
+  bulkDelete: (ids: string[]) => void
+  bulkMove: (ids: string[], locationId: string | null) => void
+  bulkUpdateStatus: (ids: string[], status: ReadingStatus) => void
+  reorder: (items: ReorderItem[]) => void
+  reset: () => void
+}
+
+export type DemoState = DemoData & DemoActions
+
+// ── Pure helpers (exported for unit testing) ───────────────────────────────
+
+function nextId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `demo-book-${crypto.randomUUID()}`
+    }
+  } catch {
+    /* fall through */
+  }
+  return `demo-book-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+}
+
+function shelfOrder(books: Book[], locations: Location[]): Book[] {
+  const orderOf = new Map(locations.map((l) => [l.id, l.display_order]))
+  return [...books].sort((a, b) => {
+    const la = a.location_id ? orderOf.get(a.location_id) ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER
+    const lb = b.location_id ? orderOf.get(b.location_id) ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER
+    if (la !== lb) return la - lb
+    const pa = a.shelf_position ?? Number.MAX_SAFE_INTEGER
+    const pb = b.shelf_position ?? Number.MAX_SAFE_INTEGER
+    if (pa !== pb) return pa - pb
+    return a.title.localeCompare(b.title)
+  })
+}
+
+/** Replicates the server-side filtering of `listBooks` for the demo dataset. */
+export function filterBooks(books: Book[], params: BookListParams = {}): Book[] {
+  const search = params.search?.trim().toLowerCase()
+  return books.filter((book) => {
+    if (search) {
+      const haystack = [book.title, book.author ?? '', book.isbn ?? ''].join(' ').toLowerCase()
+      if (!haystack.includes(search)) return false
+    }
+    if (params.locationId && book.location_id !== params.locationId) return false
+    if (params.unassignedOnly && book.location_id) return false
+    if (params.readingStatus && book.reading_status !== params.readingStatus) return false
+    if (params.language && book.language !== params.language) return false
+    if (params.publisher && book.publisher !== params.publisher) return false
+    if (typeof params.yearFrom === 'number' && (book.publication_year ?? -Infinity) < params.yearFrom) return false
+    if (typeof params.yearTo === 'number' && (book.publication_year ?? Infinity) > params.yearTo) return false
+    return true
+  })
+}
+
+function applyUpdate(book: Book, payload: BookUpdateRequest): Book {
+  const next: Book = { ...book, updated_at: new Date().toISOString() }
+  const assignIfPresent = <K extends keyof BookUpdateRequest & keyof Book>(key: K) => {
+    if (payload[key] !== undefined) {
+      ;(next[key] as Book[K]) = payload[key] as Book[K]
+    }
+  }
+  assignIfPresent('title')
+  assignIfPresent('author')
+  assignIfPresent('isbn')
+  assignIfPresent('publisher')
+  assignIfPresent('language')
+  assignIfPresent('description')
+  assignIfPresent('publication_year')
+  assignIfPresent('cover_image_url')
+  assignIfPresent('location_id')
+  assignIfPresent('shelf_position')
+  assignIfPresent('reading_status')
+  return next
+}
+
+// ── Store ──────────────────────────────────────────────────────────────────
+
+export const useDemoStore = create<DemoState>()(
+  persist(
+    (set, get) => ({
+      books: createDemoBooks(),
+      locations: createDemoLocations(),
+
+      queryBooks: (params = {}) => {
+        const all = get().books
+        const filtered = shelfOrder(filterBooks(all, params), get().locations)
+        const page = params.page ?? 1
+        const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE
+        const start = (page - 1) * pageSize
+        return {
+          total: filtered.length,
+          page,
+          page_size: pageSize,
+          has_sample_books: all.some((b) => b.is_sample),
+          items: filtered.slice(start, start + pageSize),
+        }
+      },
+
+      booksForShelf: () => shelfOrder(get().books, get().locations),
+
+      booksByLocation: (locationId) =>
+        shelfOrder(
+          get().books.filter((b) => b.location_id === locationId),
+          get().locations,
+        ),
+
+      counts: () => {
+        const books = get().books
+        return {
+          total: books.length,
+          read: books.filter((b) => b.reading_status === 'read').length,
+          reading: books.filter((b) => b.reading_status === 'reading').length,
+          lent: books.filter((b) => b.reading_status === 'lent').length,
+        }
+      },
+
+      addBook: (payload) => {
+        const now = new Date().toISOString()
+        const locationId = payload.location_id ?? null
+        // Append to the end of the target shelf when no explicit position given.
+        const siblings = get().books.filter((b) => b.location_id === locationId)
+        const maxPos = siblings.reduce((m, b) => Math.max(m, b.shelf_position ?? -1), -1)
+        const book: Book = {
+          id: nextId(),
+          title: payload.title,
+          author: payload.author ?? null,
+          isbn: payload.isbn ?? null,
+          publisher: payload.publisher ?? null,
+          language: payload.language ?? null,
+          description: payload.description ?? null,
+          publication_year: payload.publication_year ?? null,
+          cover_image_url: payload.cover_image_url ?? null,
+          location_id: locationId,
+          shelf_position: payload.shelf_position ?? maxPos + 1,
+          processing_status: 'done',
+          reading_status: payload.reading_status ?? 'unread',
+          is_currently_lent: false,
+          active_loan: null,
+          is_sample: false,
+          created_at: now,
+          updated_at: now,
+        }
+        set((s) => ({ books: [...s.books, book] }))
+        return book
+      },
+
+      updateBook: (id, payload) => {
+        let updated: Book | null = null
+        set((s) => ({
+          books: s.books.map((b) => {
+            if (b.id !== id) return b
+            updated = applyUpdate(b, payload)
+            return updated
+          }),
+        }))
+        return updated
+      },
+
+      deleteBook: (id) => set((s) => ({ books: s.books.filter((b) => b.id !== id) })),
+
+      bulkDelete: (ids) => {
+        const remove = new Set(ids)
+        set((s) => ({ books: s.books.filter((b) => !remove.has(b.id)) }))
+      },
+
+      bulkMove: (ids, locationId) => {
+        const move = new Set(ids)
+        const now = new Date().toISOString()
+        set((s) => ({
+          books: s.books.map((b) =>
+            move.has(b.id) ? { ...b, location_id: locationId, updated_at: now } : b,
+          ),
+        }))
+      },
+
+      bulkUpdateStatus: (ids, status) => {
+        const target = new Set(ids)
+        const now = new Date().toISOString()
+        set((s) => ({
+          books: s.books.map((b) =>
+            target.has(b.id) ? { ...b, reading_status: status, updated_at: now } : b,
+          ),
+        }))
+      },
+
+      reorder: (items) => {
+        const byId = new Map(items.map((i) => [i.id, i]))
+        const now = new Date().toISOString()
+        set((s) => ({
+          books: s.books.map((b) => {
+            const move = byId.get(b.id)
+            return move
+              ? { ...b, location_id: move.location_id, shelf_position: move.shelf_position, updated_at: now }
+              : b
+          }),
+        }))
+      },
+
+      reset: () => set({ books: createDemoBooks(), locations: createDemoLocations() }),
+    }),
+    {
+      name: DEMO_STORAGE_KEY,
+      storage: createJSONStorage(() => sessionStorage),
+      // Persist data only — never the action closures.
+      partialize: (state) => ({ books: state.books, locations: state.locations }),
+    },
+  ),
+)


### PR DESCRIPTION
## Summary

Foundation for the interactive landing-page demo (epic #284–#287). Adds the data + state layer that the demo routes (#285), scripted scan (#286), and landing wiring (#287) build on. **No user-visible routes yet** — nothing in the authenticated app imports this.

- **`features/demo/demoSeed.ts`** — typed frontend mirror of the backend sample library (`backend/app/services/library.py` `_SAMPLE_LOCATIONS`/`_SAMPLE_BOOKS`): 3 shelves, 16 Czech/EN titles. Full `Book`/`Location` type fidelity (all required fields), deterministic ids (`demo-book-01`…) + fixed timestamps, fresh-object factories so `reset()` is never polluted by in-place mutations.
- **`store/useDemoStore.ts`** — in-memory zustand store. Read selectors mirror `lib/api.ts` response shapes (`queryBooks` → `BookListResponse` with search/filter/pagination, `booksForShelf`, `booksByLocation`, `counts`); write actions (`addBook`/`updateBook`/`deleteBook`/`bulkDelete`/`bulkMove`/`bulkUpdateStatus`/`reorder`/`reset`). `sessionStorage`-backed via `persist` (tab-scoped, pristine on new session, data-only — no action closures, no blobs). Zero network calls by construction.
- **`features/demo/DemoContext.tsx`** — `isDemoMode` flag (default `false`) for the #285 demo-aware hooks.

## Decisions baked in (from the issue review)

- Full type fidelity in the seed (no missing fields / `as any`).
- Persistence semantics: survives in-tab nav, fresh tab starts pristine, `reset()` re-seeds.

## Test plan

- [x] `npm run test` — 14 new unit tests (seed fidelity, fresh-object factories, filtering, pagination, counts, add/update/delete/bulk/reorder, sessionStorage persistence + reset). Full suite 209/209 green.
- [x] `npm run lint` — 0 errors (one pre-existing-style `react-refresh` warning on the context file, same as `AuthContext.tsx`).
- [x] Confirmed no production module imports `useDemoStore` yet.

Part of #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a demo mode that allows users to explore the app with sample book library data.
* Demo includes sample locations and books that persist throughout a session.
* Non-demo (authenticated) flows remain unaffected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smeglofus/shelfy/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->