### PR TITLE
fix(demo): make book detail reachable and usable in the demo

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,6 +111,7 @@ function AppShell() {
             <Route index element={<Navigate to='/demo/books' replace />} />
             <Route path='books' element={<BooksPage />} />
             <Route path='books/new' element={<AddBookPage />} />
+            <Route path='books/:bookId' element={<BookDetailPage />} />
             <Route path='scan' element={<ScanShelfPage />} />
             <Route path='bookshelf' element={<BookshelfViewPage />} />
           </Route>

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 import type { Book } from '../lib/types'
 import { ReadingStatusBadge } from './ReadingStatusBadge'
 import { getBookDetailRoute } from '../lib/routes'
-import { useIsDemoMode } from '../features/demo/DemoContext'
+import { useDemoPath } from '../features/demo/demoNav'
 
 // ── Cover palette: [bgColor, accentColor] ────────────────────────────
 // Replaces the old GRADIENTS array. Each palette has a dark background
@@ -130,8 +130,9 @@ export function BookCard({
   onSelect,
 }: Props) {
   const { t } = useTranslation()
-  // The demo has no book-detail route, so cards there are non-navigating. (#285)
-  const isDemo = useIsDemoMode()
+  // In the demo, book detail lives at the `/demo`-prefixed twin route; demoPath
+  // is an identity function outside the demo, so the link works in both worlds.
+  const demoPath = useDemoPath()
 
   const hash = hashTitle(book.title)
   const [bgColor, accentColor] = COVER_PALETTES[hash % COVER_PALETTES.length]
@@ -357,7 +358,7 @@ export function BookCard({
         </button>
       )}
 
-      {selectable || isDemo ? (
+      {selectable ? (
         <div
           style={{
             background: 'var(--sh-surface)',
@@ -374,7 +375,7 @@ export function BookCard({
         </div>
       ) : (
         <Link
-          to={getBookDetailRoute(book.id)}
+          to={demoPath(getBookDetailRoute(book.id))}
           style={{
             background: 'var(--sh-surface)',
             borderRadius: 'var(--sh-radius-lg)',

--- a/frontend/src/pages/BookDetailPage.demo.test.tsx
+++ b/frontend/src/pages/BookDetailPage.demo.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Demo-mode behaviour for BookDetailPage (#288 follow-up).
+ *
+ * A logged-out visitor can now open a book from the demo list. The detail page
+ * reads and writes the in-memory demo store (no network), and the backend-only
+ * affordances (AI enrichment, loan history) are suppressed.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: false })),
+}))
+
+// Stub the API so the test fails loudly if the demo ever reaches the network.
+vi.mock('../lib/api', () => ({
+  getBook: vi.fn(),
+  updateBook: vi.fn(),
+  deleteBook: vi.fn(),
+  listLocations: vi.fn(),
+  enrichBook: vi.fn(),
+  listLoans: vi.fn(),
+  createLoan: vi.fn(),
+  returnLoan: vi.fn(),
+  formatApiError: (e: unknown) => String(e),
+}))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: vi.fn(
+    (selector: (s: { showError: () => void; showSuccess: () => void; showInfo: () => void }) => unknown) =>
+      selector({ showError: vi.fn(), showSuccess: vi.fn(), showInfo: vi.fn() }),
+  ),
+}))
+
+import * as api from '../lib/api'
+import { BookDetailPage } from './BookDetailPage'
+import { DemoModeProvider } from '../features/demo/DemoContext'
+import { useDemoStore } from '../store/useDemoStore'
+
+function renderDetail(bookId: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/demo/books/${bookId}`]}>
+        <DemoModeProvider>{children}</DemoModeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+  return render(
+    <Routes>
+      <Route path="/demo/books/:bookId" element={<BookDetailPage />} />
+    </Routes>,
+    { wrapper },
+  )
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  useDemoStore.getState().reset()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+  useDemoStore.getState().reset()
+})
+
+describe('BookDetailPage — demo mode', () => {
+  it('renders the book from the in-memory store and hides backend-only sections', async () => {
+    const book = useDemoStore.getState().books[0]
+    renderDetail(book.id)
+
+    expect((await screen.findAllByText(book.title)).length).toBeGreaterThan(0)
+    // AI enrichment + loan history depend on the backend — hidden in the demo.
+    expect(screen.queryByText('enrich.enrich_book')).not.toBeInTheDocument()
+    expect(screen.queryByText('loans.history_title')).not.toBeInTheDocument()
+    // Never touched the network.
+    expect(api.getBook).not.toHaveBeenCalled()
+  })
+
+  it('persists metadata edits to the in-memory store, no network', async () => {
+    const user = userEvent.setup()
+    const book = useDemoStore.getState().books[0]
+    renderDetail(book.id)
+    await screen.findAllByText(book.title)
+
+    await user.click(screen.getByText('book_detail.metadata_edit_title'))
+    const titleInput = screen.getByLabelText('edit-title')
+    await user.clear(titleInput)
+    await user.type(titleInput, 'Nový název')
+    await user.click(screen.getByText('book_detail.save'))
+
+    await waitFor(() => {
+      expect(useDemoStore.getState().books.find((b) => b.id === book.id)?.title).toBe('Nový název')
+    })
+    expect(api.updateBook).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 
 import { AccordionSection } from '../components/AccordionSection'
 import { ReadingStatusBadge } from '../components/ReadingStatusBadge'
@@ -12,6 +12,8 @@ import { ROUTES } from '../lib/routes'
 import type { ReadingStatus } from '../lib/types'
 import { LoanHistory } from '../components/LoanHistory'
 import { Modal } from '../components/Modal'
+import { useIsDemoMode } from '../features/demo/DemoContext'
+import { useAppNavigate } from '../features/demo/demoNav'
 
 const GRADIENTS: [string, string][] = [
   ['#1D9E75', '#085041'],
@@ -43,7 +45,10 @@ function sectionHeading(text: string) {
 
 export function BookDetailPage() {
   const { t } = useTranslation()
-  const navigate = useNavigate()
+  // useAppNavigate keeps back / show-in-twin / post-delete navigation inside the
+  // `/demo` subtree when the visitor is in the public demo. (#288 follow-up)
+  const navigate = useAppNavigate()
+  const isDemo = useIsDemoMode()
   const { bookId = '' } = useParams()
   const [expandedDescription, setExpandedDescription] = useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
@@ -259,19 +264,22 @@ export function BookDetailPage() {
                 <span className="sh-metadata-row__label">{t('book_detail.scan_status')}</span>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                   <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--sh-text-main)', display: 'inline-block', background: book.processing_status === 'done' ? 'var(--sh-teal-bg)' : 'var(--sh-amber-bg)', padding: '2px 8px', borderRadius: 'var(--sh-radius-pill)' }}>{t(`processing_status.${book.processing_status}`)}</span>
-                  <button
-                    type="button"
-                    onClick={() => enrichMutation.mutate({ bookId: book.id, force: book.processing_status === 'done' })}
-                    disabled={enrichMutation.isPending}
-                    style={{
-                      background: 'none', border: '1px solid var(--sh-border)',
-                      borderRadius: 'var(--sh-radius-sm)', padding: '2px 10px',
-                      fontSize: 12, fontWeight: 500, cursor: enrichMutation.isPending ? 'wait' : 'pointer',
-                      color: 'var(--sh-teal)',
-                    }}
-                  >
-                    {enrichMutation.isPending ? t('enrich.enriching') : t('enrich.enrich_book')}
-                  </button>
+                  {/* AI enrichment hits the backend, so it's hidden in the demo. */}
+                  {!isDemo && (
+                    <button
+                      type="button"
+                      onClick={() => enrichMutation.mutate({ bookId: book.id, force: book.processing_status === 'done' })}
+                      disabled={enrichMutation.isPending}
+                      style={{
+                        background: 'none', border: '1px solid var(--sh-border)',
+                        borderRadius: 'var(--sh-radius-sm)', padding: '2px 10px',
+                        fontSize: 12, fontWeight: 500, cursor: enrichMutation.isPending ? 'wait' : 'pointer',
+                        color: 'var(--sh-teal)',
+                      }}
+                    >
+                      {enrichMutation.isPending ? t('enrich.enriching') : t('enrich.enrich_book')}
+                    </button>
+                  )}
                 </div>
               </div>
             </div>
@@ -387,10 +395,14 @@ export function BookDetailPage() {
             </div>
           </form>
 
-          {/* ── Loan history (accordion, collapsed by default) ── */}
-          <AccordionSection title={t('loans.history_title')} defaultOpen={false}>
-            <LoanHistory bookId={book.id} />
-          </AccordionSection>
+          {/* ── Loan history (accordion, collapsed by default) ──
+               Borrowers/loans are backend-only, so the section is omitted in
+               the demo. */}
+          {!isDemo && (
+            <AccordionSection title={t('loans.history_title')} defaultOpen={false}>
+              <LoanHistory bookId={book.id} />
+            </AccordionSection>
+          )}
 
           {/* ── Danger zone (de-emphasized) ── */}
           <AccordionSection title={t('book_detail.danger_zone_title')} defaultOpen={false}>

--- a/frontend/src/pages/BooksPage.demo.test.tsx
+++ b/frontend/src/pages/BooksPage.demo.test.tsx
@@ -87,10 +87,14 @@ describe('BooksPage — demo mode (#285)', () => {
     expect(screen.queryByTestId('sample-library-banner')).not.toBeInTheDocument()
   })
 
-  it('renders book cards as non-navigating elements (no detail links)', async () => {
+  it('links book cards to the /demo book-detail twin (not the authenticated route)', async () => {
     renderDemo()
     await screen.findAllByText('Proměna')
-    // BookCard links to /books/:id outside the demo; inside it must not.
+    // Cards must point at the demo-prefixed detail route…
+    const detailLinks = Array.from(document.querySelectorAll('a[href^="/demo/books/"]'))
+      .filter((a) => a.getAttribute('href') !== '/demo/books/new')
+    expect(detailLinks.length).toBeGreaterThan(0)
+    // …and never at the authenticated `/books/:id` route (which would bounce to login).
     expect(document.querySelector('a[href^="/books/"]')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
Patrik reported that clicking a book in the demo doesn't open its detail. Two reasons: there was **no `/demo/books/:bookId` route**, and `BookCard` rendered a non-navigating `<div>` in demo mode. Fixed end to end:

- **Route added**: `/demo/books/:bookId` → `BookDetailPage`.
- **BookCard** now links to the demo-prefixed detail twin via `useDemoPath` — identical to the authenticated card outside the demo.
- **BookDetailPage is demo-aware**: back / show-in-twin / post-delete navigation stays inside `/demo` (`useAppNavigate`), and the backend-only sections — **AI enrichment** and **loan history** — are hidden.

The read/edit/delete hooks were already demo-aware, so metadata edits persist to the in-memory store with **zero network calls**.

## Test plan
- [x] New `BookDetailPage.demo.test.tsx`: renders from the in-memory store, hides enrichment + loan history, and metadata edits persist with no API calls.
- [x] Updated `BooksPage.demo.test.tsx`: cards link to `/demo/books/:id`, never the authenticated `/books/:id`.
- [x] `vitest run` — 247 passed (31 files)
- [x] `vite build` + `eslint` clean
- [ ] CI green → deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a book detail page accessible in the demo, enabling users to view individual book information from the catalog.

* **Bug Fixes**
  * Fixed book card links to properly navigate to book details when browsing in demo mode.
  * Loan history and AI enrichment sections are now hidden from the public demo interface.

* **Tests**
  * Added comprehensive tests verifying book detail page behavior and data handling in demo mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->