### PR TITLE
feat(demo): scripted shelf-scan walkthrough (#286)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,6 +109,7 @@ function AppShell() {
             <Route index element={<Navigate to='/demo/books' replace />} />
             <Route path='books' element={<BooksPage />} />
             <Route path='books/new' element={<AddBookPage />} />
+            <Route path='scan' element={<ScanShelfPage />} />
             <Route path='bookshelf' element={<BookshelfViewPage />} />
           </Route>
 

--- a/frontend/src/features/demo/DemoShelfPhoto.tsx
+++ b/frontend/src/features/demo/DemoShelfPhoto.tsx
@@ -1,0 +1,68 @@
+/**
+ * DemoShelfPhoto — a lightweight inline SVG that stands in for a real shelf
+ * photo in the scripted demo scan (#286).
+ *
+ * We deliberately avoid bundling binary JPG/WEBP assets: the PWA precache
+ * (`vite.config.ts` workbox `globPatterns`) excludes those formats, and a real
+ * photo would imply an upload that the demo must never perform. An inline SVG
+ * of colourful book spines reads clearly as "a shelf of books", stays text-only
+ * (no network, no precache concern), and scales crisply.
+ */
+interface DemoShelfPhotoProps {
+  /** Base hue (degrees) so each sample photo looks distinct. */
+  hue?: number
+  /** Number of spines to draw. */
+  spines?: number
+}
+
+export function DemoShelfPhoto({ hue = 175, spines = 9 }: DemoShelfPhotoProps) {
+  const width = 240
+  const height = 150
+  const padding = 10
+  const usable = width - padding * 2
+  const gap = 4
+  const spineWidth = (usable - gap * (spines - 1)) / spines
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width="100%"
+      role="img"
+      aria-hidden="true"
+      style={{ display: 'block', borderRadius: 'var(--sh-radius-md)' }}
+    >
+      <rect x="0" y="0" width={width} height={height} fill={`hsl(${hue} 30% 16%)`} />
+      {Array.from({ length: spines }).map((_, i) => {
+        const x = padding + i * (spineWidth + gap)
+        // Pseudo-random but deterministic per index.
+        const seed = (i * 73 + 17) % 100
+        const lightness = 42 + (seed % 30)
+        const spineHue = (hue + seed * 1.6) % 360
+        const top = padding + (seed % 16)
+        return (
+          <g key={i}>
+            <rect
+              x={x}
+              y={top}
+              width={spineWidth}
+              height={height - top - padding}
+              rx="2"
+              fill={`hsl(${spineHue} 45% ${lightness}%)`}
+            />
+            <rect
+              x={x + spineWidth * 0.2}
+              y={top + 14}
+              width={spineWidth * 0.6}
+              height={height - top - padding - 28}
+              rx="1"
+              fill={`hsl(${spineHue} 45% ${lightness + 12}%)`}
+              opacity="0.55"
+            />
+          </g>
+        )
+      })}
+      {/* Shelf board */}
+      <rect x="0" y={height - padding} width={width} height={padding} fill={`hsl(${hue} 25% 10%)`} />
+    </svg>
+  )
+}

--- a/frontend/src/features/demo/demoScan.ts
+++ b/frontend/src/features/demo/demoScan.ts
@@ -1,0 +1,94 @@
+/**
+ * Canned shelf-scan fixtures for the public client-side demo (#286).
+ *
+ * The real scan flow uploads a photo to the backend and runs an AI vision
+ * pipeline. The demo must do **none** of that — zero upload, zero AI, zero
+ * network. Instead, tapping a "sample photo" in the demo replays one of these
+ * pre-baked results, so visitors can experience the full
+ * scan → review → confirm wizard without generating any server load.
+ *
+ * Each photo yields a deterministic list of `ScannedBookItem`s. We deliberately
+ * include a `needs_review` / no-text entry so the review step's
+ * low-confidence affordances are visible in the demo.
+ */
+import type { ScannedBookItem } from '../../lib/types'
+
+export interface DemoScanPhoto {
+  /** Stable id — also used to derive the segment jobId and de-dupe tiles. */
+  id: string
+  /** Accent hue (degrees) used by the SVG illustration for visual variety. */
+  hue: number
+  /** Pre-baked detection result for this photo. */
+  books: ScannedBookItem[]
+}
+
+export const DEMO_SCAN_PHOTOS: readonly DemoScanPhoto[] = [
+  {
+    id: 'photo-1',
+    hue: 175,
+    books: [
+      {
+        position: 0,
+        title: 'Krakatit',
+        author: 'Karel Čapek',
+        isbn: null,
+        observed_text: 'KRAKATIT — Karel Čapek',
+        confidence: 'auto',
+      },
+      {
+        position: 1,
+        title: 'Bílá nemoc',
+        author: 'Karel Čapek',
+        isbn: null,
+        observed_text: 'Bílá nemoc',
+        confidence: 'auto',
+      },
+      {
+        position: 2,
+        title: 'Saturnin',
+        author: 'Zdeněk Jirotka',
+        isbn: null,
+        observed_text: 'SATURNIN  Z. Jirotka',
+        confidence: 'auto',
+      },
+      {
+        position: 3,
+        title: null,
+        author: null,
+        isbn: null,
+        observed_text: 'no visible text',
+        confidence: 'needs_review',
+      },
+    ],
+  },
+  {
+    id: 'photo-2',
+    hue: 25,
+    books: [
+      {
+        position: 0,
+        title: 'Fahrenheit 451',
+        author: 'Ray Bradbury',
+        isbn: null,
+        observed_text: 'FAHRENHEIT 451 · Ray Bradbury',
+        confidence: 'auto',
+      },
+      {
+        position: 1,
+        title: 'Marťan',
+        author: 'Andy Weir',
+        isbn: null,
+        observed_text: 'Marťan / Andy Weir',
+        confidence: 'auto',
+      },
+      {
+        position: 2,
+        title: 'Nadace',
+        author: 'Isaac Asimov',
+        isbn: null,
+        observed_text: 'NADACE  Asimov',
+        confidence: 'auto',
+      },
+    ],
+  },
+] as const

--- a/frontend/src/hooks/useScan.ts
+++ b/frontend/src/hooks/useScan.ts
@@ -10,9 +10,11 @@ import {
   scanShelf,
 } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
+import { useIsDemoMode } from '../features/demo/DemoContext'
 import { useToastStore } from '../lib/toast-store'
+import { useDemoStore } from '../store/useDemoStore'
 import type { ShelfScanConfirmRequest } from '../lib/types'
-import { BOOKS_QUERY_KEY } from './useBooks'
+import { BOOKS_QUERY_KEY, DEMO_QUERY_KEY } from './useBooks'
 
 export function useScanShelf() {
   const showError = useToastStore((state) => state.showError)
@@ -45,11 +47,13 @@ export function useConfirmShelfScan() {
   const showError = useToastStore((state) => state.showError)
   const showSuccess = useToastStore((state) => state.showSuccess)
   const { t } = useTranslation()
+  const isDemo = useIsDemoMode()
 
   return useMutation({
-    mutationFn: (payload: ShelfScanConfirmRequest) => confirmShelfScan(payload),
+    mutationFn: async (payload: ShelfScanConfirmRequest) =>
+      isDemo ? useDemoStore.getState().confirmShelfScan(payload) : confirmShelfScan(payload),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: isDemo ? DEMO_QUERY_KEY : BOOKS_QUERY_KEY })
       showSuccess(t('toast.scan_confirmed', 'Books saved to your library!'))
     },
     onError: (error: unknown) => {
@@ -60,10 +64,14 @@ export function useConfirmShelfScan() {
 
 export function useBooksByLocation(locationId: string | null) {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
-    queryKey: ['books-by-location', locationId],
-    queryFn: () => listBooksByLocation(locationId as string),
-    enabled: isAuthenticated && Boolean(locationId),
+    queryKey: isDemo ? [...DEMO_QUERY_KEY, 'books-by-location', locationId] : ['books-by-location', locationId],
+    queryFn: () =>
+      isDemo
+        ? useDemoStore.getState().booksByLocation(locationId as string)
+        : listBooksByLocation(locationId as string),
+    enabled: (isDemo || isAuthenticated) && Boolean(locationId),
     retry: false,
   })
 }

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -825,6 +825,9 @@
     "badge": "Ukázka",
     "banner_text": "Prohlížíte si živé demo. Změny zůstávají ve vašem prohlížeči a po odchodu se vynulují.",
     "cta_signup": "Vyzkoušet zdarma",
-    "exit": "Ukončit ukázku"
+    "exit": "Ukončit ukázku",
+    "scan_note": "Tohle je ukázka — klepněte na vzorovou fotku a uvidíte výsledek. Žádná fotka se nenahrává a neběží žádná AI.",
+    "scan_sample": "Naskenovat vzorovou fotku {{n}}",
+    "scan_sample_used": "Vzorová fotka {{n}} naskenována"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -819,6 +819,9 @@
     "badge": "Demo",
     "banner_text": "You're exploring a live demo. Changes stay in your browser and reset when you leave.",
     "cta_signup": "Sign up free",
-    "exit": "Exit demo"
+    "exit": "Exit demo",
+    "scan_note": "This is a scripted demo — tap a sample photo to see the result. No photo is uploaded and no AI runs.",
+    "scan_sample": "Scan sample photo {{n}}",
+    "scan_sample_used": "Sample photo {{n}} scanned"
   }
 }

--- a/frontend/src/pages/BookshelfViewPage.tsx
+++ b/frontend/src/pages/BookshelfViewPage.tsx
@@ -411,12 +411,11 @@ export function BookshelfViewPage() {
             </button>
           </>
         )}
-        {/* Scan entry point hits the AI pipeline — hidden in the demo (#285). */}
-        {!isDemo && (
-          <button onClick={() => navigate(ROUTES.scanShelf)} className="sh-btn-primary hover-scale" style={{ padding: isMobile ? '8px 12px' : '10px 20px', fontSize: isMobile ? 13 : 14, marginLeft: isMobile ? 'auto' : 0 }}>
-            + {t('bookshelf.scan_shelf')}
-          </button>
-        )}
+        {/* Scan entry point. In the demo this routes to the scripted, canned
+            scan walkthrough (#286) — still no upload / AI / network. */}
+        <button onClick={() => navigate(ROUTES.scanShelf)} className="sh-btn-primary hover-scale" style={{ padding: isMobile ? '8px 12px' : '10px 20px', fontSize: isMobile ? 13 : 14, marginLeft: isMobile ? 'auto' : 0 }}>
+          + {t('bookshelf.scan_shelf')}
+        </button>
       </div>
 
       {/* Locations management is network-backed — only shelves in the demo. */}

--- a/frontend/src/pages/ScanShelfPage.demo.test.tsx
+++ b/frontend/src/pages/ScanShelfPage.demo.test.tsx
@@ -107,5 +107,5 @@ describe('ScanShelfPage — demo mode (#286)', () => {
     expect(api.scanShelf).not.toHaveBeenCalled()
     expect(api.getShelfScanResult).not.toHaveBeenCalled()
     expect(api.confirmShelfScan).not.toHaveBeenCalled()
-  })
+  }, 20000) // multi-step wizard + simulated scan delay; generous for slow CI
 })

--- a/frontend/src/pages/ScanShelfPage.demo.test.tsx
+++ b/frontend/src/pages/ScanShelfPage.demo.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Demo-mode behaviour for ScanShelfPage — the scripted shelf-scan walkthrough
+ * (#286).
+ *
+ * Drives the full wizard (location → scan → review → confirm) for a logged-out
+ * visitor and asserts:
+ *  - tapping a sample photo replays a canned result (no upload / AI / network),
+ *  - confirming writes the books into the in-memory demo store,
+ *  - the scan API surface is never touched.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: false })),
+}))
+
+// Loud stubs: any reach for the network fails the demo's core promise.
+vi.mock('../lib/api', () => ({
+  scanShelf: vi.fn(),
+  getShelfScanResult: vi.fn(),
+  confirmShelfScan: vi.fn(),
+  listBooksByLocation: vi.fn(),
+  listLocations: vi.fn(),
+  createLocation: vi.fn(),
+  formatApiError: (e: unknown) => String(e),
+}))
+
+vi.mock('../lib/analytics', () => ({ trackEvent: vi.fn() }))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: vi.fn(
+    (selector: (s: { showError: () => void; showSuccess: () => void; showInfo: () => void }) => unknown) =>
+      selector({ showError: vi.fn(), showSuccess: vi.fn(), showInfo: vi.fn() }),
+  ),
+}))
+
+import * as api from '../lib/api'
+import { ScanShelfPage } from './ScanShelfPage'
+import { DemoModeProvider } from '../features/demo/DemoContext'
+import { useDemoStore } from '../store/useDemoStore'
+
+function renderDemo() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/demo/scan']}>
+        <DemoModeProvider>{children}</DemoModeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+  return render(<ScanShelfPage />, { wrapper })
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  useDemoStore.getState().reset()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+  useDemoStore.getState().reset()
+})
+
+describe('ScanShelfPage — demo mode (#286)', () => {
+  it('runs the scripted scan and writes results to the in-memory store, no network', async () => {
+    renderDemo()
+
+    // ── Step 1: pick the seeded Living room / Bookcase / Shelf 1 ──
+    // Locations arrive asynchronously from the demo store via React Query.
+    await waitFor(() =>
+      expect(screen.getAllByRole('combobox')[0].querySelectorAll('option').length).toBeGreaterThan(1),
+    )
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'Living room' } })
+    fireEvent.change(screen.getAllByRole('combobox')[1], { target: { value: 'Bookcase' } })
+    fireEvent.change(screen.getAllByRole('combobox')[2], { target: { value: 'Shelf 1' } })
+    fireEvent.click(screen.getByText('scan.next_step'))
+
+    // ── Step 2: a sample photo, not a file input, drives the scan ──
+    expect(screen.getByTestId('demo-scan-note')).toBeInTheDocument()
+    expect(document.querySelector('input[type="file"]')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('demo-scan-photo-photo-1'))
+
+    // Canned result lands after the simulated processing delay.
+    await waitFor(() => expect(screen.getByText('scan.go_to_review')).toBeInTheDocument(), { timeout: 2000 })
+    fireEvent.click(screen.getByText('scan.go_to_review'))
+
+    // ── Step 3: review shows the detected titles ──
+    expect(await screen.findByDisplayValue('Krakatit')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Saturnin')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('scan.confirm_books'))
+
+    // Replace mode wiped the 6 seeded Shelf-1 books and wrote the 3 named ones
+    // (the no-text / needs-review entry was dropped for having no title).
+    await waitFor(() => {
+      const shelf = useDemoStore.getState().booksByLocation('demo-loc-1')
+      expect(shelf.map((b) => b.title)).toEqual(['Krakatit', 'Bílá nemoc', 'Saturnin'])
+    })
+
+    expect(api.scanShelf).not.toHaveBeenCalled()
+    expect(api.getShelfScanResult).not.toHaveBeenCalled()
+    expect(api.confirmShelfScan).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/ScanShelfPage.tsx
+++ b/frontend/src/pages/ScanShelfPage.tsx
@@ -1,9 +1,13 @@
 import { Fragment, useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
 import { BookshelfInlineIcon, CameraIcon, ProcessingIcon } from '../components/EmptyStateIcons'
 import { Modal } from '../components/Modal'
+import { useIsDemoMode } from '../features/demo/DemoContext'
+import { DemoShelfPhoto } from '../features/demo/DemoShelfPhoto'
+import { DEMO_SCAN_PHOTOS } from '../features/demo/demoScan'
+import { useAppNavigate } from '../features/demo/demoNav'
 import { useLocations, useCreateLocation } from '../hooks/useLocations'
 import { useBooksByLocation, useConfirmShelfScan, useScanShelf, useShelfScanResult } from '../hooks/useScan'
 import { useToastStore } from '../lib/toast-store'
@@ -50,7 +54,8 @@ const SCAN_DRAFT_KEY = 'shelfy:scan-shelf-draft:v1'
 
 export function ScanShelfPage() {
   const { t } = useTranslation()
-  const navigate = useNavigate()
+  const navigate = useAppNavigate()
+  const isDemo = useIsDemoMode()
   const [searchParams] = useSearchParams()
   const showError = useToastStore(s => s.showError)
 
@@ -90,6 +95,8 @@ export function ScanShelfPage() {
   const [pendingDraft, setPendingDraft] = useState<ScanDraft | null>(null)
   const [tipsDismissed, setTipsDismissed] = useState(() => localStorage.getItem('shelfy_scan_tips_dismissed') === '1')
   const [confirmRemoveSegmentIdx, setConfirmRemoveSegmentIdx] = useState<number | null>(null)
+  // Demo-only: a brief simulated "scanning" state while the canned result lands.
+  const [demoScanning, setDemoScanning] = useState(false)
 
   const { data: booksAtLocation = [] } = useBooksByLocation(locationId)
   const existingShelfBooks = [...booksAtLocation].sort((a, b) => (a.shelf_position ?? 99999) - (b.shelf_position ?? 99999))
@@ -119,6 +126,8 @@ export function ScanShelfPage() {
 
 
   useEffect(() => {
+    // The demo never persists a draft (keeps localStorage clean + isolated).
+    if (isDemo) return
     try {
       const raw = localStorage.getItem(SCAN_DRAFT_KEY)
       if (!raw) return
@@ -131,7 +140,7 @@ export function ScanShelfPage() {
     } catch {
       localStorage.removeItem(SCAN_DRAFT_KEY)
     }
-  }, [])
+  }, [isDemo])
 
   const hasAutoExpandedNewLocationRef = useRef(false)
   useEffect(() => {
@@ -142,6 +151,7 @@ export function ScanShelfPage() {
   }, [locationsLoading, locations.length])
 
   useEffect(() => {
+    if (isDemo) return
     const hasDraftData =
       step !== 'location'
       || !!selRoom
@@ -184,7 +194,7 @@ export function ScanShelfPage() {
     }, 400)
 
     return () => clearTimeout(timer)
-  }, [step, selRoom, selFurniture, selShelf, newRoom, newFurniture, newShelf, showNewLocation, segments, editableBooks, locationId, scanMode, appendAfterBookId])
+  }, [isDemo, step, selRoom, selFurniture, selShelf, newRoom, newFurniture, newShelf, showNewLocation, segments, editableBooks, locationId, scanMode, appendAfterBookId])
 
   useEffect(() => {
     const preLocationId = searchParams.get('location_id')
@@ -205,7 +215,7 @@ export function ScanShelfPage() {
 
   // Derived state
   const totalBooksFound = segments.reduce((sum, seg) => sum + seg.books.length, 0)
-  const isProcessing = scanMutation.isPending || activeJobId !== null
+  const isProcessing = scanMutation.isPending || activeJobId !== null || demoScanning
   const hasCompletedSegments = segments.some(seg => seg.status === 'done' && seg.books.length > 0)
 
   function handleLocationNext() {
@@ -261,6 +271,26 @@ export function ScanShelfPage() {
         },
       }
     )
+  }
+
+  // Demo-only: replay a canned scan result for a sample photo. No upload, no
+  // AI, no network — just a short simulated "scanning" pause (#286).
+  function handleDemoScan(photoId: string) {
+    if (isProcessing) return
+    const photo = DEMO_SCAN_PHOTOS.find(p => p.id === photoId)
+    if (!photo) return
+    const jobId = `demo-scan-${photo.id}`
+    if (segments.some(seg => seg.jobId === jobId)) return // already scanned
+
+    const photoIndex = segments.length
+    setDemoScanning(true)
+    setSegments(prev => [...prev, { jobId, photoIndex, status: 'processing', books: [] }])
+    window.setTimeout(() => {
+      setSegments(prev => prev.map(seg =>
+        seg.jobId === jobId ? { ...seg, status: 'done', books: [...photo.books] } : seg
+      ))
+      setDemoScanning(false)
+    }, 900)
   }
 
   const handleGoToReview = useCallback(() => {
@@ -703,38 +733,92 @@ export function ScanShelfPage() {
             </button>
           )}
 
-          {/* Upload area */}
-          <div
-            onClick={() => !isProcessing && fileInputRef.current?.click()}
-            className={`sh-upload-area hover-lift${isProcessing ? ' sh-upload-area--processing' : ''}`}
-            style={{ marginBottom: 16 }}
-          >
-            {isProcessing ? (
-              <>
-                <ProcessingIcon size={48} className="sh-icon-processing" />
-                <span className="text-p" style={{ fontWeight: 600, color: 'var(--sh-amber-text)' }}>{t('scan.scanning')}</span>
-                <span className="text-small">{t('scan.scanning_desc')}</span>
-              </>
-            ) : (
-              <>
-                <CameraIcon size={48} style={{ color: 'var(--sh-primary)', filter: 'drop-shadow(0 4px 6px rgba(0,0,0,0.08))' }} />
-                <span className="text-p" style={{ fontWeight: 600, color: 'var(--sh-text-main)' }}>
-                  {segments.length === 0 ? t('scan.take_photo') : t('scan.take_next_photo')}
-                </span>
-                <span className="text-small">
-                  {segments.length === 0 ? t('scan.take_photo_desc') : t('scan.take_next_photo_desc')}
-                </span>
-              </>
-            )}
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/jpeg,image/png"
-              capture="environment"
-              style={{ display: 'none' }}
-              onChange={handleFileSelect}
-            />
-          </div>
+          {/* Upload area — in the demo this is replaced by tappable sample
+              photos that replay a canned result (no upload / AI / network). */}
+          {isDemo ? (
+            <div style={{ marginBottom: 16 }}>
+              <div
+                data-testid="demo-scan-note"
+                style={{
+                  padding: '10px 14px', marginBottom: 12,
+                  background: 'var(--sh-teal-bg)', borderRadius: 'var(--sh-radius-md)',
+                  fontSize: 13, color: 'var(--sh-teal)', fontWeight: 500,
+                }}
+              >
+                {t('demo.scan_note')}
+              </div>
+              {isProcessing ? (
+                <div className="sh-upload-area sh-upload-area--processing">
+                  <ProcessingIcon size={48} className="sh-icon-processing" />
+                  <span className="text-p" style={{ fontWeight: 600, color: 'var(--sh-amber-text)' }}>{t('scan.scanning')}</span>
+                  <span className="text-small">{t('scan.scanning_desc')}</span>
+                </div>
+              ) : (
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12 }}>
+                  {DEMO_SCAN_PHOTOS.map((photo, i) => {
+                    const used = segments.some(seg => seg.jobId === `demo-scan-${photo.id}`)
+                    return (
+                      <button
+                        key={photo.id}
+                        type="button"
+                        data-testid={`demo-scan-photo-${photo.id}`}
+                        onClick={() => handleDemoScan(photo.id)}
+                        disabled={used}
+                        className="sh-card-panel hover-lift"
+                        style={{
+                          padding: 8, cursor: used ? 'default' : 'pointer',
+                          border: 'none', textAlign: 'left',
+                          opacity: used ? 0.5 : 1,
+                        }}
+                      >
+                        <DemoShelfPhoto hue={photo.hue} />
+                        <span style={{
+                          display: 'flex', alignItems: 'center', gap: 6,
+                          marginTop: 8, fontSize: 13, fontWeight: 600,
+                          color: 'var(--sh-text-main)',
+                        }}>
+                          <CameraIcon size={16} style={{ color: 'var(--sh-primary)' }} />
+                          {used ? t('demo.scan_sample_used', { n: i + 1 }) : t('demo.scan_sample', { n: i + 1 })}
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div
+              onClick={() => !isProcessing && fileInputRef.current?.click()}
+              className={`sh-upload-area hover-lift${isProcessing ? ' sh-upload-area--processing' : ''}`}
+              style={{ marginBottom: 16 }}
+            >
+              {isProcessing ? (
+                <>
+                  <ProcessingIcon size={48} className="sh-icon-processing" />
+                  <span className="text-p" style={{ fontWeight: 600, color: 'var(--sh-amber-text)' }}>{t('scan.scanning')}</span>
+                  <span className="text-small">{t('scan.scanning_desc')}</span>
+                </>
+              ) : (
+                <>
+                  <CameraIcon size={48} style={{ color: 'var(--sh-primary)', filter: 'drop-shadow(0 4px 6px rgba(0,0,0,0.08))' }} />
+                  <span className="text-p" style={{ fontWeight: 600, color: 'var(--sh-text-main)' }}>
+                    {segments.length === 0 ? t('scan.take_photo') : t('scan.take_next_photo')}
+                  </span>
+                  <span className="text-small">
+                    {segments.length === 0 ? t('scan.take_photo_desc') : t('scan.take_next_photo_desc')}
+                  </span>
+                </>
+              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png"
+                capture="environment"
+                style={{ display: 'none' }}
+                onChange={handleFileSelect}
+              />
+            </div>
+          )}
 
           {/* Segments list */}
           {segments.length > 0 && (

--- a/frontend/src/store/useDemoStore.test.ts
+++ b/frontend/src/store/useDemoStore.test.ts
@@ -127,6 +127,42 @@ describe('useDemoStore', () => {
     expect(shelf[0].shelf_position).toBe(0)
   })
 
+  it('confirmShelfScan (replace) swaps out the shelf and adds non-sample books', () => {
+    const get = useDemoStore.getState
+    // demo-loc-1 seeds 6 books; replace mode should leave only the scanned ones.
+    const res = get().confirmShelfScan({
+      location_id: 'demo-loc-1',
+      append_after_book_id: null,
+      books: [
+        { position: 0, title: 'Krakatit', author: 'Karel Čapek', isbn: null },
+        { position: 1, title: 'Saturnin', author: 'Zdeněk Jirotka', isbn: null },
+      ],
+    })
+    expect(res.created_count).toBe(2)
+    expect(res.book_ids).toHaveLength(2)
+    const shelf = get().booksByLocation('demo-loc-1')
+    expect(shelf.map((b) => b.title)).toEqual(['Krakatit', 'Saturnin'])
+    expect(shelf.every((b) => b.is_sample === false)).toBe(true)
+    expect(shelf.map((b) => b.shelf_position)).toEqual([0, 1])
+  })
+
+  it('confirmShelfScan (append-right) inserts after the anchor and shifts the rest', () => {
+    const get = useDemoStore.getState
+    // Anchor on demo-loc-1 position 0 (shelf_position 0); insert 1 book after it.
+    const anchor = get().booksByLocation('demo-loc-1')[0]
+    get().confirmShelfScan({
+      location_id: 'demo-loc-1',
+      append_after_book_id: anchor.id,
+      books: [{ position: 0, title: 'Inserted', author: null, isbn: null }],
+    })
+    const shelf = get().booksByLocation('demo-loc-1')
+    // 6 seeded + 1 inserted, contiguous positions, inserted sits at index 1.
+    expect(shelf).toHaveLength(7)
+    expect(shelf[0].id).toBe(anchor.id)
+    expect(shelf[1].title).toBe('Inserted')
+    expect(shelf[1].shelf_position).toBe(1)
+  })
+
   it('persists to sessionStorage and reset() returns to pristine seed', () => {
     const get = useDemoStore.getState
     get().addBook({ title: 'Throwaway' })

--- a/frontend/src/store/useDemoStore.ts
+++ b/frontend/src/store/useDemoStore.ts
@@ -30,6 +30,8 @@ import type {
   BookUpdateRequest,
   Location,
   ReadingStatus,
+  ShelfScanConfirmRequest,
+  ShelfScanConfirmResponse,
 } from '../lib/types'
 
 export const DEMO_STORAGE_KEY = 'shelfy:demo:v1'
@@ -68,6 +70,7 @@ interface DemoActions {
   bulkMove: (ids: string[], locationId: string | null) => void
   bulkUpdateStatus: (ids: string[], status: ReadingStatus) => void
   reorder: (items: ReorderItem[]) => void
+  confirmShelfScan: (payload: ShelfScanConfirmRequest) => ShelfScanConfirmResponse
   reset: () => void
 }
 
@@ -260,6 +263,56 @@ export const useDemoStore = create<DemoState>()(
               : b
           }),
         }))
+      },
+
+      confirmShelfScan: (payload) => {
+        const now = new Date().toISOString()
+        const { location_id, append_after_book_id, books } = payload
+
+        // Build the freshly scanned books (all in-memory, never sample).
+        const newBooks: Book[] = books.map((b, i) => ({
+          id: nextId(),
+          title: b.title,
+          author: b.author ?? null,
+          isbn: b.isbn ?? null,
+          publisher: null,
+          language: null,
+          description: null,
+          publication_year: null,
+          cover_image_url: null,
+          location_id,
+          shelf_position: i,
+          processing_status: 'done',
+          reading_status: 'unread',
+          is_currently_lent: false,
+          active_loan: null,
+          is_sample: false,
+          created_at: now,
+          updated_at: now,
+        }))
+
+        set((s) => {
+          if (!append_after_book_id) {
+            // Replace mode: drop existing books on this shelf, then add scanned
+            // ones at positions 0..n-1.
+            const others = s.books.filter((b) => b.location_id !== location_id)
+            return { books: [...others, ...newBooks] }
+          }
+
+          // Append-right mode: insert after the anchor book, shifting the books
+          // that currently sit to its right.
+          const anchor = s.books.find((b) => b.id === append_after_book_id)
+          const anchorPos = anchor?.shelf_position ?? -1
+          const shifted = s.books.map((b) =>
+            b.location_id === location_id && (b.shelf_position ?? 0) > anchorPos
+              ? { ...b, shelf_position: (b.shelf_position ?? 0) + newBooks.length, updated_at: now }
+              : b,
+          )
+          const placed = newBooks.map((b, i) => ({ ...b, shelf_position: anchorPos + 1 + i }))
+          return { books: [...shifted, ...placed] }
+        })
+
+        return { created_count: newBooks.length, book_ids: newBooks.map((b) => b.id) }
       },
 
       reset: () => set({ books: createDemoBooks(), locations: createDemoLocations() }),


### PR DESCRIPTION
## Summary
Implements **#286** — the scripted photo-scan walkthrough for the public client-side demo. Unauthenticated visitors can now run the *entire* shelf-scan wizard (location → scan → review → confirm) from the landing demo with **zero upload, zero AI, zero network**.

- New public route `/demo/scan` (added to the `/demo/*` subtree in `App.tsx`).
- Tapping a **sample photo** (inline SVG, no bundled binary → no PWA-precache concern) replays a pre-baked `ScannedBookItem` result after a short simulated processing pause. Two canned photos, one with a `needs_review`/no-text entry so the review step's low-confidence affordances are exercised.
- `useDemoStore.confirmShelfScan()` writes the confirmed books into the in-memory store, mirroring backend replace / append-right semantics.
- `useScan` hooks (`useConfirmShelfScan`, `useBooksByLocation`) made demo-aware (queryFn-swap to the store, cache scoped under `['demo', …]`) — same pattern as #285.
- Scan-draft `localStorage` persistence is skipped in demo (clean + isolated).
- Re-exposed the "Scan shelf" CTA inside the demo (hidden in #285) — it now routes to the scripted walkthrough.
- i18n: `demo.scan_note`, `demo.scan_sample`, `demo.scan_sample_used` (cs + en).

## Test plan
- [x] `vitest run` — 230 passed (+3 new: store replace/append-right, full demo wizard end-to-end)
- [x] `eslint` — 0 errors (pre-existing warnings only)
- [x] `vite build` — success, PWA precache unaffected (16 entries, no new binaries)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a demo mode for shelf scanning at `/demo/scan` allowing users to test the scanning workflow without authentication.
  * Introduced sample shelf photos to try the scan feature with pre-configured sample books and detection results.
  * Scan button is now always visible on the bookshelf view page.

* **Translations**
  * Added Czech and English translations for demo-specific UI messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->