### PR TITLE
demo: sandbox borrowers + loan lifecycle for unauthenticated visitors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -114,6 +114,8 @@ function AppShell() {
             <Route path='books/:bookId' element={<BookDetailPage />} />
             <Route path='scan' element={<ScanShelfPage />} />
             <Route path='bookshelf' element={<BookshelfViewPage />} />
+            <Route path='borrowers' element={<BorrowersPage />} />
+            <Route path='borrowers/:borrowerId' element={<BorrowerDetailPage />} />
           </Route>
 
           {/* ── Protected routes ── */}

--- a/frontend/src/components/Navigation.demo.test.tsx
+++ b/frontend/src/components/Navigation.demo.test.tsx
@@ -2,9 +2,10 @@
  * Navigation — demo-aware sidebar (#288 follow-up).
  *
  * Inside `/demo/*` the same sidebar is reused so visitors can move between
- * search / bookshelf / add / scan, but it must (a) keep every destination
- * inside the `/demo` subtree and (b) drop the authenticated-only controls
- * (borrowers, settings, usage meter, logout).
+ * search / bookshelf / add / scan / borrowers, but it must (a) keep every
+ * destination inside the `/demo` subtree and (b) drop the truly
+ * authenticated-only controls (settings, usage meter, logout). Borrowers IS
+ * shown — the loan lifecycle is fully sandboxed client-side.
  */
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -36,15 +37,16 @@ beforeEach(() => navigateMock.mockReset())
 afterEach(() => cleanup())
 
 describe('Navigation — demo mode', () => {
-  it('exposes the demo-relevant items and hides authenticated-only controls', () => {
+  it('exposes the demo-relevant items (incl. borrowers) and hides authenticated-only controls', () => {
     renderAt('/demo/books')
 
     expect(screen.getByText('nav.library')).toBeInTheDocument()
     expect(screen.getByText('nav.bookshelf')).toBeInTheDocument()
     expect(screen.getByText('nav.add')).toBeInTheDocument()
     expect(screen.getByText('nav.scan')).toBeInTheDocument()
+    // Borrowers/loans are sandboxed client-side, so the entry IS shown.
+    expect(screen.getByText('nav.borrowers')).toBeInTheDocument()
 
-    expect(screen.queryByText('nav.borrowers')).not.toBeInTheDocument()
     expect(screen.queryByText('nav.settings')).not.toBeInTheDocument()
     expect(screen.queryByText('nav.logout')).not.toBeInTheDocument()
   })
@@ -61,6 +63,9 @@ describe('Navigation — demo mode', () => {
 
     await user.click(screen.getByText('nav.bookshelf'))
     expect(navigateMock).toHaveBeenLastCalledWith('/demo/bookshelf')
+
+    await user.click(screen.getByText('nav.borrowers'))
+    expect(navigateMock).toHaveBeenLastCalledWith('/demo/borrowers')
   })
 
   it('keeps the full authenticated sidebar (borrowers/settings/logout) outside the demo', () => {

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -160,9 +160,9 @@ export function Navigation() {
 
   const secondaryGroup = useMemo<NavItem[]>(
     () => [
-      { label: t('nav.borrowers'), icon: 'borrowers', path: ROUTES.borrowers },
+      { label: t('nav.borrowers'), icon: 'borrowers', path: prefix(ROUTES.borrowers) },
     ],
-    [t],
+    [t, prefix],
   )
 
   const settingsGroup = useMemo<NavItem[]>(
@@ -181,6 +181,7 @@ export function Navigation() {
         ? [
             { label: t('nav.library'), icon: 'library', path: prefix(ROUTES.books) },
             { label: t('nav.bookshelf'), icon: 'bookshelf', path: prefix(ROUTES.bookshelfView) },
+            { label: t('nav.borrowers'), icon: 'borrowers', path: prefix(ROUTES.borrowers) },
           ]
         : [
             { label: t('nav.library'), icon: 'library', path: ROUTES.books },
@@ -294,25 +295,28 @@ export function Navigation() {
           )
         })}
 
+        {/* Borrowers — shown in the demo too (the loan lifecycle is fully
+            sandboxed client-side). Usage / settings / logout stay
+            authenticated-only. */}
+        <div className="sh-sidebar-divider" />
+        {secondaryGroup.map((tab) => {
+          const active = isActive(tab.path)
+          const Icon = iconComponents[tab.icon]
+          return (
+            <button
+              key={tab.path}
+              onClick={() => navigate(tab.path)}
+              className={`sh-sidebar-btn${active ? ' active' : ''}`}
+              data-testid={`nav-${tab.icon}`}
+            >
+              <Icon size={20} />
+              <span>{tab.label}</span>
+            </button>
+          )
+        })}
+
         {!isDemo && (
           <>
-            <div className="sh-sidebar-divider" />
-            {secondaryGroup.map((tab) => {
-              const active = isActive(tab.path)
-              const Icon = iconComponents[tab.icon]
-              return (
-                <button
-                  key={tab.path}
-                  onClick={() => navigate(tab.path)}
-                  className={`sh-sidebar-btn${active ? ' active' : ''}`}
-                  data-testid={`nav-${tab.icon}`}
-                >
-                  <Icon size={20} />
-                  <span>{tab.label}</span>
-                </button>
-              )
-            })}
-
             <div className="sh-sidebar-divider" style={{ marginTop: 'auto' }} />
             <UsageMeterCard />
             {settingsGroup.map((tab) => {

--- a/frontend/src/features/demo/demoSeed.ts
+++ b/frontend/src/features/demo/demoSeed.ts
@@ -16,7 +16,7 @@
  *  - The factory functions return **fresh** arrays/objects on every call, so a
  *    `reset()` can never be polluted by in-place demo mutations.
  */
-import type { Book, Location, ReadingStatus } from '../../lib/types'
+import type { Book, Borrower, Loan, Location, ReadingStatus } from '../../lib/types'
 
 /** Fixed timestamp for all seed rows — keeps demo snapshots deterministic. */
 export const DEMO_SEED_TS = '2026-01-01T00:00:00.000Z'
@@ -146,6 +146,94 @@ const SEED_BOOKS: readonly SeedBook[] = [
   ['Snídaně u Tiffanyho', 'Truman Capote', 'cs', 1958, 'unread', 2, 32],
 ] as const
 
+// ── Borrowers & loans (#284 follow-up) ──────────────────────────────────────
+//
+// Mirrors the real borrowers/loans feature client-side so the demo can show a
+// populated "Borrowers" view and a working lend / return lifecycle — still with
+// zero backend/AI load. Anonymize / merge are intentionally NOT seeded or
+// exposed in the demo (they're hidden in the UI), so every borrower row here is
+// a plain, active record (no `anonymized_at`, no `pending_anonymization_until`).
+
+interface SeedBorrower {
+  id: string
+  name: string
+  contact: string | null
+  notes: string | null
+}
+
+const SEED_BORROWERS: readonly SeedBorrower[] = [
+  { id: 'demo-borrower-1', name: 'Jana Nováková', contact: 'jana.novakova@email.cz', notes: 'Kolegyně z práce, vrací včas.' },
+  { id: 'demo-borrower-2', name: 'Petr Svoboda', contact: '+420 777 123 456', notes: null },
+  { id: 'demo-borrower-3', name: 'Lucie Dvořáková', contact: 'lucie.dvorakova@email.cz', notes: null },
+  { id: 'demo-borrower-4', name: 'Tomáš Procházka', contact: null, notes: 'Soused odvedle.' },
+] as const
+
+type ReturnCondition = NonNullable<Loan['return_condition']>
+
+/** [id, bookId, borrowerId, lentDate, dueDate, returnedDate, returnCondition, notes] */
+type SeedLoan = readonly [
+  string,
+  string,
+  string,
+  string,
+  string | null,
+  string | null,
+  ReturnCondition | null,
+  string | null,
+]
+
+const SEED_LOANS: readonly SeedLoan[] = [
+  // ── Active loans (currently out) ──
+  ['demo-loan-1', 'demo-book-06', 'demo-borrower-1', '2026-05-20', '2026-06-20', null, null, null],
+  ['demo-loan-2', 'demo-book-37', 'demo-borrower-2', '2026-05-28', '2026-06-15', null, null, 'Půjčeno na dovolenou.'],
+  ['demo-loan-3', 'demo-book-51', 'demo-borrower-1', '2026-06-02', '2026-07-02', null, null, null],
+  // ── Returned loans (history) ──
+  ['demo-loan-4', 'demo-book-01', 'demo-borrower-3', '2026-03-01', '2026-03-21', '2026-03-22', 'good', null],
+  ['demo-loan-5', 'demo-book-71', 'demo-borrower-2', '2026-02-10', '2026-03-01', '2026-03-05', 'perfect', null],
+  ['demo-loan-6', 'demo-book-85', 'demo-borrower-4', '2026-04-15', '2026-05-15', '2026-05-10', 'fair', 'Trochu ohnutý roh.'],
+  ['demo-loan-7', 'demo-book-28', 'demo-borrower-1', '2026-01-05', '2026-02-05', '2026-02-01', 'good', null],
+] as const
+
+/** Build a fresh array of seed borrowers (new objects every call). */
+export function createDemoBorrowers(): Borrower[] {
+  return SEED_BORROWERS.map((b) => ({
+    id: b.id,
+    name: b.name,
+    contact: b.contact,
+    notes: b.notes,
+    anonymized_at: null,
+    pending_anonymization_until: null,
+    created_by_user_id: null,
+    anonymized_by_user_id: null,
+    merged_into_by_user_id: null,
+    created_at: DEMO_SEED_TS,
+    updated_at: DEMO_SEED_TS,
+  }))
+}
+
+/** Build a fresh array of seed loans, denormalizing the borrower snapshot. */
+export function createDemoLoans(): Loan[] {
+  const byId = new Map(createDemoBorrowers().map((b) => [b.id, b]))
+  return SEED_LOANS.map(([id, bookId, borrowerId, lentDate, dueDate, returnedDate, returnCondition, notes]) => {
+    const borrower = byId.get(borrowerId) ?? null
+    return {
+      id,
+      book_id: bookId,
+      borrower_id: borrowerId,
+      borrower_name: borrower?.name ?? '',
+      borrower_contact: borrower?.contact ?? null,
+      borrower,
+      lent_date: lentDate,
+      due_date: dueDate,
+      returned_date: returnedDate,
+      return_condition: returnCondition,
+      notes,
+      created_at: `${lentDate}T00:00:00.000Z`,
+      is_active: returnedDate === null,
+    }
+  })
+}
+
 /** Build a fresh array of seed locations (new objects every call). */
 export function createDemoLocations(): Location[] {
   return SEED_LOCATIONS.map((loc) => ({
@@ -162,24 +250,34 @@ export function createDemoLocations(): Location[] {
 
 /** Build a fresh array of seed books (new objects every call). */
 export function createDemoBooks(): Book[] {
-  return SEED_BOOKS.map(([title, author, language, year, readingStatus, locIdx, shelfPos], index) => ({
-    id: `demo-book-${String(index + 1).padStart(2, '0')}`,
-    title,
-    author,
-    isbn: null,
-    publisher: null,
-    language,
-    description: null,
-    publication_year: year,
-    cover_image_url: null,
-    location_id: SEED_LOCATIONS[locIdx].id,
-    shelf_position: shelfPos,
-    processing_status: 'done',
-    reading_status: readingStatus,
-    is_currently_lent: false,
-    active_loan: null,
-    is_sample: true,
-    created_at: DEMO_SEED_TS,
-    updated_at: DEMO_SEED_TS,
-  }))
+  // Reflect the seeded lending state: books with an active (un-returned) loan
+  // render as "currently lent" and carry their active loan on the book object,
+  // exactly like the backend's `Book` payload.
+  const activeLoanByBook = new Map(
+    createDemoLoans().filter((l) => l.is_active).map((l) => [l.book_id, l]),
+  )
+  return SEED_BOOKS.map(([title, author, language, year, readingStatus, locIdx, shelfPos], index) => {
+    const id = `demo-book-${String(index + 1).padStart(2, '0')}`
+    const activeLoan = activeLoanByBook.get(id) ?? null
+    return {
+      id,
+      title,
+      author,
+      isbn: null,
+      publisher: null,
+      language,
+      description: null,
+      publication_year: year,
+      cover_image_url: null,
+      location_id: SEED_LOCATIONS[locIdx].id,
+      shelf_position: shelfPos,
+      processing_status: 'done',
+      reading_status: readingStatus,
+      is_currently_lent: activeLoan !== null,
+      active_loan: activeLoan,
+      is_sample: true,
+      created_at: DEMO_SEED_TS,
+      updated_at: DEMO_SEED_TS,
+    }
+  })
 }

--- a/frontend/src/hooks/useBorrowers.ts
+++ b/frontend/src/hooks/useBorrowers.ts
@@ -3,6 +3,9 @@ import { useTranslation } from 'react-i18next'
 
 import { anonymizeBorrower, formatApiError, getBorrower, listBorrowerLoans, listBorrowers, mergeBorrowers, restoreBorrower, undoMerge, updateBorrower } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
+import { useIsDemoMode } from '../features/demo/DemoContext'
+import { DEMO_QUERY_KEY } from './useBooks'
+import { useDemoStore } from '../store/useDemoStore'
 import { useMergeUndoStore } from '../lib/merge-undo-store'
 import { useToastStore } from '../lib/toast-store'
 import type { BorrowerListParams, BorrowerUpdateRequest } from '../lib/types'
@@ -21,32 +24,40 @@ const borrowerLoansKey = (id: string) => ['borrower', id, 'loans']
 
 export function useBorrowers(params: BorrowerListParams = {}) {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
-    queryKey: borrowersListKey(params),
-    queryFn: () => listBorrowers(params),
+    queryKey: isDemo ? [...DEMO_QUERY_KEY, ...borrowersListKey(params)] : borrowersListKey(params),
+    queryFn: () => (isDemo ? useDemoStore.getState().queryBorrowers(params) : listBorrowers(params)),
     retry: false,
-    enabled: isAuthenticated,
+    enabled: isDemo || isAuthenticated,
     placeholderData: (previous) => previous,
   })
 }
 
 export function useBorrower(id: string) {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
-    queryKey: borrowerKey(id),
-    queryFn: () => getBorrower(id),
+    queryKey: isDemo ? [...DEMO_QUERY_KEY, ...borrowerKey(id)] : borrowerKey(id),
+    queryFn: () => {
+      if (!isDemo) return getBorrower(id)
+      const found = useDemoStore.getState().getBorrowerDetail(id)
+      if (!found) throw new Error('Borrower not found')
+      return found
+    },
     retry: false,
-    enabled: isAuthenticated && Boolean(id),
+    enabled: (isDemo || isAuthenticated) && Boolean(id),
   })
 }
 
 export function useBorrowerLoans(id: string) {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
-    queryKey: borrowerLoansKey(id),
-    queryFn: () => listBorrowerLoans(id),
+    queryKey: isDemo ? [...DEMO_QUERY_KEY, ...borrowerLoansKey(id)] : borrowerLoansKey(id),
+    queryFn: () => (isDemo ? useDemoStore.getState().borrowerLoans(id) : listBorrowerLoans(id)),
     retry: false,
-    enabled: isAuthenticated && Boolean(id),
+    enabled: (isDemo || isAuthenticated) && Boolean(id),
   })
 }
 
@@ -55,11 +66,25 @@ export function useUpdateBorrower() {
   const showError = useToastStore((s) => s.showError)
   const showSuccess = useToastStore((s) => s.showSuccess)
   const { t } = useTranslation()
+  const isDemo = useIsDemoMode()
 
   return useMutation({
-    mutationFn: ({ id, payload }: { id: string; payload: BorrowerUpdateRequest }) =>
-      updateBorrower(id, payload),
+    mutationFn: async ({ id, payload }: { id: string; payload: BorrowerUpdateRequest }) => {
+      if (isDemo) {
+        const updated = useDemoStore.getState().updateBorrower(id, payload)
+        if (!updated) throw new Error('Borrower not found')
+        return updated
+      }
+      return updateBorrower(id, payload)
+    },
     onSuccess: async (updated) => {
+      if (isDemo) {
+        // The demo cache lives under a single ['demo', …] prefix; one
+        // invalidation refreshes the list, detail and any loan rows at once.
+        await queryClient.invalidateQueries({ queryKey: DEMO_QUERY_KEY })
+        showSuccess(t('toast.borrower_saved', 'Borrower saved.'))
+        return
+      }
       // ADR 008: edits do NOT propagate to historical loan rows. Only the
       // borrower-level caches need invalidating.
       // Invalidate every page/search variant of the borrowers list under

--- a/frontend/src/hooks/useLoans.ts
+++ b/frontend/src/hooks/useLoans.ts
@@ -4,6 +4,9 @@ import { useTranslation } from 'react-i18next'
 
 import { createLoan, formatApiError, listLoans, returnLoan } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
+import { useIsDemoMode } from '../features/demo/DemoContext'
+import { DEMO_QUERY_KEY } from './useBooks'
+import { useDemoStore } from '../store/useDemoStore'
 import { useToastStore } from '../lib/toast-store'
 import type { LoanCreateRequest, LoanReturnRequest } from '../lib/types'
 
@@ -11,10 +14,11 @@ const loansKey = (bookId: string) => ['loans', bookId]
 
 export function useLoans(bookId: string) {
   const { isAuthenticated } = useAuth()
+  const isDemo = useIsDemoMode()
   return useQuery({
-    queryKey: loansKey(bookId),
-    queryFn: () => listLoans(bookId),
-    enabled: isAuthenticated && Boolean(bookId),
+    queryKey: isDemo ? [...DEMO_QUERY_KEY, ...loansKey(bookId)] : loansKey(bookId),
+    queryFn: () => (isDemo ? useDemoStore.getState().loansForBook(bookId) : listLoans(bookId)),
+    enabled: (isDemo || isAuthenticated) && Boolean(bookId),
     retry: false,
   })
 }
@@ -24,12 +28,20 @@ export function useCreateLoan(bookId: string) {
   const showError = useToastStore((state) => state.showError)
   const showSuccess = useToastStore((state) => state.showSuccess)
   const { t } = useTranslation()
+  const isDemo = useIsDemoMode()
 
   return useMutation({
-    mutationFn: (payload: LoanCreateRequest) => createLoan(bookId, payload),
+    mutationFn: async (payload: LoanCreateRequest) =>
+      isDemo ? useDemoStore.getState().createLoan(bookId, payload) : createLoan(bookId, payload),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: loansKey(bookId) })
-      await queryClient.invalidateQueries({ queryKey: ['books'] })
+      if (isDemo) {
+        // One ['demo', …] invalidation refreshes loans, the book and the
+        // borrower list/detail (a new borrower may have just been created).
+        await queryClient.invalidateQueries({ queryKey: DEMO_QUERY_KEY })
+      } else {
+        await queryClient.invalidateQueries({ queryKey: loansKey(bookId) })
+        await queryClient.invalidateQueries({ queryKey: ['books'] })
+      }
       showSuccess(t('toast.book_lent', 'Book lent successfully.'))
     },
     onError: (error: unknown) => showError(formatApiError(error)),
@@ -41,12 +53,20 @@ export function useReturnLoan(bookId: string) {
   const showError = useToastStore((state) => state.showError)
   const showSuccess = useToastStore((state) => state.showSuccess)
   const { t } = useTranslation()
+  const isDemo = useIsDemoMode()
 
   return useMutation({
-    mutationFn: ({ loanId, payload }: { loanId: string; payload: LoanReturnRequest }) => returnLoan(bookId, loanId, payload),
+    mutationFn: async ({ loanId, payload }: { loanId: string; payload: LoanReturnRequest }) =>
+      isDemo
+        ? useDemoStore.getState().returnLoan(bookId, loanId, payload)
+        : returnLoan(bookId, loanId, payload),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: loansKey(bookId) })
-      await queryClient.invalidateQueries({ queryKey: ['books'] })
+      if (isDemo) {
+        await queryClient.invalidateQueries({ queryKey: DEMO_QUERY_KEY })
+      } else {
+        await queryClient.invalidateQueries({ queryKey: loansKey(bookId) })
+        await queryClient.invalidateQueries({ queryKey: ['books'] })
+      }
       showSuccess(t('toast.book_returned', 'Book returned successfully.'))
     },
     onError: (error: unknown) => showError(formatApiError(error)),

--- a/frontend/src/pages/BookDetailPage.demo.test.tsx
+++ b/frontend/src/pages/BookDetailPage.demo.test.tsx
@@ -2,8 +2,9 @@
  * Demo-mode behaviour for BookDetailPage (#288 follow-up).
  *
  * A logged-out visitor can now open a book from the demo list. The detail page
- * reads and writes the in-memory demo store (no network), and the backend-only
- * affordances (AI enrichment, loan history) are suppressed.
+ * reads and writes the in-memory demo store (no network). AI enrichment (a
+ * backend/AI call) stays suppressed, but the loan-history section IS shown —
+ * the lend/return lifecycle is fully sandboxed client-side.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
@@ -70,16 +71,18 @@ afterEach(() => {
 })
 
 describe('BookDetailPage — demo mode', () => {
-  it('renders the book from the in-memory store and hides backend-only sections', async () => {
+  it('renders the book from the in-memory store, hides AI enrichment, shows loan history', async () => {
     const book = useDemoStore.getState().books[0]
     renderDetail(book.id)
 
     expect((await screen.findAllByText(book.title)).length).toBeGreaterThan(0)
-    // AI enrichment + loan history depend on the backend — hidden in the demo.
+    // AI enrichment hits the backend — still hidden in the demo.
     expect(screen.queryByText('enrich.enrich_book')).not.toBeInTheDocument()
-    expect(screen.queryByText('loans.history_title')).not.toBeInTheDocument()
+    // Loan history is now sandboxed client-side, so the section IS present.
+    expect(screen.getAllByText('loans.history_title').length).toBeGreaterThan(0)
     // Never touched the network.
     expect(api.getBook).not.toHaveBeenCalled()
+    expect(api.listLoans).not.toHaveBeenCalled()
   })
 
   it('persists metadata edits to the in-memory store, no network', async () => {

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -396,13 +396,11 @@ export function BookDetailPage() {
           </form>
 
           {/* ── Loan history (accordion, collapsed by default) ──
-               Borrowers/loans are backend-only, so the section is omitted in
-               the demo. */}
-          {!isDemo && (
-            <AccordionSection title={t('loans.history_title')} defaultOpen={false}>
-              <LoanHistory bookId={book.id} />
-            </AccordionSection>
-          )}
+               The lend / return lifecycle is fully sandboxed client-side in the
+               demo (see useDemoStore), so the section renders there too. */}
+          <AccordionSection title={t('loans.history_title')} defaultOpen={false}>
+            <LoanHistory bookId={book.id} />
+          </AccordionSection>
 
           {/* ── Danger zone (de-emphasized) ── */}
           <AccordionSection title={t('book_detail.danger_zone_title')} defaultOpen={false}>

--- a/frontend/src/pages/BorrowerDetailPage.tsx
+++ b/frontend/src/pages/BorrowerDetailPage.tsx
@@ -6,6 +6,8 @@ import { EditBorrowerModal } from '../components/EditBorrowerModal'
 import { EmptyShelfIcon, NoResultsIcon } from '../components/EmptyStateIcons'
 import { MergeBorrowerModal } from '../components/MergeBorrowerModal'
 import { Modal } from '../components/Modal'
+import { useDemoPath } from '../features/demo/demoNav'
+import { useIsDemoMode } from '../features/demo/DemoContext'
 import { useAnonymizeBorrower, useBorrower, useBorrowerLoans, useRestoreBorrower } from '../hooks/useBorrowers'
 import { displayBorrowerName } from '../lib/borrowerDisplay'
 import { ROUTES, getBookDetailRoute } from '../lib/routes'
@@ -139,6 +141,7 @@ interface LoanRowProps {
 
 function LoanRow({ loan, locale }: LoanRowProps) {
   const { t } = useTranslation()
+  const demoPath = useDemoPath()
   return (
     <li
       data-testid={`borrower-loan-${loan.id}`}
@@ -154,7 +157,7 @@ function LoanRow({ loan, locale }: LoanRowProps) {
     >
       <div style={{ minWidth: 0 }}>
         <Link
-          to={getBookDetailRoute(loan.book_id)}
+          to={demoPath(getBookDetailRoute(loan.book_id))}
           style={{ fontWeight: 600, color: 'inherit', textDecoration: 'none' }}
         >
           {loan.book_title}
@@ -196,6 +199,8 @@ function LoanRow({ loan, locale }: LoanRowProps) {
 export function BorrowerDetailPage() {
   const { borrowerId } = useParams<{ borrowerId: string }>()
   const { t, i18n } = useTranslation()
+  const isDemo = useIsDemoMode()
+  const demoPath = useDemoPath()
   const borrowerQuery = useBorrower(borrowerId ?? '')
   const loansQuery = useBorrowerLoans(borrowerId ?? '')
   const anonymize = useAnonymizeBorrower()
@@ -236,7 +241,7 @@ export function BorrowerDetailPage() {
         <p data-testid="borrower-detail-error" style={{ color: 'var(--sh-text-muted)' }}>
           {t('borrowers.detail_not_found')}
         </p>
-        <Link to={ROUTES.borrowers}>{t('borrowers.back_to_overview')}</Link>
+        <Link to={demoPath(ROUTES.borrowers)}>{t('borrowers.back_to_overview')}</Link>
       </main>
     )
   }
@@ -250,7 +255,7 @@ export function BorrowerDetailPage() {
     <main className="sh-main" style={{ padding: 24, maxWidth: 760, margin: '0 auto' }}>
       <div style={{ marginBottom: 16 }}>
         <Link
-          to={ROUTES.borrowers}
+          to={demoPath(ROUTES.borrowers)}
           style={{ fontSize: 13, color: 'var(--sh-text-muted)', textDecoration: 'none' }}
         >
           ← {t('borrowers.back_to_overview')}
@@ -349,22 +354,27 @@ export function BorrowerDetailPage() {
             >
               {t('borrowers.edit_button')}
             </button>
-            <button
-              type="button"
-              data-testid="merge-button"
-              className="sh-btn-secondary"
-              onClick={() => setMergeOpen(true)}
-            >
-              {t('borrowers.merge_button')}
-            </button>
-            <button
-              type="button"
-              data-testid="anonymize-button"
-              className="sh-btn-secondary"
-              onClick={() => setConfirmOpen(true)}
-            >
-              {t('borrowers.anonymize_button')}
-            </button>
+            {/* Merge & anonymize are backend/GDPR workflows — hidden in the demo. */}
+            {!isDemo && (
+              <>
+                <button
+                  type="button"
+                  data-testid="merge-button"
+                  className="sh-btn-secondary"
+                  onClick={() => setMergeOpen(true)}
+                >
+                  {t('borrowers.merge_button')}
+                </button>
+                <button
+                  type="button"
+                  data-testid="anonymize-button"
+                  className="sh-btn-secondary"
+                  onClick={() => setConfirmOpen(true)}
+                >
+                  {t('borrowers.anonymize_button')}
+                </button>
+              </>
+            )}
           </div>
         )}
       </header>

--- a/frontend/src/pages/BorrowersPage.demo.test.tsx
+++ b/frontend/src/pages/BorrowersPage.demo.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Demo-mode behaviour for BorrowersPage (#288 follow-up).
+ *
+ * A logged-out visitor inside `/demo/*` can browse the seeded borrowers. The
+ * list reads the in-memory demo store (no network), links into the `/demo`
+ * subtree, and hides the GDPR bulk-anonymize control. The lend/return
+ * lifecycle is fully sandboxed client-side, so seeded borrowers carry real
+ * active/total loan counts.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: false })),
+}))
+
+// Stub the API so the test fails loudly if the demo ever reaches the network.
+vi.mock('../lib/api', () => ({
+  listBorrowers: vi.fn(),
+  getBorrower: vi.fn(),
+  listBorrowerLoans: vi.fn(),
+  anonymizeBorrower: vi.fn(),
+  restoreBorrower: vi.fn(),
+  updateBorrower: vi.fn(),
+  mergeBorrowers: vi.fn(),
+  formatApiError: (e: unknown) => String(e),
+}))
+
+vi.mock('../lib/toast-store', () => ({
+  useToastStore: (selector: (s: { showError: () => void; showSuccess: () => void; showInfo: () => void }) => unknown) =>
+    selector({ showError: vi.fn(), showSuccess: vi.fn(), showInfo: vi.fn() }),
+}))
+
+import * as api from '../lib/api'
+import { BorrowersPage } from './BorrowersPage'
+import { DemoModeProvider } from '../features/demo/DemoContext'
+import { useDemoStore } from '../store/useDemoStore'
+
+function renderList() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/demo/borrowers']}>
+        <DemoModeProvider>{children}</DemoModeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+  return render(
+    <Routes>
+      <Route path="/demo/borrowers" element={<BorrowersPage />} />
+    </Routes>,
+    { wrapper },
+  )
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  useDemoStore.getState().reset()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+  useDemoStore.getState().reset()
+})
+
+describe('BorrowersPage — demo mode', () => {
+  it('renders seeded borrowers from the in-memory store with /demo links, no network', async () => {
+    renderList()
+
+    // Seeded borrowers surface from the store.
+    expect(await screen.findByText('Jana Nováková')).toBeInTheDocument()
+    expect(screen.getByText('Petr Svoboda')).toBeInTheDocument()
+    expect(screen.getByText('Lucie Dvořáková')).toBeInTheDocument()
+    expect(screen.getByText('Tomáš Procházka')).toBeInTheDocument()
+
+    // The row links stay inside the /demo subtree.
+    const janaRow = useDemoStore.getState().borrowers.find((b) => b.name === 'Jana Nováková')!
+    expect(screen.getByTestId(`borrower-row-${janaRow.id}`)).toHaveAttribute(
+      'href',
+      `/demo/borrowers/${janaRow.id}`,
+    )
+
+    // Loan aggregates come from the sandboxed lifecycle (Jana lends 2 active).
+    expect(screen.getByTestId(`borrower-active-${janaRow.id}`)).toHaveTextContent(
+      'borrowers.active_count',
+    )
+
+    // Never touched the network.
+    expect(api.listBorrowers).not.toHaveBeenCalled()
+  })
+
+  it('hides the GDPR bulk-anonymize control in the demo', async () => {
+    renderList()
+    await screen.findByText('Jana Nováková')
+
+    expect(screen.queryByTestId('bulk-anonymize-button')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/BorrowersPage.tsx
+++ b/frontend/src/pages/BorrowersPage.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom'
 
 import { BulkAnonymizeModal } from '../components/BulkAnonymizeModal'
 import { NoResultsIcon } from '../components/EmptyStateIcons'
+import { useDemoPath } from '../features/demo/demoNav'
+import { useIsDemoMode } from '../features/demo/DemoContext'
 import { useDebounce } from '../hooks/useDebounce'
 import { useBorrowers } from '../hooks/useBorrowers'
 import { displayBorrowerName } from '../lib/borrowerDisplay'
@@ -23,6 +25,8 @@ function formatDate(value: string | null, locale: string): string {
 
 export function BorrowersPage() {
   const { t, i18n } = useTranslation()
+  const isDemo = useIsDemoMode()
+  const demoPath = useDemoPath()
   const [searchInput, setSearchInput] = useState('')
   const [page, setPage] = useState(1)
 
@@ -83,17 +87,20 @@ export function BorrowersPage() {
             {t('borrowers.subtitle')}
           </p>
         </div>
-        <button
-          type="button"
-          data-testid="bulk-anonymize-button"
-          className="sh-btn-secondary"
-          onClick={() => setBulkAnonOpen(true)}
-        >
-          {t('borrowers.bulk_anon_button')}
-        </button>
+        {/* Anonymization is a backend/GDPR workflow — not exposed in the demo. */}
+        {!isDemo && (
+          <button
+            type="button"
+            data-testid="bulk-anonymize-button"
+            className="sh-btn-secondary"
+            onClick={() => setBulkAnonOpen(true)}
+          >
+            {t('borrowers.bulk_anon_button')}
+          </button>
+        )}
       </header>
 
-      {bulkAnonOpen && (
+      {!isDemo && bulkAnonOpen && (
         <BulkAnonymizeModal onClose={() => setBulkAnonOpen(false)} />
       )}
 
@@ -194,7 +201,7 @@ export function BorrowersPage() {
           {items.map((borrower) => (
             <li key={borrower.id}>
               <Link
-                to={getBorrowerDetailRoute(borrower.id)}
+                to={demoPath(getBorrowerDetailRoute(borrower.id))}
                 data-testid={`borrower-row-${borrower.id}`}
                 className="sh-card"
                 style={{

--- a/frontend/src/store/useDemoStore.test.ts
+++ b/frontend/src/store/useDemoStore.test.ts
@@ -177,3 +177,111 @@ describe('useDemoStore', () => {
     expect(get().books.every((b) => b.is_sample)).toBe(true)
   })
 })
+
+describe('demo borrowers & loans', () => {
+  it('seeds borrowers with derived loan aggregates', () => {
+    const get = useDemoStore.getState
+    const res = get().queryBorrowers()
+    expect(res.total).toBe(4)
+    // Sorted by name; Jana has 2 active + 1 returned = 3 total.
+    const jana = res.items.find((b) => b.id === 'demo-borrower-1')!
+    expect(jana.active_loans).toBe(2)
+    expect(jana.total_loans).toBe(3)
+    expect(jana.last_activity_at).toBe('2026-06-02')
+  })
+
+  it('filters borrowers by search and active status', () => {
+    const get = useDemoStore.getState
+    expect(get().queryBorrowers({ search: 'svoboda' }).total).toBe(1)
+    expect(get().queryBorrowers({ search: 'email.cz' }).total).toBe(2)
+    // Tomáš has only a returned loan, so he drops out of the "active" filter.
+    const active = get().queryBorrowers({ status: 'active' })
+    expect(active.items.map((b) => b.id)).not.toContain('demo-borrower-4')
+    // No anonymization in the demo → the pending recovery view is always empty.
+    expect(get().queryBorrowers({ status: 'pending' }).total).toBe(0)
+  })
+
+  it('marks actively-lent seed books as currently lent', () => {
+    const get = useDemoStore.getState
+    const hobit = get().books.find((b) => b.id === 'demo-book-06')!
+    expect(hobit.is_currently_lent).toBe(true)
+    expect(hobit.active_loan?.borrower_id).toBe('demo-borrower-1')
+    // A returned-loan book is not currently lent.
+    expect(get().books.find((b) => b.id === 'demo-book-71')!.is_currently_lent).toBe(false)
+  })
+
+  it('builds borrower loan rows with joined book titles', () => {
+    const get = useDemoStore.getState
+    const rows = get().borrowerLoans('demo-borrower-1')
+    expect(rows).toHaveLength(3)
+    expect(rows.find((r) => r.book_id === 'demo-book-06')!.book_title).toBe('Hobit')
+  })
+
+  it('lends a book to an existing borrower and updates the book', () => {
+    const get = useDemoStore.getState
+    const loan = get().createLoan('demo-book-02', {
+      borrower_id: 'demo-borrower-2',
+      lent_date: '2026-06-08',
+      due_date: '2026-07-08',
+      notes: null,
+    })
+    expect(loan.is_active).toBe(true)
+    expect(loan.borrower_name).toBe('Petr Svoboda')
+    const book = get().books.find((b) => b.id === 'demo-book-02')!
+    expect(book.is_currently_lent).toBe(true)
+    expect(book.active_loan?.id).toBe(loan.id)
+    // No new borrower created when linking an existing one.
+    expect(get().queryBorrowers().total).toBe(4)
+  })
+
+  it('lends to a new typed-name borrower (creates the borrower)', () => {
+    const get = useDemoStore.getState
+    get().createLoan('demo-book-03', {
+      borrower_name: 'Nový Čtenář',
+      borrower_contact: 'novy@email.cz',
+      lent_date: '2026-06-08',
+      notes: null,
+    })
+    const res = get().queryBorrowers({ search: 'Nový' })
+    expect(res.total).toBe(1)
+    expect(res.items[0].contact).toBe('novy@email.cz')
+    expect(res.items[0].active_loans).toBe(1)
+  })
+
+  it('returns a loan and frees the book', () => {
+    const get = useDemoStore.getState
+    get().returnLoan('demo-book-06', 'demo-loan-1', {
+      returned_date: '2026-06-08',
+      return_condition: 'good',
+      notes: 'Vráceno.',
+    })
+    const loan = get().loansForBook('demo-book-06').find((l) => l.id === 'demo-loan-1')!
+    expect(loan.is_active).toBe(false)
+    expect(loan.returned_date).toBe('2026-06-08')
+    expect(get().books.find((b) => b.id === 'demo-book-06')!.is_currently_lent).toBe(false)
+    // Jana now has one fewer active loan.
+    expect(get().queryBorrowers().items.find((b) => b.id === 'demo-borrower-1')!.active_loans).toBe(1)
+  })
+
+  it('edits a borrower and refreshes nested loan references without rewriting snapshots', () => {
+    const get = useDemoStore.getState
+    get().updateBorrower('demo-borrower-3', { name: 'Lucie Nová', contact: 'lucie.nova@email.cz', notes: 'Sestřenice.' })
+    expect(get().getBorrowerDetail('demo-borrower-3')!.name).toBe('Lucie Nová')
+    const loan = get().loansForBook('demo-book-01').find((l) => l.borrower_id === 'demo-borrower-3')!
+    // Nested borrower reflects the edit (live resolution)...
+    expect(loan.borrower?.name).toBe('Lucie Nová')
+    // ...but the denormalized snapshot column is left intact (ADR 008).
+    expect(loan.borrower_name).toBe('Lucie Dvořáková')
+  })
+
+  it('persists borrowers/loans and reset() restores the pristine seed', () => {
+    const get = useDemoStore.getState
+    get().createLoan('demo-book-05', { borrower_name: 'Throwaway Reader', lent_date: '2026-06-08', notes: null })
+    const raw = sessionStorage.getItem(DEMO_STORAGE_KEY)!
+    expect(raw).toContain('Throwaway Reader')
+    expect(raw).toContain('demo-loan-1')
+    get().reset()
+    expect(get().queryBorrowers().total).toBe(4)
+    expect(get().loansForBook('demo-book-05')).toHaveLength(0)
+  })
+})

--- a/frontend/src/store/useDemoStore.ts
+++ b/frontend/src/store/useDemoStore.ts
@@ -21,13 +21,23 @@
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
-import { createDemoBooks, createDemoLocations } from '../features/demo/demoSeed'
+import { createDemoBooks, createDemoBorrowers, createDemoLoans, createDemoLocations } from '../features/demo/demoSeed'
 import type {
   Book,
   BookCreateRequest,
   BookListParams,
   BookListResponse,
   BookUpdateRequest,
+  Borrower,
+  BorrowerDetail,
+  BorrowerListItem,
+  BorrowerListParams,
+  BorrowerListResponse,
+  BorrowerLoanItem,
+  BorrowerUpdateRequest,
+  Loan,
+  LoanCreateRequest,
+  LoanReturnRequest,
   Location,
   ReadingStatus,
   ShelfScanConfirmRequest,
@@ -54,6 +64,8 @@ export interface ReorderItem {
 interface DemoData {
   books: Book[]
   locations: Location[]
+  borrowers: Borrower[]
+  loans: Loan[]
 }
 
 interface DemoActions {
@@ -62,6 +74,11 @@ interface DemoActions {
   booksForShelf: () => Book[]
   booksByLocation: (locationId: string) => Book[]
   counts: () => DemoBookCounts
+  // ── Borrower / loan read selectors ──
+  queryBorrowers: (params?: BorrowerListParams) => BorrowerListResponse
+  getBorrowerDetail: (id: string) => BorrowerDetail | null
+  borrowerLoans: (id: string) => BorrowerLoanItem[]
+  loansForBook: (bookId: string) => Loan[]
   // ── Write actions (all in-memory) ──
   addBook: (payload: BookCreateRequest) => Book
   updateBook: (id: string, payload: BookUpdateRequest) => Book | null
@@ -71,6 +88,10 @@ interface DemoActions {
   bulkUpdateStatus: (ids: string[], status: ReadingStatus) => void
   reorder: (items: ReorderItem[]) => void
   confirmShelfScan: (payload: ShelfScanConfirmRequest) => ShelfScanConfirmResponse
+  // ── Borrower / loan write actions ──
+  updateBorrower: (id: string, payload: BorrowerUpdateRequest) => Borrower | null
+  createLoan: (bookId: string, payload: LoanCreateRequest) => Loan
+  returnLoan: (bookId: string, loanId: string, payload: LoanReturnRequest) => Loan | null
   reset: () => void
 }
 
@@ -87,6 +108,35 @@ function nextId(): string {
     /* fall through */
   }
   return `demo-book-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+}
+
+function prefixedId(prefix: string): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `${prefix}-${crypto.randomUUID()}`
+    }
+  } catch {
+    /* fall through */
+  }
+  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+}
+
+/** Derive the list-row aggregates (`active_loans`, `total_loans`,
+ *  `last_activity_at`) for a borrower from the loan set. Exported for tests. */
+export function borrowerListItem(borrower: Borrower, loans: Loan[]): BorrowerListItem {
+  const mine = loans.filter((l) => l.borrower_id === borrower.id)
+  const dates: string[] = []
+  for (const l of mine) {
+    dates.push(l.lent_date)
+    if (l.returned_date) dates.push(l.returned_date)
+  }
+  dates.sort()
+  return {
+    ...borrower,
+    active_loans: mine.filter((l) => l.returned_date === null).length,
+    total_loans: mine.length,
+    last_activity_at: dates.length > 0 ? dates[dates.length - 1] : null,
+  }
 }
 
 function shelfOrder(books: Book[], locations: Location[]): Book[] {
@@ -149,6 +199,8 @@ export const useDemoStore = create<DemoState>()(
     (set, get) => ({
       books: createDemoBooks(),
       locations: createDemoLocations(),
+      borrowers: createDemoBorrowers(),
+      loans: createDemoLoans(),
 
       queryBooks: (params = {}) => {
         const all = get().books
@@ -182,6 +234,74 @@ export const useDemoStore = create<DemoState>()(
           lent: books.filter((b) => b.reading_status === 'lent').length,
         }
       },
+
+      queryBorrowers: (params = {}) => {
+        const { borrowers, loans } = get()
+        const search = params.search?.trim().toLowerCase()
+        const status = params.status ?? 'all'
+        let rows = borrowers.map((b) => borrowerListItem(b, loans))
+        if (search) {
+          rows = rows.filter((b) =>
+            [b.name, b.contact ?? ''].join(' ').toLowerCase().includes(search),
+          )
+        }
+        if (status === 'active') {
+          rows = rows.filter((b) => b.active_loans > 0)
+        } else if (status === 'pending') {
+          // No anonymization in the demo — the recovery view is always empty.
+          rows = rows.filter((b) => b.anonymized_at === null && b.pending_anonymization_until !== null)
+        }
+        rows.sort((a, b) => a.name.localeCompare(b.name))
+        const page = params.page ?? 1
+        const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE
+        const start = (page - 1) * pageSize
+        return {
+          total: rows.length,
+          page,
+          page_size: pageSize,
+          items: rows.slice(start, start + pageSize),
+        }
+      },
+
+      getBorrowerDetail: (id) => {
+        const borrower = get().borrowers.find((b) => b.id === id)
+        if (!borrower) return null
+        // The demo has no user accounts, so every audit FK is null — which is
+        // exactly the "legacy row" shape the detail page hides the footer for.
+        return {
+          ...borrower,
+          created_by_email: null,
+          anonymized_by_email: null,
+          merged_into_by_email: null,
+        }
+      },
+
+      borrowerLoans: (id) => {
+        const { books, loans } = get()
+        const titleOf = new Map(books.map((b) => [b.id, b]))
+        return loans
+          .filter((l) => l.borrower_id === id)
+          .sort((a, b) => (a.lent_date < b.lent_date ? 1 : -1))
+          .map((l) => {
+            const book = titleOf.get(l.book_id)
+            return {
+              id: l.id,
+              book_id: l.book_id,
+              book_title: book?.title ?? l.book_id,
+              book_author: book?.author ?? null,
+              lent_date: l.lent_date,
+              due_date: l.due_date,
+              returned_date: l.returned_date,
+              return_condition: l.return_condition,
+              notes: l.notes,
+            }
+          })
+      },
+
+      loansForBook: (bookId) =>
+        get()
+          .loans.filter((l) => l.book_id === bookId)
+          .sort((a, b) => (a.lent_date < b.lent_date ? 1 : -1)),
 
       addBook: (payload) => {
         const now = new Date().toISOString()
@@ -315,13 +435,140 @@ export const useDemoStore = create<DemoState>()(
         return { created_count: newBooks.length, book_ids: newBooks.map((b) => b.id) }
       },
 
-      reset: () => set({ books: createDemoBooks(), locations: createDemoLocations() }),
+      updateBorrower: (id, payload) => {
+        const now = new Date().toISOString()
+        let updated: Borrower | null = null
+        set((s) => {
+          const borrowers = s.borrowers.map((b) => {
+            if (b.id !== id) return b
+            updated = {
+              ...b,
+              name: payload.name !== undefined ? payload.name : b.name,
+              contact: payload.contact !== undefined ? payload.contact : b.contact,
+              notes: payload.notes !== undefined ? payload.notes : b.notes,
+              updated_at: now,
+            }
+            return updated
+          })
+          if (!updated) return {}
+          const fresh = updated
+          // ADR 008: edits do NOT rewrite the denormalized snapshot columns on
+          // historical loan rows — but the nested `borrower` object is resolved
+          // live, so refresh it everywhere it's referenced (loan rows + the
+          // active loan carried on the book).
+          const loans = s.loans.map((l) =>
+            l.borrower_id === id ? { ...l, borrower: fresh } : l,
+          )
+          const books = s.books.map((b) =>
+            b.active_loan && b.active_loan.borrower_id === id
+              ? { ...b, active_loan: { ...b.active_loan, borrower: fresh } }
+              : b,
+          )
+          return { borrowers, loans, books }
+        })
+        return updated
+      },
+
+      createLoan: (bookId, payload) => {
+        const now = new Date().toISOString()
+        const lentDate = payload.lent_date
+        let borrower: Borrower | null = null
+        const newBorrowers: Borrower[] = []
+
+        if (payload.borrower_id) {
+          borrower = get().borrowers.find((b) => b.id === payload.borrower_id) ?? null
+        }
+        if (!borrower) {
+          // Typed-name flow: mint a fresh borrower record (mirrors the backend
+          // creating a Borrower when a loan is made against a new name).
+          borrower = {
+            id: prefixedId('demo-borrower'),
+            name: payload.borrower_name?.trim() || 'Neznámý',
+            contact: payload.borrower_contact?.trim() || null,
+            notes: null,
+            anonymized_at: null,
+            pending_anonymization_until: null,
+            created_by_user_id: null,
+            anonymized_by_user_id: null,
+            merged_into_by_user_id: null,
+            created_at: now,
+            updated_at: now,
+          }
+          newBorrowers.push(borrower)
+        }
+
+        const loan: Loan = {
+          id: prefixedId('demo-loan'),
+          book_id: bookId,
+          borrower_id: borrower.id,
+          borrower_name: borrower.name,
+          borrower_contact: borrower.contact,
+          borrower,
+          lent_date: lentDate,
+          due_date: payload.due_date ?? null,
+          returned_date: null,
+          return_condition: null,
+          notes: payload.notes ?? null,
+          created_at: now,
+          is_active: true,
+        }
+
+        set((s) => ({
+          borrowers: newBorrowers.length ? [...s.borrowers, ...newBorrowers] : s.borrowers,
+          loans: [...s.loans, loan],
+          books: s.books.map((b) =>
+            b.id === bookId
+              ? { ...b, is_currently_lent: true, active_loan: loan, updated_at: now }
+              : b,
+          ),
+        }))
+        return loan
+      },
+
+      returnLoan: (bookId, loanId, payload) => {
+        const now = new Date().toISOString()
+        let updated: Loan | null = null
+        set((s) => {
+          const loans = s.loans.map((l) => {
+            if (l.id !== loanId) return l
+            updated = {
+              ...l,
+              returned_date: payload.returned_date,
+              return_condition: payload.return_condition,
+              notes: payload.notes ?? l.notes,
+              is_active: false,
+            }
+            return updated
+          })
+          if (!updated) return {}
+          const books = s.books.map((b) =>
+            b.id === bookId
+              ? { ...b, is_currently_lent: false, active_loan: null, updated_at: now }
+              : b,
+          )
+          return { loans, books }
+        })
+        return updated
+      },
+
+      reset: () =>
+        set({
+          books: createDemoBooks(),
+          locations: createDemoLocations(),
+          borrowers: createDemoBorrowers(),
+          loans: createDemoLoans(),
+        }),
     }),
     {
       name: DEMO_STORAGE_KEY,
       storage: createJSONStorage(() => sessionStorage),
       // Persist data only — never the action closures.
-      partialize: (state) => ({ books: state.books, locations: state.locations }),
+      partialize: (state) => ({
+        books: state.books,
+        locations: state.locations,
+        borrowers: state.borrowers,
+        loans: state.loans,
+      }),
     },
   ),
 )


### PR DESCRIPTION
## Summary
- Borrowers ("půjčující") were invisible in the `/demo/*` sandbox. This wires a fully **client-side** borrowers + lend/return lifecycle so logged-out visitors can browse and edit borrowers and see books as actually lent — with **zero backend/AI/network load**.
- Seed 4 borrowers + 7 loans (3 active, 4 returned); books reflect `is_currently_lent` / `active_loan`. `useBorrowers`/`useLoans` become demo-aware via the shared `['demo']` cache prefix (one invalidation refreshes list/detail/loans/books).
- Register `/demo/borrowers` + `/demo/borrowers/:id`, show the borrowers nav entry in demo, render the loan-history accordion on demo book detail. GDPR-only controls (merge, anonymize, bulk-anonymize) stay hidden in the demo.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npx vitest run` — 259 passing (incl. new `BorrowersPage.demo.test`, extended `useDemoStore.test`, updated `Navigation.demo` + `BookDetailPage.demo`)
- [x] `npm run build` — succeeds
- [ ] Manual: open `/demo`, navigate to Borrowers, browse seeded list, open a borrower, edit name, lend/return a book, confirm no network calls in devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added demo routes for browsing borrowers and accessing borrower details
  * Enabled loan creation and return functionality within demo mode
  * Loan history now displays in book details during demo mode

* **Changes**
  * Bulk anonymization controls hidden in demo mode
  * Demo navigation properly routes borrower items within `/demo` subtree

<!-- end of auto-generated comment: release notes by coderabbit.ai -->