### PR TITLE
feat(demo): public /demo routes, demo-aware hooks + shell (#285)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { TermsPage } from './pages/TermsPage'
 import { ForgotPasswordPage } from './pages/ForgotPasswordPage'
 import { ResetPasswordPage } from './pages/ResetPasswordPage'
 import { ChangelogPage } from './pages/ChangelogPage'
+import { DemoLayout } from './features/demo/DemoLayout'
 
 import { ROUTES } from './lib/routes'
 
@@ -84,7 +85,9 @@ function AppShell() {
     },
   })
   const location = useLocation()
-  const hideNav = PUBLIC_PATHS.has(location.pathname)
+  // The demo subtree (#285) ships its own chrome (DemoBanner), so the
+  // authenticated Navigation must stay hidden across all of `/demo/*`.
+  const hideNav = PUBLIC_PATHS.has(location.pathname) || location.pathname.startsWith('/demo')
 
   return (
     <div className='sh-app'>
@@ -100,6 +103,14 @@ function AppShell() {
           <Route path={ROUTES.terms} element={<TermsPage />} />
           <Route path={ROUTES.pricing} element={<PricingPage />} />
           <Route path={ROUTES.changelog} element={<ChangelogPage />} />
+
+          {/* ── Public client-side demo (#285) — no auth, no network ── */}
+          <Route path='/demo' element={<DemoLayout />}>
+            <Route index element={<Navigate to='/demo/books' replace />} />
+            <Route path='books' element={<BooksPage />} />
+            <Route path='books/new' element={<AddBookPage />} />
+            <Route path='bookshelf' element={<BookshelfViewPage />} />
+          </Route>
 
           {/* ── Protected routes ── */}
           <Route element={<ProtectedRoute />}>

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import type { Book } from '../lib/types'
 import { ReadingStatusBadge } from './ReadingStatusBadge'
 import { getBookDetailRoute } from '../lib/routes'
+import { useIsDemoMode } from '../features/demo/DemoContext'
 
 // ── Cover palette: [bgColor, accentColor] ────────────────────────────
 // Replaces the old GRADIENTS array. Each palette has a dark background
@@ -129,6 +130,8 @@ export function BookCard({
   onSelect,
 }: Props) {
   const { t } = useTranslation()
+  // The demo has no book-detail route, so cards there are non-navigating. (#285)
+  const isDemo = useIsDemoMode()
 
   const hash = hashTitle(book.title)
   const [bgColor, accentColor] = COVER_PALETTES[hash % COVER_PALETTES.length]
@@ -354,7 +357,7 @@ export function BookCard({
         </button>
       )}
 
-      {selectable ? (
+      {selectable || isDemo ? (
         <div
           style={{
             background: 'var(--sh-surface)',

--- a/frontend/src/features/demo/DemoBanner.tsx
+++ b/frontend/src/features/demo/DemoBanner.tsx
@@ -1,0 +1,33 @@
+/**
+ * DemoBanner — the persistent chrome shown across every `/demo/*` page (#285).
+ *
+ * It replaces the authenticated `Navigation` for demo visitors, makes the
+ * sandbox nature explicit ("changes reset when you leave"), and offers the
+ * primary conversion path (sign up) plus an exit back to the landing page.
+ *
+ * Conversion analytics for these CTAs are wired in #287; the markup/hooks here
+ * intentionally stay minimal so that work can slot in without restructuring.
+ */
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+import { ROUTES } from '../../lib/routes'
+
+export function DemoBanner() {
+  const { t } = useTranslation()
+
+  return (
+    <div className='sh-demo-banner' role='region' aria-label={t('demo.badge')}>
+      <span className='sh-demo-banner__badge'>{t('demo.badge')}</span>
+      <span className='sh-demo-banner__text'>{t('demo.banner_text')}</span>
+      <span className='sh-demo-banner__actions'>
+        <Link className='sh-demo-banner__exit' to='/'>
+          {t('demo.exit')}
+        </Link>
+        <Link className='sh-demo-banner__cta' to={ROUTES.login}>
+          {t('demo.cta_signup')}
+        </Link>
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/features/demo/DemoLayout.tsx
+++ b/frontend/src/features/demo/DemoLayout.tsx
@@ -1,0 +1,26 @@
+/**
+ * DemoLayout — the route wrapper + chrome for the public client-side demo (#285).
+ *
+ * Every `/demo/*` route renders inside this layout. It does two things:
+ *  1. Wraps the subtree in {@link DemoModeProvider} so the demo-aware hooks
+ *     (`useBooks`, `useLocations`, …) read the in-memory `useDemoStore` instead
+ *     of the network — guaranteeing zero backend/AI load for visitors.
+ *  2. Renders the {@link DemoBanner} in place of the authenticated `Navigation`
+ *     shell, making it obvious this is a sandbox and offering a sign-up CTA.
+ *
+ * The real pages (`BooksPage`, `BookshelfViewPage`, …) are reused verbatim via
+ * `<Outlet />`; they adapt to demo mode through `useIsDemoMode()`.
+ */
+import { Outlet } from 'react-router-dom'
+
+import { DemoModeProvider } from './DemoContext'
+import { DemoBanner } from './DemoBanner'
+
+export function DemoLayout() {
+  return (
+    <DemoModeProvider>
+      <DemoBanner />
+      <Outlet />
+    </DemoModeProvider>
+  )
+}

--- a/frontend/src/features/demo/demoNav.test.tsx
+++ b/frontend/src/features/demo/demoNav.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Spy on react-router's useNavigate so we can assert the resolved destination.
+const navigateSpy = vi.fn()
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateSpy,
+}))
+
+import { DemoModeProvider } from './DemoContext'
+import { DEMO_PREFIX, useAppNavigate, useDemoPath, withDemoPrefix } from './demoNav'
+
+const demoWrapper = ({ children }: { children: ReactNode }) => (
+  <DemoModeProvider>{children}</DemoModeProvider>
+)
+
+afterEach(() => navigateSpy.mockClear())
+
+describe('withDemoPrefix', () => {
+  it('prefixes absolute app paths', () => {
+    expect(withDemoPrefix('/books')).toBe('/demo/books')
+    expect(withDemoPrefix('/books/new')).toBe('/demo/books/new')
+  })
+
+  it('preserves query strings', () => {
+    expect(withDemoPrefix('/bookshelf?tab=locations')).toBe('/demo/bookshelf?tab=locations')
+  })
+
+  it('is idempotent — never double-prefixes', () => {
+    expect(withDemoPrefix('/demo/books')).toBe('/demo/books')
+    expect(withDemoPrefix(DEMO_PREFIX)).toBe(DEMO_PREFIX)
+  })
+
+  it('tolerates a missing leading slash', () => {
+    expect(withDemoPrefix('books')).toBe('/demo/books')
+  })
+})
+
+describe('useDemoPath', () => {
+  it('rewrites paths inside the demo', () => {
+    const { result } = renderHook(() => useDemoPath(), { wrapper: demoWrapper })
+    expect(result.current('/books')).toBe('/demo/books')
+  })
+
+  it('is an identity outside the demo', () => {
+    const { result } = renderHook(() => useDemoPath())
+    expect(result.current('/books')).toBe('/books')
+  })
+})
+
+describe('useAppNavigate', () => {
+  it('rewrites string destinations to the demo subtree', () => {
+    const { result } = renderHook(() => useAppNavigate(), { wrapper: demoWrapper })
+    result.current('/books')
+    expect(navigateSpy).toHaveBeenCalledWith('/demo/books', undefined)
+  })
+
+  it('passes numeric history deltas through unchanged', () => {
+    const { result } = renderHook(() => useAppNavigate(), { wrapper: demoWrapper })
+    result.current(-1)
+    expect(navigateSpy).toHaveBeenCalledWith(-1)
+  })
+
+  it('leaves destinations untouched outside the demo', () => {
+    const { result } = renderHook(() => useAppNavigate())
+    result.current('/books')
+    expect(navigateSpy).toHaveBeenCalledWith('/books', undefined)
+  })
+})

--- a/frontend/src/features/demo/demoNav.ts
+++ b/frontend/src/features/demo/demoNav.ts
@@ -1,0 +1,53 @@
+/**
+ * demoNav — keeps in-app navigation inside the `/demo/*` subtree (#285).
+ *
+ * The demo reuses the real pages (`BooksPage`, `BookshelfViewPage`, …), which
+ * navigate with absolute production paths like `ROUTES.books` (`/books`). Left
+ * alone, a click in the demo would jump the visitor straight into the
+ * authenticated app (and bounce them to `/login`). These helpers transparently
+ * rewrite those absolute paths to their `/demo`-prefixed twins **only when the
+ * `DemoModeProvider` is active** — outside the demo they are exact pass-throughs,
+ * so the authenticated app is completely unaffected.
+ */
+import { useCallback } from 'react'
+import { useNavigate, type NavigateOptions } from 'react-router-dom'
+
+import { useIsDemoMode } from './DemoContext'
+
+/** Path prefix that scopes every public demo route. */
+export const DEMO_PREFIX = '/demo'
+
+/** Map an absolute app path to its demo twin (idempotent). */
+export function withDemoPrefix(path: string): string {
+  if (path === DEMO_PREFIX || path.startsWith(`${DEMO_PREFIX}/`)) return path
+  return `${DEMO_PREFIX}${path.startsWith('/') ? '' : '/'}${path}`
+}
+
+/**
+ * Returns a path-rewriter: identity outside the demo, `/demo`-prefixer inside.
+ * Use for `<Link to={…}>` targets.
+ */
+export function useDemoPath(): (path: string) => string {
+  const isDemo = useIsDemoMode()
+  return useCallback((path: string) => (isDemo ? withDemoPrefix(path) : path), [isDemo])
+}
+
+/**
+ * Drop-in replacement for `useNavigate` that keeps string destinations inside
+ * the demo subtree. Numeric (history-delta) navigation is passed through
+ * unchanged.
+ */
+export function useAppNavigate(): (to: string | number, options?: NavigateOptions) => void {
+  const navigate = useNavigate()
+  const isDemo = useIsDemoMode()
+  return useCallback(
+    (to: string | number, options?: NavigateOptions) => {
+      if (typeof to === 'number') {
+        navigate(to)
+        return
+      }
+      navigate(isDemo ? withDemoPrefix(to) : to, options)
+    },
+    [navigate, isDemo],
+  )
+}

--- a/frontend/src/hooks/useBooks.ts
+++ b/frontend/src/hooks/useBooks.ts
@@ -17,10 +17,23 @@ import {
 } from '../lib/api'
 import { useToastStore } from '../lib/toast-store'
 import { useAuth } from '../contexts/AuthContext'
+import { useIsDemoMode } from '../features/demo/DemoContext'
+import { useDemoStore } from '../store/useDemoStore'
 import type { BookCreateRequest, BookListParams, BookUpdateRequest, BulkDeleteRequest, BulkMoveRequest, BulkStatusRequest } from '../lib/types'
 import { useTranslation } from 'react-i18next'
 
 export const BOOKS_QUERY_KEY = ['books']
+
+/**
+ * Query-key prefix for the client-side demo (#285).
+ *
+ * Demo-aware hooks read/write the in-memory ``useDemoStore`` instead of the
+ * network. They live under a separate ``['demo', …]`` key space so demo
+ * invalidations never disturb the authenticated cache (and vice-versa), and
+ * so prod-only invalidators like ``useScan``/``useEnrich`` (which hit
+ * ``BOOKS_QUERY_KEY``) are inert inside the demo.
+ */
+export const DEMO_QUERY_KEY = ['demo']
 
 /**
  * List books for the current user.
@@ -33,11 +46,12 @@ export const BOOKS_QUERY_KEY = ['books']
  */
 export function useBooks(params: BookListParams) {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
-    queryKey: [...BOOKS_QUERY_KEY, params],
-    queryFn: () => listBooks(params),
+    queryKey: isDemo ? [...DEMO_QUERY_KEY, ...BOOKS_QUERY_KEY, params] : [...BOOKS_QUERY_KEY, params],
+    queryFn: () => (isDemo ? useDemoStore.getState().queryBooks(params) : listBooks(params)),
     retry: false,
-    enabled: isAuthenticated,
+    enabled: isDemo || isAuthenticated,
   })
 }
 
@@ -53,32 +67,43 @@ export const BOOKS_SHELF_QUERY_KEY = [...BOOKS_QUERY_KEY, 'shelf']
 
 export function useBooksForShelf() {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
-    queryKey: BOOKS_SHELF_QUERY_KEY,
-    queryFn: () => listBooksForShelf(),
+    queryKey: isDemo ? [...DEMO_QUERY_KEY, ...BOOKS_SHELF_QUERY_KEY] : BOOKS_SHELF_QUERY_KEY,
+    queryFn: () => (isDemo ? useDemoStore.getState().booksForShelf() : listBooksForShelf()),
     retry: false,
-    enabled: isAuthenticated,
+    enabled: isDemo || isAuthenticated,
   })
 }
 
 export function useBook(bookId: string) {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
-    queryKey: [...BOOKS_QUERY_KEY, 'detail', bookId],
-    queryFn: () => getBook(bookId),
+    queryKey: isDemo
+      ? [...DEMO_QUERY_KEY, ...BOOKS_QUERY_KEY, 'detail', bookId]
+      : [...BOOKS_QUERY_KEY, 'detail', bookId],
+    queryFn: () => {
+      if (!isDemo) return getBook(bookId)
+      const found = useDemoStore.getState().books.find((b) => b.id === bookId)
+      if (!found) throw new Error('Book not found')
+      return found
+    },
     retry: false,
-    enabled: isAuthenticated && Boolean(bookId),
+    enabled: (isDemo || isAuthenticated) && Boolean(bookId),
   })
 }
 
 export function useCreateBook() {
   const queryClient = useQueryClient()
   const showError = useToastStore((state) => state.showError)
+  const isDemo = useIsDemoMode()
 
   return useMutation({
-    mutationFn: (payload: BookCreateRequest) => createBook(payload),
+    mutationFn: async (payload: BookCreateRequest) =>
+      isDemo ? useDemoStore.getState().addBook(payload) : createBook(payload),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: isDemo ? DEMO_QUERY_KEY : BOOKS_QUERY_KEY })
     },
     onError: (error: unknown) => {
       showError(formatApiError(error))
@@ -91,11 +116,13 @@ export function useUpdateBook() {
   const showError = useToastStore((state) => state.showError)
   const showSuccess = useToastStore((state) => state.showSuccess)
   const { t } = useTranslation()
+  const isDemo = useIsDemoMode()
 
   return useMutation({
-    mutationFn: ({ id, payload }: { id: string; payload: BookUpdateRequest }) => updateBook(id, payload),
+    mutationFn: async ({ id, payload }: { id: string; payload: BookUpdateRequest }) =>
+      isDemo ? useDemoStore.getState().updateBook(id, payload) : updateBook(id, payload),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: isDemo ? DEMO_QUERY_KEY : BOOKS_QUERY_KEY })
       showSuccess(t('toast.book_saved', 'Changes saved successfully.'))
     },
     onError: (error: unknown) => {
@@ -109,11 +136,18 @@ export function useDeleteBook() {
   const showError = useToastStore((state) => state.showError)
   const showSuccess = useToastStore((state) => state.showSuccess)
   const { t } = useTranslation()
+  const isDemo = useIsDemoMode()
 
   return useMutation({
-    mutationFn: (id: string) => deleteBook(id),
+    mutationFn: async (id: string) => {
+      if (isDemo) {
+        useDemoStore.getState().deleteBook(id)
+        return
+      }
+      return deleteBook(id)
+    },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: isDemo ? DEMO_QUERY_KEY : BOOKS_QUERY_KEY })
       showSuccess(t('toast.book_deleted', 'Book deleted.'))
     },
     onError: (error: unknown) => {
@@ -138,10 +172,17 @@ export function useBulkDeleteBooks() {
   const showError = useToastStore((s) => s.showError)
   const showSuccess = useToastStore((s) => s.showSuccess)
   const { t } = useTranslation()
+  const isDemo = useIsDemoMode()
   return useMutation({
-    mutationFn: (payload: BulkDeleteRequest) => bulkDeleteBooks(payload),
+    mutationFn: async (payload: BulkDeleteRequest) => {
+      if (isDemo) {
+        useDemoStore.getState().bulkDelete(payload.ids)
+        return { affected: payload.ids.length, operation: 'delete' as const }
+      }
+      return bulkDeleteBooks(payload)
+    },
     onSuccess: async (data) => {
-      await queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: isDemo ? DEMO_QUERY_KEY : BOOKS_QUERY_KEY })
       showSuccess(t('bulk.deleted', { count: data.affected }))
     },
     onError: (error: unknown) => showError(formatApiError(error)),
@@ -153,10 +194,17 @@ export function useBulkMoveBooks() {
   const showError = useToastStore((s) => s.showError)
   const showSuccess = useToastStore((s) => s.showSuccess)
   const { t } = useTranslation()
+  const isDemo = useIsDemoMode()
   return useMutation({
-    mutationFn: (payload: BulkMoveRequest) => bulkMoveBooks(payload),
+    mutationFn: async (payload: BulkMoveRequest) => {
+      if (isDemo) {
+        useDemoStore.getState().bulkMove(payload.ids, payload.location_id)
+        return { affected: payload.ids.length, operation: 'move' as const }
+      }
+      return bulkMoveBooks(payload)
+    },
     onSuccess: async (data) => {
-      await queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: isDemo ? DEMO_QUERY_KEY : BOOKS_QUERY_KEY })
       showSuccess(t('bulk.moved', { count: data.affected }))
     },
     onError: (error: unknown) => showError(formatApiError(error)),
@@ -168,10 +216,17 @@ export function useBulkUpdateStatus() {
   const showError = useToastStore((s) => s.showError)
   const showSuccess = useToastStore((s) => s.showSuccess)
   const { t } = useTranslation()
+  const isDemo = useIsDemoMode()
   return useMutation({
-    mutationFn: (payload: BulkStatusRequest) => bulkUpdateStatus(payload),
+    mutationFn: async (payload: BulkStatusRequest) => {
+      if (isDemo) {
+        useDemoStore.getState().bulkUpdateStatus(payload.ids, payload.reading_status)
+        return { affected: payload.ids.length, operation: 'status' as const }
+      }
+      return bulkUpdateStatus(payload)
+    },
     onSuccess: async (data) => {
-      await queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: isDemo ? DEMO_QUERY_KEY : BOOKS_QUERY_KEY })
       showSuccess(t('bulk.status_updated', { count: data.affected }))
     },
     onError: (error: unknown) => showError(formatApiError(error)),
@@ -180,11 +235,18 @@ export function useBulkUpdateStatus() {
 
 export function useBookCounts() {
   const { isAuthenticated } = useAuth()
-  const opts = { retry: false, enabled: isAuthenticated, staleTime: 30_000 } as const
-  const total = useQuery({ queryKey: [...BOOKS_QUERY_KEY, 'count'], queryFn: () => listBooks({ pageSize: 1 }), ...opts })
-  const read = useQuery({ queryKey: [...BOOKS_QUERY_KEY, 'count', 'read'], queryFn: () => listBooks({ readingStatus: 'read', pageSize: 1 }), ...opts })
-  const reading = useQuery({ queryKey: [...BOOKS_QUERY_KEY, 'count', 'reading'], queryFn: () => listBooks({ readingStatus: 'reading', pageSize: 1 }), ...opts })
-  const lent = useQuery({ queryKey: [...BOOKS_QUERY_KEY, 'count', 'lent'], queryFn: () => listBooks({ readingStatus: 'lent', pageSize: 1 }), ...opts })
+  const isDemo = useIsDemoMode()
+  const opts = { retry: false, enabled: isDemo || isAuthenticated, staleTime: 30_000 } as const
+  // In demo, the in-memory store returns the same ``BookListResponse`` shape,
+  // so only the data source swaps — the ``.total`` read below is identical.
+  const fetch = (params: BookListParams) => () =>
+    isDemo ? useDemoStore.getState().queryBooks(params) : listBooks(params)
+  const key = (...rest: string[]) =>
+    isDemo ? [...DEMO_QUERY_KEY, ...BOOKS_QUERY_KEY, 'count', ...rest] : [...BOOKS_QUERY_KEY, 'count', ...rest]
+  const total = useQuery({ queryKey: key(), queryFn: fetch({ pageSize: 1 }), ...opts })
+  const read = useQuery({ queryKey: key('read'), queryFn: fetch({ readingStatus: 'read', pageSize: 1 }), ...opts })
+  const reading = useQuery({ queryKey: key('reading'), queryFn: fetch({ readingStatus: 'reading', pageSize: 1 }), ...opts })
+  const lent = useQuery({ queryKey: key('lent'), queryFn: fetch({ readingStatus: 'lent', pageSize: 1 }), ...opts })
   return {
     total: total.data?.total ?? 0,
     read: read.data?.total ?? 0,

--- a/frontend/src/hooks/useDemoHooks.test.tsx
+++ b/frontend/src/hooks/useDemoHooks.test.tsx
@@ -1,0 +1,120 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Demo hooks must never touch the network. Mock the whole API module so any
+// accidental call surfaces as an assertion failure instead of a real request.
+vi.mock('../lib/api', () => ({
+  listBooks: vi.fn(),
+  listBooksForShelf: vi.fn(),
+  getBook: vi.fn(),
+  createBook: vi.fn(),
+  updateBook: vi.fn(),
+  deleteBook: vi.fn(),
+  bulkDeleteBooks: vi.fn(),
+  bulkMoveBooks: vi.fn(),
+  bulkUpdateStatus: vi.fn(),
+  clearSampleLibrary: vi.fn(),
+  getJobStatus: vi.fn(),
+  uploadBookImage: vi.fn(),
+  listLocations: vi.fn(),
+  createLocation: vi.fn(),
+  updateLocation: vi.fn(),
+  deleteLocation: vi.fn(),
+  formatApiError: (e: unknown) => String(e),
+}))
+
+// The demo is for logged-out visitors: prove the hooks work with NO auth.
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: false })),
+}))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: vi.fn(
+    (selector: (s: { showError: () => void; showSuccess: () => void; showInfo: () => void }) => unknown) =>
+      selector({ showError: vi.fn(), showSuccess: vi.fn(), showInfo: vi.fn() }),
+  ),
+}))
+
+import * as api from '../lib/api'
+import { DemoModeProvider } from '../features/demo/DemoContext'
+import { useDemoStore } from '../store/useDemoStore'
+import {
+  useBookCounts,
+  useBooks,
+  useBooksForShelf,
+  useBulkUpdateStatus,
+  useCreateBook,
+} from './useBooks'
+import { useLocations } from './useLocations'
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={qc}>
+      <DemoModeProvider>{children}</DemoModeProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  useDemoStore.getState().reset()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  useDemoStore.getState().reset()
+})
+
+describe('demo-aware hooks (#285)', () => {
+  it('useBooks reads the in-memory store without auth or network', async () => {
+    const { result } = renderHook(() => useBooks({ pageSize: 10, page: 1 }), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.total).toBe(16)
+    expect(result.current.data?.items).toHaveLength(10)
+    expect(api.listBooks).not.toHaveBeenCalled()
+  })
+
+  it('useBooksForShelf returns the full ordered dataset from the store', async () => {
+    const { result } = renderHook(() => useBooksForShelf(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toHaveLength(16)
+    expect(api.listBooksForShelf).not.toHaveBeenCalled()
+  })
+
+  it('useLocations returns the seeded locations from the store', async () => {
+    const { result } = renderHook(() => useLocations(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toHaveLength(3)
+    expect(api.listLocations).not.toHaveBeenCalled()
+  })
+
+  it('useBookCounts mirrors the store reading-status tallies', async () => {
+    const { result } = renderHook(() => useBookCounts(), { wrapper })
+    await waitFor(() => expect(result.current.total).toBe(16))
+    expect(result.current.read).toBe(9)
+    expect(result.current.reading).toBe(2)
+    expect(api.listBooks).not.toHaveBeenCalled()
+  })
+
+  it('useCreateBook appends to the in-memory store (no network)', async () => {
+    const { result } = renderHook(() => useCreateBook(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ title: 'Demo addition', location_id: 'demo-loc-3' })
+    })
+    expect(useDemoStore.getState().counts().total).toBe(17)
+    expect(api.createBook).not.toHaveBeenCalled()
+  })
+
+  it('useBulkUpdateStatus mutates the store and reports affected count', async () => {
+    const { result } = renderHook(() => useBulkUpdateStatus(), { wrapper })
+    await act(async () => {
+      const res = await result.current.mutateAsync({ ids: ['demo-book-12'], reading_status: 'lent' })
+      expect(res.affected).toBe(1)
+    })
+    expect(useDemoStore.getState().counts().lent).toBe(1)
+    expect(api.bulkUpdateStatus).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useLocations.ts
+++ b/frontend/src/hooks/useLocations.ts
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next'
 import { createLocation, deleteLocation, formatApiError, listLocations, updateLocation } from '../lib/api'
 import { useToastStore } from '../lib/toast-store'
 import { useAuth } from '../contexts/AuthContext'
+import { useIsDemoMode } from '../features/demo/DemoContext'
+import { useDemoStore } from '../store/useDemoStore'
 import type { Location, LocationCreateRequest, LocationUpdateRequest } from '../lib/types'
 
 const LOCATIONS_QUERY_KEY = ['locations']
@@ -12,14 +14,18 @@ const LOCATIONS_QUERY_KEY = ['locations']
 /**
  * List the current user's locations. Gated on ``isAuthenticated`` so the
  * query never fires before auth bootstrap has settled (see #125).
+ *
+ * In the client-side demo (#285) it reads the in-memory ``useDemoStore``
+ * under a ``['demo', …]`` key instead — no network call.
  */
 export function useLocations() {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
-    queryKey: LOCATIONS_QUERY_KEY,
-    queryFn: listLocations,
+    queryKey: isDemo ? ['demo', ...LOCATIONS_QUERY_KEY] : LOCATIONS_QUERY_KEY,
+    queryFn: () => (isDemo ? useDemoStore.getState().locations : listLocations()),
     retry: false,
-    enabled: isAuthenticated,
+    enabled: isDemo || isAuthenticated,
   })
 }
 

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -7,6 +7,7 @@ import {
   skipOnboarding,
 } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
+import { useIsDemoMode } from '../features/demo/DemoContext'
 
 export const ONBOARDING_QUERY_KEY = ['onboarding']
 
@@ -14,15 +15,19 @@ export const ONBOARDING_QUERY_KEY = ['onboarding']
  * Fetch onboarding status. Gated on ``isAuthenticated`` so the onboarding
  * wizard doesn't flash for logged-out visitors during an auth transition
  * (see #125).
+ *
+ * In the client-side demo (#285) the query is disabled entirely — there is no
+ * account to onboard, so the wizard must never appear.
  */
 export function useOnboardingStatus() {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
     queryKey: ONBOARDING_QUERY_KEY,
     queryFn: getOnboardingStatus,
     staleTime: 5 * 60 * 1000, // 5 min — rarely changes
     retry: false,
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && !isDemo,
   })
 }
 

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -820,5 +820,11 @@
     "audit_anonymized_by": "Anonymizoval(a) {{email}} — {{date}}",
     "audit_merged_into_by": "Sloučení provedl(a) {{email}}",
     "audit_actor_unknown": "neznámý uživatel"
+  },
+  "demo": {
+    "badge": "Ukázka",
+    "banner_text": "Prohlížíte si živé demo. Změny zůstávají ve vašem prohlížeči a po odchodu se vynulují.",
+    "cta_signup": "Vyzkoušet zdarma",
+    "exit": "Ukončit ukázku"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -814,5 +814,11 @@
     "audit_anonymized_by": "Anonymized by {{email}} on {{date}}",
     "audit_merged_into_by": "Merged by {{email}}",
     "audit_actor_unknown": "unknown user"
+  },
+  "demo": {
+    "badge": "Demo",
+    "banner_text": "You're exploring a live demo. Changes stay in your browser and reset when you leave.",
+    "cta_signup": "Sign up free",
+    "exit": "Exit demo"
   }
 }

--- a/frontend/src/pages/AddBookPage.tsx
+++ b/frontend/src/pages/AddBookPage.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ProcessingIcon } from '../components/EmptyStateIcons'
 import { useCreateBook, useUploadBookImage, useJobStatus } from '../hooks/useBooks'
 import { useLocations } from '../hooks/useLocations'
+import { useIsDemoMode } from '../features/demo/DemoContext'
+import { useAppNavigate } from '../features/demo/demoNav'
 import { useToastStore } from '../lib/toast-store'
 import { ROUTES } from '../lib/routes'
 import type { BookCreateRequest, ReadingStatus } from '../lib/types'
 
 export function AddBookPage() {
   const { t } = useTranslation()
-  const navigate      = useNavigate()
+  const navigate      = useAppNavigate()
+  const isDemo        = useIsDemoMode()
   const showError     = useToastStore(s => s.showError)
   const showSuccess   = useToastStore(s => s.showSuccess)
   const { data: locations = [] } = useLocations()
@@ -88,7 +90,8 @@ export function AddBookPage() {
         <h2 className="text-h2" style={{ marginBottom: 0 }}>{t('add_book.page_title')}</h2>
       </div>
 
-      {/* Scan area */}
+      {/* Scan area — hidden in the demo (#285): no AI/upload pipeline there. */}
+      {!isDemo && (<>
       <div
         onClick={() => fileInputRef.current?.click()}
         style={{
@@ -135,6 +138,7 @@ export function AddBookPage() {
         <span style={{ fontSize: 13, color: 'var(--sh-text-muted)', fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.05em' }}>{t('add_book.or_manual')}</span>
         <hr style={{ flex: 1, border: 'none', borderTop: '1px solid var(--sh-border)' }} />
       </div>
+      </>)}
 
       {/* Form */}
       <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
@@ -196,15 +200,20 @@ export function AddBookPage() {
           </div>
           <p style={{ marginTop: 10, marginBottom: 0, fontSize: 12, color: 'var(--sh-text-muted)' }}>
             {t('add_book.location_help')}
-            {' '}
-            <button
-              type='button'
-              className='sh-btn-ghost'
-              onClick={() => navigate(ROUTES.locations)}
-              style={{ padding: 0, fontSize: 12, textDecoration: 'underline' }}
-            >
-              {t('add_book.add_location_cta')}
-            </button>
+            {/* Location management is network-backed — hidden in demo (#285). */}
+            {!isDemo && (
+              <>
+                {' '}
+                <button
+                  type='button'
+                  className='sh-btn-ghost'
+                  onClick={() => navigate(ROUTES.locations)}
+                  style={{ padding: 0, fontSize: 12, textDecoration: 'underline' }}
+                >
+                  {t('add_book.add_location_cta')}
+                </button>
+              </>
+            )}
           </p>
         </div>
 

--- a/frontend/src/pages/BooksPage.demo.test.tsx
+++ b/frontend/src/pages/BooksPage.demo.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Demo-mode behaviour for BooksPage (#285).
+ *
+ * Renders the real page inside the DemoModeProvider with the real demo hooks
+ * and in-memory store (no network). Asserts the page is fully usable for a
+ * logged-out visitor and that network-only affordances are suppressed.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Logged-out visitor — the demo must not depend on auth.
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: false })),
+}))
+
+// Stub the API so the test fails loudly if the demo ever reaches the network.
+vi.mock('../lib/api', () => ({
+  listBooks: vi.fn(),
+  listBooksForShelf: vi.fn(),
+  getBook: vi.fn(),
+  createBook: vi.fn(),
+  updateBook: vi.fn(),
+  deleteBook: vi.fn(),
+  bulkDeleteBooks: vi.fn(),
+  bulkMoveBooks: vi.fn(),
+  bulkUpdateStatus: vi.fn(),
+  clearSampleLibrary: vi.fn(),
+  getJobStatus: vi.fn(),
+  uploadBookImage: vi.fn(),
+  listLocations: vi.fn(),
+  getOnboardingStatus: vi.fn(),
+  completeOnboarding: vi.fn(),
+  skipOnboarding: vi.fn(),
+  resetOnboarding: vi.fn(),
+  formatApiError: (e: unknown) => String(e),
+}))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: vi.fn(
+    (selector: (s: { showError: () => void; showSuccess: () => void; showInfo: () => void }) => unknown) =>
+      selector({ showError: vi.fn(), showSuccess: vi.fn(), showInfo: vi.fn() }),
+  ),
+}))
+
+import * as api from '../lib/api'
+import { BooksPage } from './BooksPage'
+import { DemoModeProvider } from '../features/demo/DemoContext'
+import { useDemoStore } from '../store/useDemoStore'
+
+function renderDemo() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/demo/books']}>
+        <DemoModeProvider>{children}</DemoModeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+  return render(<BooksPage />, { wrapper })
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  useDemoStore.getState().reset()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+  useDemoStore.getState().reset()
+})
+
+describe('BooksPage — demo mode (#285)', () => {
+  it('renders seeded books from the in-memory store without any network call', async () => {
+    renderDemo()
+    expect((await screen.findAllByText('Proměna')).length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Hobit').length).toBeGreaterThan(0)
+    expect(api.listBooks).not.toHaveBeenCalled()
+  })
+
+  it('hides the sample-library banner even though demo books are samples', async () => {
+    renderDemo()
+    await screen.findAllByText('Proměna')
+    expect(screen.queryByTestId('sample-library-banner')).not.toBeInTheDocument()
+  })
+
+  it('renders book cards as non-navigating elements (no detail links)', async () => {
+    renderDemo()
+    await screen.findAllByText('Proměna')
+    // BookCard links to /books/:id outside the demo; inside it must not.
+    expect(document.querySelector('a[href^="/books/"]')).toBeNull()
+  })
+})

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
 import { BookCard } from '../components/BookCard'
@@ -13,6 +12,8 @@ import { useBulkDeleteBooks, useBulkMoveBooks, useBulkUpdateStatus, useBookCount
 import { useDebounce } from '../hooks/useDebounce'
 import { useLocations } from '../hooks/useLocations'
 import { useOnboardingStatus } from '../hooks/useOnboarding'
+import { useIsDemoMode } from '../features/demo/DemoContext'
+import { useAppNavigate } from '../features/demo/demoNav'
 import { useToastStore } from '../lib/toast-store'
 import { ROUTES } from '../lib/routes'
 import type { Book, Location, ReadingStatus } from '../lib/types'
@@ -23,7 +24,8 @@ const PAGE_SIZE = 20
 
 export function BooksPage() {
   const { t } = useTranslation()
-  const navigate = useNavigate()
+  const navigate = useAppNavigate()
+  const isDemo = useIsDemoMode()
   const [searchInput, setSearchInput] = useState('')
   const debouncedSearch = useDebounce(searchInput.trim(), 300)
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
@@ -419,7 +421,9 @@ export function BooksPage() {
         </p>
       )}
 
-      {booksQuery.data?.has_sample_books && (
+      {/* The whole demo library is sample data; its "clear samples" action is a
+          network call, so the banner is suppressed in demo mode (#285). */}
+      {!isDemo && booksQuery.data?.has_sample_books && (
         <div
           data-testid="sample-library-banner"
           style={{

--- a/frontend/src/pages/BookshelfViewPage.tsx
+++ b/frontend/src/pages/BookshelfViewPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import {
@@ -31,13 +31,17 @@ import { useBooksForShelf, useBulkMoveBooks } from '../hooks/useBooks'
 import { bulkReorderBooks } from '../lib/api'
 import { useToastStore } from '../lib/toast-store'
 import { useLocations } from '../hooks/useLocations'
+import { useIsDemoMode } from '../features/demo/DemoContext'
+import { useDemoStore } from '../store/useDemoStore'
+import { useAppNavigate } from '../features/demo/demoNav'
 import { ROUTES, getBookDetailRoute } from '../lib/routes'
 import { LocationsPage } from './LocationsPage'
 import type { Book, Location } from '../lib/types'
 
 export function BookshelfViewPage() {
   const { t } = useTranslation()
-  const navigate = useNavigate()
+  const navigate = useAppNavigate()
+  const isDemo = useIsDemoMode()
   const [searchParams] = useSearchParams()
   const showError = useToastStore((s) => s.showError)
   const showSuccess = useToastStore((s) => s.showSuccess)
@@ -51,7 +55,9 @@ export function BookshelfViewPage() {
 
   const preselectedLocationId = searchParams.get('location_id')
   const highlightBookId = searchParams.get('highlight_book_id')
-  const activeTab = searchParams.get('tab') === 'locations' ? 'locations' : 'shelves'
+  // The locations tab edits real locations (network-backed) and is hidden in
+  // the demo, so force the shelves view there regardless of the query param.
+  const activeTab = !isDemo && searchParams.get('tab') === 'locations' ? 'locations' : 'shelves'
   const highlightSpineRef = useRef<HTMLButtonElement | null>(null)
   const shelfRefs = useRef<Map<string, HTMLDivElement>>(new Map())
 
@@ -298,7 +304,12 @@ export function BookshelfViewPage() {
 
     setSavingReorder(true)
     try {
-      await bulkReorderBooks({ items: changed })
+      if (isDemo) {
+        // Demo: mutate the in-memory store directly — no network. (#285)
+        useDemoStore.getState().reorder(changed)
+      } else {
+        await bulkReorderBooks({ items: changed })
+      }
       showSuccess(t('books.reorder_saved', 'Reordering saved'))
     } catch {
       setLocalByLocation(booksByLocation)
@@ -400,15 +411,21 @@ export function BookshelfViewPage() {
             </button>
           </>
         )}
-        <button onClick={() => navigate(ROUTES.scanShelf)} className="sh-btn-primary hover-scale" style={{ padding: isMobile ? '8px 12px' : '10px 20px', fontSize: isMobile ? 13 : 14, marginLeft: isMobile ? 'auto' : 0 }}>
-          + {t('bookshelf.scan_shelf')}
-        </button>
+        {/* Scan entry point hits the AI pipeline — hidden in the demo (#285). */}
+        {!isDemo && (
+          <button onClick={() => navigate(ROUTES.scanShelf)} className="sh-btn-primary hover-scale" style={{ padding: isMobile ? '8px 12px' : '10px 20px', fontSize: isMobile ? 13 : 14, marginLeft: isMobile ? 'auto' : 0 }}>
+            + {t('bookshelf.scan_shelf')}
+          </button>
+        )}
       </div>
 
-      <div className="sh-underline-tabs" style={{ marginBottom: 24 }}>
-        <button type='button' className={`sh-underline-tab${activeTab === 'shelves' ? ' sh-underline-tab--active' : ''}`} onClick={() => navigate(ROUTES.bookshelfView)}>{t('bookshelf.tab_shelves')}</button>
-        <button type='button' className={`sh-underline-tab${activeTab === 'locations' ? ' sh-underline-tab--active' : ''}`} onClick={() => navigate(`${ROUTES.bookshelfView}?tab=locations`)}>{t('bookshelf.tab_locations')}</button>
-      </div>
+      {/* Locations management is network-backed — only shelves in the demo. */}
+      {!isDemo && (
+        <div className="sh-underline-tabs" style={{ marginBottom: 24 }}>
+          <button type='button' className={`sh-underline-tab${activeTab === 'shelves' ? ' sh-underline-tab--active' : ''}`} onClick={() => navigate(ROUTES.bookshelfView)}>{t('bookshelf.tab_shelves')}</button>
+          <button type='button' className={`sh-underline-tab${activeTab === 'locations' ? ' sh-underline-tab--active' : ''}`} onClick={() => navigate(`${ROUTES.bookshelfView}?tab=locations`)}>{t('bookshelf.tab_locations')}</button>
+        </div>
+      )}
 
       {activeTab === 'locations' ? (
         <LocationsPage />
@@ -513,7 +530,7 @@ export function BookshelfViewPage() {
                                   highlighted={highlightBookId === book.id}
                                   selected={selectedIds.has(book.id)}
                                   focusRef={highlightBookId === book.id ? highlightSpineRef : undefined}
-                                  onClick={() => (selectMode ? toggleSelect(book.id) : (reorderMode ? undefined : navigate(getBookDetailRoute(book.id))))}
+                                  onClick={() => (selectMode ? toggleSelect(book.id) : (reorderMode || isDemo ? undefined : navigate(getBookDetailRoute(book.id))))}
                                   compact={isMobile}
                                 />
                               ))}

--- a/frontend/src/styles/shelfy.css
+++ b/frontend/src/styles/shelfy.css
@@ -300,6 +300,61 @@ a:focus-visible,
   padding-bottom: 0;
 }
 
+/* ── Demo banner (#285) ───────────────────────────────────────────── */
+.sh-demo-banner {
+  position: sticky;
+  top: 0;
+  z-index: var(--sh-z-nav);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 8px 16px;
+  background: var(--sh-primary-bg);
+  border-bottom: 1px solid var(--sh-border);
+  color: var(--sh-primary-text);
+  font-size: 13px;
+}
+.sh-demo-banner__badge {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  border-radius: var(--sh-radius-pill);
+  background: var(--sh-primary);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.sh-demo-banner__text {
+  flex: 1 1 220px;
+  min-width: 0;
+}
+.sh-demo-banner__actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+}
+.sh-demo-banner__exit {
+  color: var(--sh-primary-text);
+  text-decoration: underline;
+  font-weight: 500;
+}
+.sh-demo-banner__cta {
+  padding: 6px 14px;
+  border-radius: var(--sh-radius-pill);
+  background: var(--sh-primary);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.sh-demo-banner__cta:hover {
+  background: var(--sh-primary-dark);
+}
+
 /* ── Bottom Nav (mobile) ──────────────────────────────────────────── */
 .sh-bottom-nav {
   position: fixed;


### PR DESCRIPTION
## Summary

Implements **#285** — the public client-side demo. Logged-out visitors at `/demo/*` can browse, search, add, edit, bulk-act on, and drag-reorder books **entirely in the browser**, backed by the in-memory `useDemoStore` from #284. No data/AI/upload calls hit the backend.

Builds on #284 (merged in #288).

## What's in it

- **Demo-aware hooks** (`useBooks`, `useBooksForShelf`, `useBook`, `useBookCounts`, `useCreateBook`/`Update`/`Delete`, `useBulkDelete`/`Move`/`UpdateStatus`, `useLocations`, `useOnboardingStatus`): branch on `useIsDemoMode()` to swap `queryFn` to the in-memory store, scope cache under a separate `['demo', …]` key space, drop the `enabled: isAuthenticated` gate, and invalidate `['demo']` on mutation. The authenticated app's code paths and cache are untouched (prod-only invalidators like `useScan`/`useEnrich` are inert in demo).
- **`features/demo/demoNav.ts`** — `useAppNavigate` / `useDemoPath` keep the reused pages' navigation inside the `/demo/*` subtree (identity outside the demo).
- **Routes** — public `/demo/{books,books/new,bookshelf}` (+ `/demo` → `/demo/books`) behind `DemoLayout` (`DemoModeProvider` + `DemoBanner`). `hideNav` is now prefix-aware so the authenticated `Navigation` never shows in demo.
- **Page adaptations** — BookshelfView reorder routes through `useDemoStore.reorder` instead of `bulkReorderBooks`; network-only affordances are hidden in demo (sample-library banner, onboarding wizard, locations tab, photo-scan area, add-location link); book cards render non-navigating (there's no demo detail route).
- **i18n** — `demo.*` strings (cs + en).

## Test plan

- [x] `npm run lint` — 0 errors (6 pre-existing warnings)
- [x] `npm run build` — succeeds
- [x] `vitest run` — 227 passed (was 209; +18 new across 3 files)
  - `demoNav.test.tsx` — prefix idempotency + nav/path rewriting in & out of demo
  - `useDemoHooks.test.tsx` — hooks read/write the store with **no auth and no network** (api module mocked, asserted not called)
  - `BooksPage.demo.test.tsx` — seeded books render, sample banner hidden, cards non-navigating
- [ ] Manual: visit `/demo`, search, add a book, reorder a shelf, refresh (session persists), open a new tab (pristine seed)

Follow-ups: #286 (scripted photo-scan + `/demo/scan`), #287 (landing CTA + conversion nudge + analytics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)