### PR TITLE
fix(frontend): burn ESLint warnings down to zero

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -351,6 +351,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
 
+// The hook is deliberately co-located with its provider; a Fast Refresh
+// full-reload on edits to this file is acceptable (auth re-bootstraps anyway).
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth(): AuthContextValue {
   const context = useContext(AuthContext)
   if (!context) {

--- a/frontend/src/features/demo/DemoContext.tsx
+++ b/frontend/src/features/demo/DemoContext.tsx
@@ -16,6 +16,9 @@ export function DemoModeProvider({ children }: { children: ReactNode }) {
 }
 
 /** True only inside the demo subtree. */
+// One-bit flag hook co-located with its provider on purpose; splitting the
+// 20-line module in two for Fast Refresh would hurt readability more than it helps.
+// eslint-disable-next-line react-refresh/only-export-components
 export function useIsDemoMode(): boolean {
   return useContext(DemoModeContext)
 }

--- a/frontend/src/pages/AddBookPage.tsx
+++ b/frontend/src/pages/AddBookPage.tsx
@@ -49,7 +49,7 @@ export function AddBookPage() {
       }
       setUploadJobId(null)
     }
-  }, [uploadJobStatusQuery.data?.status, uploadJobStatusQuery.data?.error_message, showError])
+  }, [uploadJobStatusQuery.data?.status, uploadJobStatusQuery.data?.error_message, showError, t])
 
   function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]

--- a/frontend/src/pages/BooksPage.tsx
+++ b/frontend/src/pages/BooksPage.tsx
@@ -181,7 +181,6 @@ export function BooksPage() {
   // Clear selection when navigating pages — selected IDs from another page are invisible
   useEffect(() => {
     clearSelection()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page])
 
   // Sort the current page (≤20 items) by location + shelf_position for grouped display

--- a/frontend/src/pages/BookshelfViewPage.tsx
+++ b/frontend/src/pages/BookshelfViewPage.tsx
@@ -142,7 +142,13 @@ export function BookshelfViewPage() {
   }, [allBooks])
 
   const roomNames = Object.keys(locationTree)
-  const filteredTree = selectedRoom ? { [selectedRoom]: locationTree[selectedRoom] } : locationTree
+  // Memoized so the `visibleBooks` memo below only recomputes when the room
+  // filter or the tree itself changes — the inline conditional re-created the
+  // object every render and made that memo recompute unconditionally.
+  const filteredTree = useMemo(
+    () => (selectedRoom ? { [selectedRoom]: locationTree[selectedRoom] } : locationTree),
+    [selectedRoom, locationTree],
+  )
 
   const visibleBooks = useMemo(() => {
     const out: Book[] = []

--- a/frontend/src/pages/ScanShelfPage.tsx
+++ b/frontend/src/pages/ScanShelfPage.tsx
@@ -124,7 +124,11 @@ export function ScanShelfPage() {
       ))
       setActiveJobId(null)
     }
-  }, [activeResult.data?.status])
+    // Full dependency list is safe here: the polling query refreshes
+    // `activeResult.data` every ~2s, but the guard above makes non-terminal
+    // re-runs a no-op, and `setActiveJobId(null)` after a terminal status
+    // short-circuits the follow-up run.
+  }, [activeResult.data, activeJobId, showError, t])
 
 
   useEffect(() => {


### PR DESCRIPTION
Closes #300.

Lint now reports **0 errors, 0 warnings** (was 0/6), so any future warning is an obvious regression in review.

- **ScanShelfPage** (the stale-closure risk): the scan-completion effect now declares its full dependency list. Safe by construction — the `!data || !activeJobId` guard makes non-terminal re-runs a no-op, and clearing `activeJobId` after a terminal status short-circuits the follow-up run. Covered by the existing scripted-scan demo test.
- **BookshelfViewPage**: `filteredTree` wrapped in `useMemo` so the `visibleBooks` memo stops recomputing on every render.
- **AddBookPage**: missing `t` dep added (i18next `t` is referentially stable).
- **BooksPage**: unused `eslint-disable` directive removed.
- **AuthContext / DemoContext** (`react-refresh/only-export-components`): scoped disables with rationale — the hooks are co-located with their providers by design; splitting the files would hurt readability more than Fast Refresh DX gains.

Verification: lint 0/0, 259/259 vitest, build + bundle budget pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)