### PR TITLE
fix(test): unblock deploy — raise waitFor timeout in demo scan test

### DIFF
--- a/frontend/src/pages/ScanShelfPage.demo.test.tsx
+++ b/frontend/src/pages/ScanShelfPage.demo.test.tsx
@@ -73,8 +73,9 @@ describe('ScanShelfPage — demo mode (#286)', () => {
 
     // ── Step 1: pick the seeded Living room / Bookcase / Shelf 1 ──
     // Locations arrive asynchronously from the demo store via React Query.
-    await waitFor(() =>
-      expect(screen.getAllByRole('combobox')[0].querySelectorAll('option').length).toBeGreaterThan(1),
+    await waitFor(
+      () => expect(screen.getAllByRole('combobox')[0].querySelectorAll('option').length).toBeGreaterThan(1),
+      { timeout: 5000 }, // React Query hydration is slow on CI runners; default 1s flakes
     )
     fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'Living room' } })
     fireEvent.change(screen.getAllByRole('combobox')[1], { target: { value: 'Bookcase' } })


### PR DESCRIPTION
## Summary
The CI run on `main` for #292 **failed** on a flaky assertion in `ScanShelfPage.demo.test.tsx` ("expected 1 to be greater than 1"). Because the **Deploy** workflow gates on a green CI run on `main`, that failure silently skipped the production deploy — so the demo-sidebar fix (#292) never shipped.

Root cause: the first `waitFor` (step-1 location selects hydrating from React Query) used the default **1s** timeout and times out on slower CI runners. Bumped to **5s**, matching the headroom already given to the later wizard steps. No production code touched.

## Test plan
- [x] `vitest run ScanShelfPage.demo.test.tsx` — passes 3/3 locally
- [ ] CI green on this PR
- [ ] After merge: CI green on `main` → Deploy runs → demo sidebar live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of demo-mode hydration check in tests through explicit timeout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->