### PR TITLE
fix(demo): show the app sidebar in the demo so visitors can navigate

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -85,9 +85,11 @@ function AppShell() {
     },
   })
   const location = useLocation()
-  // The demo subtree (#285) ships its own chrome (DemoBanner), so the
-  // authenticated Navigation must stay hidden across all of `/demo/*`.
-  const hideNav = PUBLIC_PATHS.has(location.pathname) || location.pathname.startsWith('/demo')
+  // Marketing/auth pages render full-bleed with no app chrome. The demo subtree
+  // (#285) keeps the sidebar `Navigation` (which is demo-aware and scopes itself
+  // to `/demo/*`) on top of its own `DemoBanner`, so visitors can move between
+  // search / bookshelf / add / scan just like the real app.
+  const hideNav = PUBLIC_PATHS.has(location.pathname)
 
   return (
     <div className='sh-app'>

--- a/frontend/src/components/Navigation.demo.test.tsx
+++ b/frontend/src/components/Navigation.demo.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Navigation — demo-aware sidebar (#288 follow-up).
+ *
+ * Inside `/demo/*` the same sidebar is reused so visitors can move between
+ * search / bookshelf / add / scan, but it must (a) keep every destination
+ * inside the `/demo` subtree and (b) drop the authenticated-only controls
+ * (borrowers, settings, usage meter, logout).
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => navigateMock }
+})
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ logout: vi.fn() }) }))
+// UsageMeterCard pulls plan usage from the API — never exercised in the demo,
+// stubbed so the authenticated-mode assertions don't need a QueryClient.
+vi.mock('./UsageMeterCard', () => ({ UsageMeterCard: () => null }))
+
+import { Navigation } from './Navigation'
+
+function renderAt(path: string): ReactNode {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Navigation />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => navigateMock.mockReset())
+afterEach(() => cleanup())
+
+describe('Navigation — demo mode', () => {
+  it('exposes the demo-relevant items and hides authenticated-only controls', () => {
+    renderAt('/demo/books')
+
+    expect(screen.getByText('nav.library')).toBeInTheDocument()
+    expect(screen.getByText('nav.bookshelf')).toBeInTheDocument()
+    expect(screen.getByText('nav.add')).toBeInTheDocument()
+    expect(screen.getByText('nav.scan')).toBeInTheDocument()
+
+    expect(screen.queryByText('nav.borrowers')).not.toBeInTheDocument()
+    expect(screen.queryByText('nav.settings')).not.toBeInTheDocument()
+    expect(screen.queryByText('nav.logout')).not.toBeInTheDocument()
+  })
+
+  it('keeps navigation inside the /demo subtree', async () => {
+    const user = userEvent.setup()
+    renderAt('/demo/books')
+
+    await user.click(screen.getByText('nav.add'))
+    expect(navigateMock).toHaveBeenLastCalledWith('/demo/books/new')
+
+    await user.click(screen.getByText('nav.scan'))
+    expect(navigateMock).toHaveBeenLastCalledWith('/demo/scan')
+
+    await user.click(screen.getByText('nav.bookshelf'))
+    expect(navigateMock).toHaveBeenLastCalledWith('/demo/bookshelf')
+  })
+
+  it('keeps the full authenticated sidebar (borrowers/settings/logout) outside the demo', () => {
+    renderAt('/books')
+
+    expect(screen.getByText('nav.borrowers')).toBeInTheDocument()
+    expect(screen.getByText('nav.settings')).toBeInTheDocument()
+    expect(screen.getByText('nav.logout')).toBeInTheDocument()
+  })
+
+  it('navigates to production paths outside the demo', async () => {
+    const user = userEvent.setup()
+    renderAt('/books')
+
+    await user.click(screen.getByText('nav.add'))
+    expect(navigateMock).toHaveBeenLastCalledWith('/books/new')
+  })
+})

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -1,9 +1,10 @@
-import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { ROUTES } from '../lib/routes'
 import { useAuth } from '../contexts/AuthContext'
+import { withDemoPrefix } from '../features/demo/demoNav'
 import { BookshelfInlineIcon } from './EmptyStateIcons'
 import { UsageMeterCard } from './UsageMeterCard'
 
@@ -131,21 +132,30 @@ export function Navigation() {
   const fabRef = useRef<HTMLDivElement>(null)
   const { logout } = useAuth()
 
+  /* Inside the public demo (#285/#288) the same sidebar is reused, but every
+     destination must stay within the `/demo/*` subtree and the authenticated-
+     only controls (borrowers, settings, usage, logout) are dropped. */
+  const isDemo = location.pathname.startsWith(ROUTES.demo)
+  const prefix = useCallback(
+    (path: string) => (isDemo ? withDemoPrefix(path) : path),
+    [isDemo],
+  )
+
   /* Grouped sidebar items (desktop) */
   const navGroup = useMemo<NavItem[]>(
     () => [
-      { label: t('nav.library'), icon: 'library', path: ROUTES.books },
-      { label: t('nav.bookshelf'), icon: 'bookshelf', path: ROUTES.bookshelfView },
+      { label: t('nav.library'), icon: 'library', path: prefix(ROUTES.books) },
+      { label: t('nav.bookshelf'), icon: 'bookshelf', path: prefix(ROUTES.bookshelfView) },
     ],
-    [t],
+    [t, prefix],
   )
 
   const actionGroup = useMemo<NavItem[]>(
     () => [
-      { label: t('nav.add'), icon: 'add', path: ROUTES.addBook },
-      { label: t('nav.scan'), icon: 'scan', path: ROUTES.scanShelf },
+      { label: t('nav.add'), icon: 'add', path: prefix(ROUTES.addBook) },
+      { label: t('nav.scan'), icon: 'scan', path: prefix(ROUTES.scanShelf) },
     ],
-    [t],
+    [t, prefix],
   )
 
   const secondaryGroup = useMemo<NavItem[]>(
@@ -162,17 +172,25 @@ export function Navigation() {
     [t],
   )
 
-  /* Mobile bottom nav: 4 tabs split around the center FAB.
-     Layout: [library] [bookshelf] [FAB] [borrowers] [settings] */
-  const mobileTabs = useMemo(
-    () => [
-      { label: t('nav.library'), icon: 'library', path: ROUTES.books },
-      { label: t('nav.bookshelf'), icon: 'bookshelf', path: ROUTES.bookshelfView },
-      { label: t('nav.borrowers'), icon: 'borrowers', path: ROUTES.borrowers },
-      { label: t('nav.settings'), icon: 'settings', path: ROUTES.settings },
-    ],
-    [t],
+  /* Mobile bottom nav: tabs split around the center FAB.
+     App:  [library] [bookshelf] [FAB] [borrowers] [settings]
+     Demo: [library]            [FAB] [bookshelf]            */
+  const mobileTabs = useMemo<NavItem[]>(
+    () =>
+      isDemo
+        ? [
+            { label: t('nav.library'), icon: 'library', path: prefix(ROUTES.books) },
+            { label: t('nav.bookshelf'), icon: 'bookshelf', path: prefix(ROUTES.bookshelfView) },
+          ]
+        : [
+            { label: t('nav.library'), icon: 'library', path: ROUTES.books },
+            { label: t('nav.bookshelf'), icon: 'bookshelf', path: ROUTES.bookshelfView },
+            { label: t('nav.borrowers'), icon: 'borrowers', path: ROUTES.borrowers },
+            { label: t('nav.settings'), icon: 'settings', path: ROUTES.settings },
+          ],
+    [t, isDemo, prefix],
   )
+  const mobileSplit = Math.ceil(mobileTabs.length / 2)
 
   useEffect(() => {
     const handleResize = () => setIsDesktop(window.innerWidth >= 768)
@@ -208,13 +226,13 @@ export function Navigation() {
   }, [location.pathname])
 
   function isActive(path: string) {
+    const booksPath = prefix(ROUTES.books)
+    const addBookPath = prefix(ROUTES.addBook)
     return (
       location.pathname === path
-      || (path === ROUTES.books
-        && (location.pathname === ROUTES.books || location.pathname.startsWith('/books/'))
-        && location.pathname !== ROUTES.addBook)
-      || (path === ROUTES.scanShelf && location.pathname === ROUTES.scanShelf)
-      || (path === ROUTES.bookshelfView && location.pathname === ROUTES.bookshelfView)
+      || (path === booksPath
+        && (location.pathname === booksPath || location.pathname.startsWith(`${booksPath}/`))
+        && location.pathname !== addBookPath)
     )
   }
 
@@ -276,43 +294,47 @@ export function Navigation() {
           )
         })}
 
-        <div className="sh-sidebar-divider" />
-        {secondaryGroup.map((tab) => {
-          const active = isActive(tab.path)
-          const Icon = iconComponents[tab.icon]
-          return (
-            <button
-              key={tab.path}
-              onClick={() => navigate(tab.path)}
-              className={`sh-sidebar-btn${active ? ' active' : ''}`}
-              data-testid={`nav-${tab.icon}`}
-            >
-              <Icon size={20} />
-              <span>{tab.label}</span>
-            </button>
-          )
-        })}
+        {!isDemo && (
+          <>
+            <div className="sh-sidebar-divider" />
+            {secondaryGroup.map((tab) => {
+              const active = isActive(tab.path)
+              const Icon = iconComponents[tab.icon]
+              return (
+                <button
+                  key={tab.path}
+                  onClick={() => navigate(tab.path)}
+                  className={`sh-sidebar-btn${active ? ' active' : ''}`}
+                  data-testid={`nav-${tab.icon}`}
+                >
+                  <Icon size={20} />
+                  <span>{tab.label}</span>
+                </button>
+              )
+            })}
 
-        <div className="sh-sidebar-divider" style={{ marginTop: 'auto' }} />
-        <UsageMeterCard />
-        {settingsGroup.map((tab) => {
-          const active = isActive(tab.path)
-          const Icon = iconComponents[tab.icon]
-          return (
-            <button
-              key={tab.path}
-              onClick={() => navigate(tab.path)}
-              className={`sh-sidebar-btn${active ? ' active' : ''}`}
-            >
-              <Icon size={20} />
-              <span>{tab.label}</span>
+            <div className="sh-sidebar-divider" style={{ marginTop: 'auto' }} />
+            <UsageMeterCard />
+            {settingsGroup.map((tab) => {
+              const active = isActive(tab.path)
+              const Icon = iconComponents[tab.icon]
+              return (
+                <button
+                  key={tab.path}
+                  onClick={() => navigate(tab.path)}
+                  className={`sh-sidebar-btn${active ? ' active' : ''}`}
+                >
+                  <Icon size={20} />
+                  <span>{tab.label}</span>
+                </button>
+              )
+            })}
+            <button onClick={logout} className="sh-sidebar-btn">
+              <IconLogout size={20} />
+              <span>{t('nav.logout', 'Logout')}</span>
             </button>
-          )
-        })}
-        <button onClick={logout} className="sh-sidebar-btn">
-          <IconLogout size={20} />
-          <span>{t('nav.logout', 'Logout')}</span>
-        </button>
+          </>
+        )}
       </nav>
     )
   }
@@ -325,7 +347,7 @@ export function Navigation() {
   //
   // Requires `viewport-fit=cover` in <meta name="viewport"> (see index.html).
 
-  const isFabActionActive = isActive(ROUTES.addBook) || isActive(ROUTES.scanShelf)
+  const isFabActionActive = isActive(prefix(ROUTES.addBook)) || isActive(prefix(ROUTES.scanShelf))
 
   const mobileTabStyle = (active: boolean): CSSProperties => ({
     flex: 1,
@@ -366,8 +388,8 @@ export function Navigation() {
       {/* ── Tab row ── */}
       <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-around' }}>
 
-        {/* Two tabs to the left of the FAB */}
-        {mobileTabs.slice(0, 2).map((tab) => {
+        {/* Tabs to the left of the FAB */}
+        {mobileTabs.slice(0, mobileSplit).map((tab) => {
           const active = isActive(tab.path)
           const Icon = iconComponents[tab.icon as NavIcon]
           return (
@@ -404,7 +426,7 @@ export function Navigation() {
               >
                 <button
                   role="menuitem"
-                  onClick={() => navigate(ROUTES.addBook)}
+                  onClick={() => navigate(prefix(ROUTES.addBook))}
                   className="sh-fab-menu-item"
                   style={{
                     display: 'flex', alignItems: 'center', gap: 12,
@@ -426,7 +448,7 @@ export function Navigation() {
                 </button>
                 <button
                   role="menuitem"
-                  onClick={() => navigate(ROUTES.scanShelf)}
+                  onClick={() => navigate(prefix(ROUTES.scanShelf))}
                   className="sh-fab-menu-item"
                   style={{
                     display: 'flex', alignItems: 'center', gap: 12,
@@ -492,8 +514,8 @@ export function Navigation() {
           )}
         </div>
 
-        {/* Two tabs to the right of the FAB */}
-        {mobileTabs.slice(2).map((tab) => {
+        {/* Tabs to the right of the FAB */}
+        {mobileTabs.slice(mobileSplit).map((tab) => {
           const active = isActive(tab.path)
           const Icon = iconComponents[tab.icon as NavIcon]
           return (


### PR DESCRIPTION
## Summary
The `/demo` subtree only rendered the `DemoBanner`, so a visitor landing in the demo had **no side panel** — no way to reach add-book, scan, bookshelf or jump back to search. That's exactly the navigation Patrik flagged as missing.

This reuses the existing app sidebar in demo mode instead of building a parallel one:
- **`Navigation` is now demo-aware** (detected via the `/demo` path prefix). Every destination is rewritten through `withDemoPrefix`, so clicks stay inside `/demo/*` and never bounce the visitor into the authenticated app.
- Authenticated-only controls (**borrowers, settings, usage meter, logout**) are dropped in demo — the visitor isn't logged in.
- **Mobile bottom nav** adapts to the two demo tabs: `Library | FAB(add/scan) | Bookshelf`.
- `AppShell` stops force-hiding the nav on `/demo`, so the demo content gets the same sidebar offset as the real app while keeping the `DemoBanner` on top.

No new component, no duplicated styling — one source of truth for the sidebar.

## Test plan
- [x] New `Navigation.demo.test.tsx`: demo sidebar shows Library/Bookshelf/Add/Scan, hides borrowers/settings/logout, and routes stay under `/demo`; full sidebar preserved outside demo.
- [x] `vitest run` — 245 passed (30 files)
- [x] `vite build` succeeds
- [x] `eslint` clean on changed files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added demo mode support to Navigation with restricted access to authenticated-only features (borrowers, settings, logout)
  * Demo mode displays appropriate navigation items and hides administrative controls
  * Mobile navigation automatically adjusts to show only demo-safe options in demo mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->