### PR TITLE
feat(demo): landing CTAs to /demo + conversion funnel analytics (#287)

### DIFF
--- a/frontend/src/features/demo/DemoBanner.test.tsx
+++ b/frontend/src/features/demo/DemoBanner.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * DemoBanner (#287) — signup analytics + conversion nudge behaviour.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const trackDemoSignupClick = vi.fn()
+vi.mock('../../lib/demoAnalytics', () => ({
+  trackDemoSignupClick: (...args: unknown[]) => trackDemoSignupClick(...args),
+}))
+
+import { DemoBanner } from './DemoBanner'
+import { useDemoActivity } from './useDemoActivity'
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <DemoBanner />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  useDemoActivity.getState().reset()
+  trackDemoSignupClick.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+  useDemoActivity.getState().reset()
+})
+
+describe('DemoBanner', () => {
+  it('tracks the banner signup CTA', () => {
+    renderBanner()
+    fireEvent.click(screen.getByText('demo.cta_signup'))
+    expect(trackDemoSignupClick).toHaveBeenCalledWith('banner')
+  })
+
+  it('hides the nudge until the visitor shows intent', () => {
+    renderBanner()
+    expect(screen.queryByTestId('demo-nudge')).not.toBeInTheDocument()
+  })
+
+  it('shows the nudge after a completed scan and tracks its signup CTA', () => {
+    useDemoActivity.getState().recordScan()
+    renderBanner()
+    expect(screen.getByTestId('demo-nudge')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('demo.nudge_cta'))
+    expect(trackDemoSignupClick).toHaveBeenCalledWith('nudge')
+  })
+
+  it('dismissing the nudge hides it', () => {
+    useDemoActivity.getState().recordSearch()
+    useDemoActivity.getState().recordAdd()
+    renderBanner()
+    expect(screen.getByTestId('demo-nudge')).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('demo.nudge_dismiss'))
+    expect(screen.queryByTestId('demo-nudge')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/demo/DemoBanner.tsx
+++ b/frontend/src/features/demo/DemoBanner.tsx
@@ -5,29 +5,63 @@
  * sandbox nature explicit ("changes reset when you leave"), and offers the
  * primary conversion path (sign up) plus an exit back to the landing page.
  *
- * Conversion analytics for these CTAs are wired in #287; the markup/hooks here
- * intentionally stay minimal so that work can slot in without restructuring.
+ * #287 adds the conversion funnel: the signup CTA emits `demo_signup_click`,
+ * and once the visitor shows real intent (see {@link shouldShowDemoNudge}) a
+ * non-blocking nudge invites them to sign up to keep their library.
  */
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
 import { ROUTES } from '../../lib/routes'
+import { trackDemoSignupClick } from '../../lib/demoAnalytics'
+import { shouldShowDemoNudge, useDemoActivity } from './useDemoActivity'
 
 export function DemoBanner() {
   const { t } = useTranslation()
+  const activity = useDemoActivity()
+  const showNudge = shouldShowDemoNudge(activity)
 
   return (
-    <div className='sh-demo-banner' role='region' aria-label={t('demo.badge')}>
-      <span className='sh-demo-banner__badge'>{t('demo.badge')}</span>
-      <span className='sh-demo-banner__text'>{t('demo.banner_text')}</span>
-      <span className='sh-demo-banner__actions'>
-        <Link className='sh-demo-banner__exit' to='/'>
-          {t('demo.exit')}
-        </Link>
-        <Link className='sh-demo-banner__cta' to={ROUTES.login}>
-          {t('demo.cta_signup')}
-        </Link>
-      </span>
-    </div>
+    <>
+      <div className='sh-demo-banner' role='region' aria-label={t('demo.badge')}>
+        <span className='sh-demo-banner__badge'>{t('demo.badge')}</span>
+        <span className='sh-demo-banner__text'>{t('demo.banner_text')}</span>
+        <span className='sh-demo-banner__actions'>
+          <Link className='sh-demo-banner__exit' to='/'>
+            {t('demo.exit')}
+          </Link>
+          <Link
+            className='sh-demo-banner__cta'
+            to={ROUTES.login}
+            onClick={() => trackDemoSignupClick('banner')}
+          >
+            {t('demo.cta_signup')}
+          </Link>
+        </span>
+      </div>
+
+      {showNudge && (
+        <div className='sh-demo-nudge' role='status' data-testid='demo-nudge'>
+          <span className='sh-demo-nudge__text'>{t('demo.nudge_text')}</span>
+          <span className='sh-demo-nudge__actions'>
+            <Link
+              className='sh-demo-nudge__cta'
+              to={ROUTES.login}
+              onClick={() => trackDemoSignupClick('nudge')}
+            >
+              {t('demo.nudge_cta')}
+            </Link>
+            <button
+              type='button'
+              className='sh-demo-nudge__dismiss'
+              aria-label={t('demo.nudge_dismiss')}
+              onClick={() => useDemoActivity.getState().dismissNudge()}
+            >
+              ✕
+            </button>
+          </span>
+        </div>
+      )}
+    </>
   )
 }

--- a/frontend/src/features/demo/useDemoActivity.test.ts
+++ b/frontend/src/features/demo/useDemoActivity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * useDemoActivity (#287) — action counters + nudge gating.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { shouldShowDemoNudge, useDemoActivity } from './useDemoActivity'
+
+beforeEach(() => useDemoActivity.getState().reset())
+
+describe('useDemoActivity', () => {
+  it('records actions and returns the running count', () => {
+    expect(useDemoActivity.getState().recordSearch()).toBe(1)
+    expect(useDemoActivity.getState().recordAdd()).toBe(1)
+    expect(useDemoActivity.getState().recordAdd()).toBe(2)
+    expect(useDemoActivity.getState().recordScan()).toBe(1)
+    const s = useDemoActivity.getState()
+    expect([s.searches, s.adds, s.scans]).toEqual([1, 2, 1])
+  })
+
+  it('reset() clears counters and the dismissed flag', () => {
+    useDemoActivity.getState().recordScan()
+    useDemoActivity.getState().dismissNudge()
+    useDemoActivity.getState().reset()
+    const s = useDemoActivity.getState()
+    expect([s.searches, s.adds, s.scans, s.nudgeDismissed]).toEqual([0, 0, 0, false])
+  })
+})
+
+describe('shouldShowDemoNudge', () => {
+  const base = { searches: 0, adds: 0, scans: 0, nudgeDismissed: false }
+
+  it('stays hidden until the visitor shows real intent', () => {
+    expect(shouldShowDemoNudge(base)).toBe(false)
+    expect(shouldShowDemoNudge({ ...base, searches: 3 })).toBe(false) // search alone is not enough
+    expect(shouldShowDemoNudge({ ...base, adds: 1 })).toBe(false)
+  })
+
+  it('fires after a completed scan, or one search + one add', () => {
+    expect(shouldShowDemoNudge({ ...base, scans: 1 })).toBe(true)
+    expect(shouldShowDemoNudge({ ...base, searches: 1, adds: 1 })).toBe(true)
+  })
+
+  it('never fires once dismissed', () => {
+    expect(shouldShowDemoNudge({ searches: 2, adds: 2, scans: 1, nudgeDismissed: true })).toBe(false)
+  })
+})

--- a/frontend/src/features/demo/useDemoActivity.ts
+++ b/frontend/src/features/demo/useDemoActivity.ts
@@ -1,0 +1,57 @@
+/**
+ * useDemoActivity — tracks how far a visitor has engaged with the demo so the
+ * conversion nudge (#287) can fire at the right moment.
+ *
+ * In-memory only (no persistence): a fresh tab starts clean, and progress
+ * survives in-app navigation between `/demo/*` pages within the same session.
+ * Holds only counts + a dismissed flag — never any library content.
+ */
+import { create } from 'zustand'
+
+interface DemoActivityState {
+  searches: number
+  adds: number
+  scans: number
+  nudgeDismissed: boolean
+  /** Record an action; returns the new running count for that action. */
+  recordSearch: () => number
+  recordAdd: () => number
+  recordScan: () => number
+  dismissNudge: () => void
+  reset: () => void
+}
+
+export const useDemoActivity = create<DemoActivityState>((set, get) => ({
+  searches: 0,
+  adds: 0,
+  scans: 0,
+  nudgeDismissed: false,
+  recordSearch: () => {
+    const n = get().searches + 1
+    set({ searches: n })
+    return n
+  },
+  recordAdd: () => {
+    const n = get().adds + 1
+    set({ adds: n })
+    return n
+  },
+  recordScan: () => {
+    const n = get().scans + 1
+    set({ scans: n })
+    return n
+  },
+  dismissNudge: () => set({ nudgeDismissed: true }),
+  reset: () => set({ searches: 0, adds: 0, scans: 0, nudgeDismissed: false }),
+}))
+
+/**
+ * The nudge appears once the visitor has shown real intent — a completed scan,
+ * or at least one search *and* one add — and hasn't dismissed it.
+ */
+export function shouldShowDemoNudge(
+  s: Pick<DemoActivityState, 'searches' | 'adds' | 'scans' | 'nudgeDismissed'>,
+): boolean {
+  if (s.nudgeDismissed) return false
+  return s.scans >= 1 || (s.searches >= 1 && s.adds >= 1)
+}

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -588,6 +588,7 @@
     "nav_features": "Funkce",
     "nav_pricing": "Ceník",
     "hero_cta_signup": "Vyzkoušet zdarma",
+    "hero_cta_try_demo": "Vyzkoušet ukázku",
     "hero_cta_login": "Přihlásit se",
     "hero_cta_watch_demo": "Jak to funguje",
     "hero_free_limits": "Začni zdarma · Bez platební karty · Až 200 knih",
@@ -605,6 +606,7 @@
     "visual_proof_zoom": "Klikni pro zvětšení",
     "visual_proof_play_demo": "Přehrát ukázku",
     "visual_proof_demo_coming": "Demo již brzy",
+    "visual_proof_try_demo": "Vyzkoušet ukázku",
     "visual_proof_step1_title": "Vyfoť polici",
     "visual_proof_step1_desc": "Jedna fotka stačí.",
     "visual_proof_step2_title": "Potvrď rozpoznání",
@@ -630,6 +632,7 @@
     "final_cta_title": "Chceš vědět, co vlastníš na každé polici?",
     "final_cta_subtitle": "Domácí čtenáři, kluby, školy a malé knihovny — katalog, který sestavíš za minuty a prohledáš za vteřinu.",
     "final_cta_button": "Vytvořit svůj katalog zdarma",
+    "final_cta_try_demo": "Vyzkoušet ukázku",
     "footer_privacy": "Zásady ochrany soukromí",
     "footer_terms": "Podmínky použití",
     "hero_trust_summary": "Tvoje data patří tobě. Kdykoli je exportuješ a účet můžeš jednoduše smazat.",
@@ -828,6 +831,9 @@
     "exit": "Ukončit ukázku",
     "scan_note": "Tohle je ukázka — klepněte na vzorovou fotku a uvidíte výsledek. Žádná fotka se nenahrává a neběží žádná AI.",
     "scan_sample": "Naskenovat vzorovou fotku {{n}}",
-    "scan_sample_used": "Vzorová fotka {{n}} naskenována"
+    "scan_sample_used": "Vzorová fotka {{n}} naskenována",
+    "nudge_text": "Líbí se vám to? Zaregistrujte se zdarma a knihovnu si uložte.",
+    "nudge_cta": "Vyzkoušet zdarma",
+    "nudge_dismiss": "Zavřít"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -262,6 +262,7 @@
     "nav_pricing": "Pricing",
     "hero_cta_signup": "Try it free",
     "hero_cta_login": "Sign in",
+    "hero_cta_try_demo": "Try the demo",
     "hero_cta_watch_demo": "How it works",
     "hero_free_limits": "Free to start · No credit card required · Up to 200 books",
     "how_title": "How it works",
@@ -278,6 +279,7 @@
     "visual_proof_zoom": "Click to enlarge",
     "visual_proof_play_demo": "Play demo",
     "visual_proof_demo_coming": "Demo coming soon",
+    "visual_proof_try_demo": "Try the demo",
     "visual_proof_step1_title": "Scan a shelf",
     "visual_proof_step1_desc": "One photo is enough.",
     "visual_proof_step2_title": "Confirm recognition",
@@ -303,6 +305,7 @@
     "final_cta_title": "Ready to know every book you own?",
     "final_cta_subtitle": "Home readers, book clubs, schools, and small libraries — finally, a catalog that takes minutes to build and seconds to search.",
     "final_cta_button": "Create your free library catalog",
+    "final_cta_try_demo": "Try the demo",
     "footer_privacy": "Privacy Policy",
     "footer_terms": "Terms of Service",
     "hero_trust_summary": "Your data stays yours. Export anytime and delete your account whenever you want.",
@@ -822,6 +825,9 @@
     "exit": "Exit demo",
     "scan_note": "This is a scripted demo — tap a sample photo to see the result. No photo is uploaded and no AI runs.",
     "scan_sample": "Scan sample photo {{n}}",
-    "scan_sample_used": "Sample photo {{n}} scanned"
+    "scan_sample_used": "Sample photo {{n}} scanned",
+    "nudge_text": "Like it? Sign up free to keep your library.",
+    "nudge_cta": "Sign up free",
+    "nudge_dismiss": "Dismiss"
   }
 }

--- a/frontend/src/lib/demoAnalytics.test.ts
+++ b/frontend/src/lib/demoAnalytics.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Demo-funnel analytics (#287) — event shape + GDPR payload audit.
+ *
+ * The hard requirement: demo events run for logged-out visitors, so their
+ * payloads must never carry personal/library content (titles, photos, raw
+ * search strings). This test pins each event's payload and asserts every key
+ * is on a counts/enums allowlist.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const trackEvent = vi.fn()
+vi.mock('./analytics', () => ({ trackEvent: (...args: unknown[]) => trackEvent(...args) }))
+
+import {
+  trackDemoAddBook,
+  trackDemoScanComplete,
+  trackDemoSearch,
+  trackDemoSignupClick,
+  trackDemoStart,
+} from './demoAnalytics'
+
+beforeEach(() => trackEvent.mockClear())
+
+describe('demoAnalytics', () => {
+  it('emits each event with the documented payload', () => {
+    trackDemoStart('hero')
+    expect(trackEvent).toHaveBeenLastCalledWith('demo_start', { source: 'hero' })
+
+    trackDemoSearch(5, 3)
+    expect(trackEvent).toHaveBeenLastCalledWith('demo_search', { query_len: 5, result_count: 3 })
+
+    trackDemoAddBook(2)
+    expect(trackEvent).toHaveBeenLastCalledWith('demo_add_book', { action_index: 2 })
+
+    trackDemoScanComplete(4)
+    expect(trackEvent).toHaveBeenLastCalledWith('demo_scan_complete', { book_count: 4 })
+
+    trackDemoSignupClick('nudge')
+    expect(trackEvent).toHaveBeenLastCalledWith('demo_signup_click', { source_section: 'nudge' })
+  })
+
+  it('never sends personal/library content — only counts, enums, booleans', () => {
+    trackDemoStart('visual_proof')
+    trackDemoSearch(12, 0)
+    trackDemoAddBook(1)
+    trackDemoScanComplete(7)
+    trackDemoSignupClick('banner')
+
+    const ALLOWED_KEYS = new Set([
+      'source',
+      'query_len',
+      'result_count',
+      'action_index',
+      'book_count',
+      'source_section',
+    ])
+    const ENUM_VALUES = new Set(['hero', 'visual_proof', 'final_cta', 'header', 'banner', 'nudge'])
+
+    for (const [, props] of trackEvent.mock.calls as Array<[string, Record<string, unknown>]>) {
+      for (const [key, value] of Object.entries(props ?? {})) {
+        expect(ALLOWED_KEYS.has(key)).toBe(true)
+        // Values are numbers or short enum strings — never free text/titles/photos.
+        if (typeof value === 'string') {
+          expect(ENUM_VALUES.has(value)).toBe(true)
+        } else {
+          expect(typeof value).toBe('number')
+        }
+      }
+    }
+  })
+})

--- a/frontend/src/lib/demoAnalytics.ts
+++ b/frontend/src/lib/demoAnalytics.ts
@@ -1,0 +1,55 @@
+/**
+ * Demo-funnel analytics (#287).
+ *
+ * Lets us compare the conversion power of the interactive demo against the
+ * (never-shipped) promo video and the plain landing→signup path.
+ *
+ * **Privacy contract (GDPR — see PrivacyPage §7).** These events run for
+ * unauthenticated visitors, so their payloads must carry *no* personal or
+ * library content: no book titles, no photos, no raw search strings. Only
+ * counts, booleans and enums are allowed (e.g. `query_len`, `result_count`,
+ * `action_index`). Keep this module the single, auditable place where demo
+ * events are shaped.
+ */
+import { trackEvent } from './analytics'
+
+/** Where the visitor entered the demo from. */
+export type DemoStartSource = 'hero' | 'visual_proof' | 'final_cta' | 'header'
+
+/** Which conversion surface the signup click came from. */
+export type DemoSignupSource = 'banner' | 'nudge'
+
+/** Visitor opened the demo. */
+export function trackDemoStart(source: DemoStartSource): void {
+  trackEvent('demo_start', { source })
+}
+
+/**
+ * Visitor ran a search inside the demo.
+ * @param queryLen   length of the query string (never the string itself)
+ * @param resultCount number of matches
+ */
+export function trackDemoSearch(queryLen: number, resultCount: number): void {
+  trackEvent('demo_search', { query_len: queryLen, result_count: resultCount })
+}
+
+/**
+ * Visitor added a book inside the demo.
+ * @param actionIndex 1-based count of adds in this demo session
+ */
+export function trackDemoAddBook(actionIndex: number): void {
+  trackEvent('demo_add_book', { action_index: actionIndex })
+}
+
+/**
+ * Visitor completed the scripted scan inside the demo.
+ * @param bookCount number of books confirmed
+ */
+export function trackDemoScanComplete(bookCount: number): void {
+  trackEvent('demo_scan_complete', { book_count: bookCount })
+}
+
+/** Visitor clicked a signup CTA from within the demo. */
+export function trackDemoSignupClick(source: DemoSignupSource): void {
+  trackEvent('demo_signup_click', { source_section: source })
+}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
   addBook: '/books/new',
   scanShelf: '/scan',
   bookshelfView: '/bookshelf',
+  demo: '/demo',
   locations: '/locations',
   borrowers: '/borrowers',
   borrowerDetail: '/borrowers/:borrowerId',

--- a/frontend/src/pages/AddBookPage.tsx
+++ b/frontend/src/pages/AddBookPage.tsx
@@ -5,6 +5,8 @@ import { useCreateBook, useUploadBookImage, useJobStatus } from '../hooks/useBoo
 import { useLocations } from '../hooks/useLocations'
 import { useIsDemoMode } from '../features/demo/DemoContext'
 import { useAppNavigate } from '../features/demo/demoNav'
+import { useDemoActivity } from '../features/demo/useDemoActivity'
+import { trackDemoAddBook } from '../lib/demoAnalytics'
 import { useToastStore } from '../lib/toast-store'
 import { ROUTES } from '../lib/routes'
 import type { BookCreateRequest, ReadingStatus } from '../lib/types'
@@ -70,6 +72,10 @@ export function AddBookPage() {
     createMutation.mutate(payload, {
       onSuccess: () => {
         showSuccess(t('add_book.success_created', 'Kniha byla přidána.'))
+        if (isDemo) {
+          const actionIndex = useDemoActivity.getState().recordAdd()
+          trackDemoAddBook(actionIndex)
+        }
         navigate(ROUTES.books)
       },
       onError:   ()  => showError(t('add_book.error')),

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -14,6 +14,9 @@ import { useLocations } from '../hooks/useLocations'
 import { useOnboardingStatus } from '../hooks/useOnboarding'
 import { useIsDemoMode } from '../features/demo/DemoContext'
 import { useAppNavigate } from '../features/demo/demoNav'
+import { useDemoActivity } from '../features/demo/useDemoActivity'
+import { useDemoStore } from '../store/useDemoStore'
+import { trackDemoSearch } from '../lib/demoAnalytics'
 import { useToastStore } from '../lib/toast-store'
 import { ROUTES } from '../lib/routes'
 import type { Book, Location, ReadingStatus } from '../lib/types'
@@ -28,6 +31,18 @@ export function BooksPage() {
   const isDemo = useIsDemoMode()
   const [searchInput, setSearchInput] = useState('')
   const debouncedSearch = useDebounce(searchInput.trim(), 300)
+  // Demo-funnel: record each distinct, meaningful search (counts only — never
+  // the query string itself). Fires at most once per query (#287).
+  const lastTrackedDemoSearch = useRef('')
+  useEffect(() => {
+    if (!isDemo) return
+    const q = debouncedSearch
+    if (q.length < 2 || q === lastTrackedDemoSearch.current) return
+    lastTrackedDemoSearch.current = q
+    const resultCount = useDemoStore.getState().queryBooks({ search: q }).total
+    trackDemoSearch(q.length, resultCount)
+    useDemoActivity.getState().recordSearch()
+  }, [isDemo, debouncedSearch])
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
   const [uploadJobId, setUploadJobId] = useState<string | null>(null)
   const [readingFilter, setReadingFilter] = useState<ReadingStatus | null>(null)

--- a/frontend/src/pages/LandingPage.test.tsx
+++ b/frontend/src/pages/LandingPage.test.tsx
@@ -145,14 +145,26 @@ describe('LandingPage', () => {
     expect(lightboxImg.src).toContain('/landing/demo-poster.webp')
   })
 
-  it('shows demo fallback when no video URL is configured', () => {
+  it('offers "Try the demo" CTAs that fire demo_start (no video placeholder)', async () => {
+    const user = userEvent.setup()
     render(
       <MemoryRouter>
         <LandingPage />
       </MemoryRouter>,
     )
 
-    expect(screen.getByText(/landing\.visual_proof_demo_coming/)).toBeInTheDocument()
+    // The old "demo coming" / video placeholder is gone.
+    expect(screen.queryByText(/landing\.visual_proof_demo_coming/)).not.toBeInTheDocument()
+
+    // Hero + visual-proof + final CTA all expose a try-demo entry point.
+    await user.click(screen.getByRole('button', { name: 'landing.hero_cta_try_demo' }))
+    expect(trackEventMock).toHaveBeenCalledWith('demo_start', { source: 'hero' })
+
+    await user.click(screen.getByRole('button', { name: /landing\.visual_proof_try_demo/ }))
+    expect(trackEventMock).toHaveBeenCalledWith('demo_start', { source: 'visual_proof' })
+
+    await user.click(screen.getByRole('button', { name: 'landing.final_cta_try_demo' }))
+    expect(trackEventMock).toHaveBeenCalledWith('demo_start', { source: 'final_cta' })
   })
 
   it('renders FAQ section with 5 questions', () => {

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -26,10 +26,8 @@ import {
   trackSignupStart,
   trackSupportingCtaClick,
 } from '../lib/landingAnalytics'
+import { trackDemoStart, type DemoStartSource } from '../lib/demoAnalytics'
 import { ROUTES } from '../lib/routes'
-
-/** Set to a real URL (e.g. YouTube embed) when demo video is ready. */
-const DEMO_VIDEO_URL = ''
 
 const AUDIENCE_ITEMS = ['home', 'club', 'school', 'library'] as const
 
@@ -57,7 +55,6 @@ export function LandingPage() {
   const [searchParams] = useSearchParams()
   const howItWorksRef = useRef<HTMLElement | null>(null)
   const variantId = useMemo(() => resolveLandingVariantId(searchParams), [searchParams])
-  const [showVideo, setShowVideo] = useState(false)
   const [openFaq, setOpenFaq] = useState<number | null>(null)
 
   /** Active showcase tab: 0 = overview poster, 1–3 = step screenshots. */
@@ -78,6 +75,11 @@ export function LandingPage() {
       trackSupportingCtaClick(ctaLabel, sourceSection)
     }
     navigate(ROUTES.login)
+  }
+
+  function handleTryDemo(source: DemoStartSource): void {
+    trackDemoStart(source)
+    navigate(ROUTES.demo)
   }
 
   const howItWorksSteps = useMemo(
@@ -154,23 +156,16 @@ export function LandingPage() {
             <button
               type="button"
               className="sh-btn-primary lp-btn-lg"
-              onClick={() => handleSignupCtaClick('hero', t('landing.hero_cta_signup'), true)}
+              onClick={() => handleTryDemo('hero')}
             >
-              {t('landing.hero_cta_signup')}
+              {t('landing.hero_cta_try_demo')}
             </button>
             <button
               type="button"
-              style={{
-                background: 'none', border: 'none', cursor: 'pointer',
-                color: 'var(--sh-text-muted)', fontSize: 14, textDecoration: 'underline',
-                padding: '8px 4px',
-              }}
-              onClick={() => {
-                trackSupportingCtaClick(t('landing.hero_cta_watch_demo'), 'hero')
-                howItWorksRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-              }}
+              className="sh-btn-secondary lp-btn-lg"
+              onClick={() => handleSignupCtaClick('hero', t('landing.hero_cta_signup'), true)}
             >
-              {t('landing.hero_cta_watch_demo')} ↓
+              {t('landing.hero_cta_signup')}
             </button>
           </div>
 
@@ -229,19 +224,18 @@ export function LandingPage() {
               {t('landing.visual_proof_zoom')}
             </span>
 
-            {/* Video play overlay — only on poster (tab 0) */}
+            {/* Try-the-demo overlay — only on the poster (tab 0) */}
             {activeShowcase === 0 && (
               <button
                 type="button"
                 className="lp-showcase-play"
                 onClick={(e) => {
                   e.stopPropagation()
-                  trackSupportingCtaClick(t('landing.visual_proof_play_demo'), 'visual_proof')
-                  if (DEMO_VIDEO_URL) setShowVideo(true)
+                  handleTryDemo('visual_proof')
                 }}
               >
                 <span style={{ fontSize: 18, lineHeight: 1 }}>&#9654;</span>
-                {DEMO_VIDEO_URL ? t('landing.visual_proof_play_demo') : t('landing.visual_proof_demo_coming')}
+                {t('landing.visual_proof_try_demo')}
               </button>
             )}
           </div>
@@ -295,49 +289,6 @@ export function LandingPage() {
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
                   <path d="M5 5l10 10M15 5l-10 10" />
                 </svg>
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Video lightbox */}
-        {showVideo && (
-          <div
-            className="sh-modal-overlay"
-            role="dialog"
-            aria-modal="true"
-            onClick={() => setShowVideo(false)}
-          >
-            <div
-              className="sh-modal-panel sh-modal-panel--lg"
-              style={{ padding: 0, overflow: 'hidden' }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div style={{ position: 'relative', paddingTop: '56.25%', background: '#000' }}>
-                {DEMO_VIDEO_URL ? (
-                  <iframe
-                    src={DEMO_VIDEO_URL}
-                    title={t('landing.visual_proof_play_demo')}
-                    style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 'none' }}
-                    allow="autoplay; encrypted-media"
-                    allowFullScreen
-                  />
-                ) : (
-                  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff' }}>
-                    <img src="/landing/demo-poster.webp" alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', opacity: 0.4 }} />
-                    <p style={{ position: 'absolute', fontSize: 18, fontWeight: 600 }}>
-                      {t('landing.visual_proof_demo_coming')}
-                    </p>
-                  </div>
-                )}
-              </div>
-              <button
-                type="button"
-                className="sh-btn-secondary"
-                style={{ margin: 12 }}
-                onClick={() => setShowVideo(false)}
-              >
-                {t('landing.visual_proof_close')}
               </button>
             </div>
           </div>
@@ -440,13 +391,22 @@ export function LandingPage() {
           <div className="lp-final-cta">
             <h2 className="lp-final-cta-title">{t('landing.final_cta_title')}</h2>
             <p className="lp-final-cta-subtitle">{t('landing.final_cta_subtitle')}</p>
-            <button
-              type="button"
-              className="sh-btn-primary lp-btn-lg"
-              onClick={() => handleSignupCtaClick('final_cta', t('landing.final_cta_button'), false)}
-            >
-              {t('landing.final_cta_button')}
-            </button>
+            <div className="lp-hero-actions">
+              <button
+                type="button"
+                className="sh-btn-primary lp-btn-lg"
+                onClick={() => handleTryDemo('final_cta')}
+              >
+                {t('landing.final_cta_try_demo')}
+              </button>
+              <button
+                type="button"
+                className="sh-btn-secondary lp-btn-lg"
+                onClick={() => handleSignupCtaClick('final_cta', t('landing.final_cta_button'), false)}
+              >
+                {t('landing.final_cta_button')}
+              </button>
+            </div>
           </div>
         </section>
       </main>

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -238,6 +238,11 @@ export function PrivacyPage() {
             nikoliv obsah knihovny, snímky nebo platební údaje.
           </p>
           <p style={P}>
+            Totéž platí pro interaktivní ukázku (demo) na úvodní stránce: měříme jen
+            agregované, neosobní události (např. počet výsledků hledání nebo počet přidaných knih),
+            <strong>nikdy</strong> názvy knih, fotografie ani text vyhledávání.
+          </p>
+          <p style={P}>
             PostHog pracuje <strong>bez sledovacích cookies</strong>. Pro persistenci analytického
             identifikátoru je využíván localStorage prohlížeče. Právním základem je oprávněný
             zájem správce na vylepšování služby (čl. 6/1f GDPR). Proti tomuto zpracování
@@ -253,6 +258,7 @@ export function PrivacyPage() {
           </p>
           <ul style={UL}>
             <li><strong>localStorage</strong> — autentizační tokeny, preference jazyka a tmavého režimu. Tato data neopouštějí váš prohlížeč.</li>
+            <li><strong>sessionStorage</strong> — dočasná knihovna v interaktivní ukázce (demo). Existuje pouze ve vašem prohlížeči, neodesílá se na server a po zavření karty se smaže.</li>
             <li><strong>Nezbytné cookies Cloudflare</strong> — technické cookies pro DDoS ochranu (cf_clearance apod.). Ty jsou nezbytné pro fungování služby a nevyžadují souhlas.</li>
           </ul>
         </div>

--- a/frontend/src/pages/ScanShelfPage.tsx
+++ b/frontend/src/pages/ScanShelfPage.tsx
@@ -8,6 +8,8 @@ import { useIsDemoMode } from '../features/demo/DemoContext'
 import { DemoShelfPhoto } from '../features/demo/DemoShelfPhoto'
 import { DEMO_SCAN_PHOTOS } from '../features/demo/demoScan'
 import { useAppNavigate } from '../features/demo/demoNav'
+import { useDemoActivity } from '../features/demo/useDemoActivity'
+import { trackDemoScanComplete } from '../lib/demoAnalytics'
 import { useLocations, useCreateLocation } from '../hooks/useLocations'
 import { useBooksByLocation, useConfirmShelfScan, useScanShelf, useShelfScanResult } from '../hooks/useScan'
 import { useToastStore } from '../lib/toast-store'
@@ -433,7 +435,13 @@ export function ScanShelfPage() {
       },
       {
         onSuccess: () => {
-          trackEvent('shelf_scanned', { book_count: validBooks.length })
+          if (isDemo) {
+            // Demo funnel — keep the real `shelf_scanned` event clean of demo noise.
+            useDemoActivity.getState().recordScan()
+            trackDemoScanComplete(validBooks.length)
+          } else {
+            trackEvent('shelf_scanned', { book_count: validBooks.length })
+          }
           clearDraft()
           navigate(ROUTES.bookshelfView + '?location_id=' + locationId)
         },

--- a/frontend/src/styles/shelfy.css
+++ b/frontend/src/styles/shelfy.css
@@ -355,6 +355,60 @@ a:focus-visible,
   background: var(--sh-primary-dark);
 }
 
+/* Conversion nudge — non-blocking bar under the banner (#287). */
+.sh-demo-nudge {
+  position: sticky;
+  top: 41px;
+  z-index: calc(var(--sh-z-nav) - 1);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 8px 16px;
+  background: var(--sh-teal-bg);
+  border-bottom: 1px solid var(--sh-border);
+  color: var(--sh-teal-text);
+  font-size: 13px;
+  animation: sh-demo-nudge-in 0.25s ease-out;
+}
+@keyframes sh-demo-nudge-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.sh-demo-nudge__text {
+  flex: 1 1 220px;
+  min-width: 0;
+  font-weight: 500;
+}
+.sh-demo-nudge__actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
+.sh-demo-nudge__cta {
+  padding: 6px 14px;
+  border-radius: var(--sh-radius-pill);
+  background: var(--sh-teal);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.sh-demo-nudge__cta:hover {
+  filter: brightness(0.95);
+}
+.sh-demo-nudge__dismiss {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--sh-teal-text);
+  font-size: 15px;
+  line-height: 1;
+  padding: 2px 4px;
+}
+
 /* ── Bottom Nav (mobile) ──────────────────────────────────────────── */
 .sh-bottom-nav {
   position: fixed;


### PR DESCRIPTION
## Summary
Final issue of the interactive-demo epic (#284–#287). Wires the landing page into the client-side demo and adds a privacy-safe conversion funnel.

- **Landing CTAs → `/demo`**: hero, visual-proof and final CTAs now launch the demo and fire `demo_start`. Removes the dead video-placeholder machinery.
- **Funnel analytics** (`demoAnalytics.ts`): `demo_start` / `demo_search` / `demo_add_book` / `demo_scan_complete` / `demo_signup_click`. Payloads carry **counts/enums only** — never titles, photos or raw search strings (GDPR-safe for logged-out visitors). A dedicated test audits every payload against an allowlist.
- **Conversion nudge** (`useDemoActivity` + `DemoBanner`): gated on real intent — a completed scan, or one search + one add — and dismissible.
- Demo funnel events are emitted from BooksPage / AddBookPage / ScanShelfPage **without** polluting the authenticated `shelf_scanned` event.
- Privacy copy updated to document the aggregated demo analytics and client-side-only demo library.

## Test plan
- [x] `vitest run` — 241 passed (29 files; +11 new for #287)
- [x] `vite build` succeeds
- [x] `eslint` — 0 errors on changed files
- [ ] CI green (frontend / backend / e2e / security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)