### PR TITLE
fix: restore mouse drag-to-reorder on the bookshelf

### DIFF
--- a/frontend/src/pages/BookshelfViewPage.tsx
+++ b/frontend/src/pages/BookshelfViewPage.tsx
@@ -694,14 +694,17 @@ function BookSpine({
   }, [book.title])
 
   const displayTitle = book.title.length > 40 ? `${book.title.slice(0, 38)}…` : book.title
-  const isDraggable = Boolean(draggableProps)
 
+  // NOTE: do NOT add an `onPointerDown`/`onTouchStart` that calls
+  // `preventDefault()` here. Canceling `pointerdown` suppresses the browser's
+  // compatibility `mousedown` event, which is exactly what dnd-kit's
+  // `MouseSensor` listens for — doing so silently breaks drag-to-reorder with a
+  // mouse (touch still works via `TouchSensor`). Unwanted text/image selection
+  // while dragging is already prevented by `userSelect`/`WebkitUserDrag` below.
   return (
     <button
       ref={focusRef}
       onClick={onClick}
-      onPointerDown={(e) => { if (isDraggable) e.preventDefault() }}
-      onTouchStart={(e) => { if (isDraggable) e.preventDefault() }}
       className="sh-book-spine"
       title={`${book.title}${book.author ? ` — ${book.author}` : ''}`}
       data-highlighted={highlighted ? '' : undefined}


### PR DESCRIPTION
## Summary
- In Reorder mode on the bookshelf, dragging a book **with a mouse** did nothing (reported in the demo, but it affected the authenticated app too).
- Root cause: each book spine had `onPointerDown={(e) => e.preventDefault()}` while draggable. Canceling `pointerdown` suppresses the browser's compatibility `mousedown` event — the exact event dnd-kit's `MouseSensor` listens for — so the sensor never activated. Touch was unaffected (that goes through `TouchSensor`/`onTouchStart`).
- Fix: remove the handler. Unwanted text/image selection during a drag is already prevented by the `userSelect`/`WebkitUserDrag` styles on the spine. Added a comment so it isn't reintroduced.

## Test plan
- [x] `npm run lint`, full `vitest run`, `vite build` all green
- [ ] After deploy (incognito): `/demo/bookshelf` → tap **Přeskupit** → drag a book spine with the mouse → order changes and persists
- [ ] Authenticated app: same reorder flow with a mouse still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop behavior for books in the bookshelf view, resolving compatibility issues that were preventing smooth dragging interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->