### PR TITLE
fix(frontend): stack borrower row vertically on mobile (#307)

### DIFF
--- a/frontend/src/pages/BorrowersPage.css
+++ b/frontend/src/pages/BorrowersPage.css
@@ -1,0 +1,55 @@
+/* Borrower list row (#307). Mobile-first: identity (name + contact) and
+   the stats block stack vertically and the stats wrap onto multiple
+   lines. From 768px — the same breakpoint the md-* utilities in
+   styles/shelfy.css use — the row returns to the original two-column
+   desktop layout with the stats pinned right on a single line. */
+.borrowers-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+  padding: 16px;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid var(--sh-border);
+  border-radius: var(--sh-radius-md);
+  background: var(--sh-surface);
+}
+
+.borrowers-row-identity {
+  min-width: 0;
+}
+
+.borrowers-row-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.borrowers-row-contact {
+  font-size: 13px;
+  color: var(--sh-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.borrowers-row-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--sh-text-muted);
+}
+
+@media (min-width: 768px) {
+  .borrowers-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .borrowers-row-stats {
+    flex-wrap: nowrap;
+    white-space: nowrap;
+  }
+}

--- a/frontend/src/pages/BorrowersPage.test.tsx
+++ b/frontend/src/pages/BorrowersPage.test.tsx
@@ -110,6 +110,35 @@ describe('BorrowersPage', () => {
     expect(screen.getByTestId('borrower-last-b-bob')).toHaveTextContent('borrowers.no_activity')
   })
 
+  // Layout itself can't be asserted in jsdom; #307 moved the row layout
+  // from inline styles into BorrowersPage.css classes, so pin the class
+  // hooks the responsive stylesheet relies on.
+  it('uses the responsive CSS classes for the row, identity and stats blocks (#307)', async () => {
+    vi.mocked(listBorrowers).mockResolvedValue(
+      makePage([
+        makeBorrower({
+          id: 'b-alice',
+          name: 'Alice',
+          active_loans: 2,
+          total_loans: 5,
+          last_activity_at: '2026-05-01',
+        }),
+      ]),
+    )
+    renderPage()
+
+    const row = await screen.findByTestId('borrower-row-b-alice')
+    expect(row).toHaveClass('sh-card', 'borrowers-row')
+    expect(row.querySelector('.borrowers-row-identity')).not.toBeNull()
+    expect(row.querySelector('.borrowers-row-name')).toHaveTextContent('Alice')
+    expect(row.querySelector('.borrowers-row-contact')).toHaveTextContent('alice@x.com')
+    const stats = row.querySelector('.borrowers-row-stats')
+    expect(stats).not.toBeNull()
+    expect(stats).toContainElement(screen.getByTestId('borrower-active-b-alice'))
+    expect(stats).toContainElement(screen.getByTestId('borrower-total-b-alice'))
+    expect(stats).toContainElement(screen.getByTestId('borrower-last-b-alice'))
+  })
+
   it('passes the typed (debounced) search string through to listBorrowers', async () => {
     vi.mocked(listBorrowers).mockResolvedValue(makePage([]))
     renderPage()

--- a/frontend/src/pages/BorrowersPage.tsx
+++ b/frontend/src/pages/BorrowersPage.tsx
@@ -12,6 +12,8 @@ import { displayBorrowerName } from '../lib/borrowerDisplay'
 import { getBorrowerDetailRoute } from '../lib/routes'
 import type { BorrowerListItem, BorrowerStatusFilter } from '../lib/types'
 
+import './BorrowersPage.css'
+
 const PAGE_SIZE = 20
 
 function formatDate(value: string | null, locale: string): string {
@@ -203,20 +205,9 @@ export function BorrowersPage() {
               <Link
                 to={demoPath(getBorrowerDetailRoute(borrower.id))}
                 data-testid={`borrower-row-${borrower.id}`}
-                className="sh-card"
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'minmax(0, 1fr) auto',
-                  gap: 12,
-                  padding: 16,
-                  textDecoration: 'none',
-                  color: 'inherit',
-                  border: '1px solid var(--sh-border)',
-                  borderRadius: 'var(--sh-radius-md)',
-                  background: 'var(--sh-surface)',
-                }}
+                className="sh-card borrowers-row"
               >
-                <div style={{ minWidth: 0 }}>
+                <div className="borrowers-row-identity">
                   <div
                     style={{
                       display: 'flex',
@@ -229,7 +220,7 @@ export function BorrowersPage() {
                       color: borrower.anonymized_at ? 'var(--sh-text-muted)' : undefined,
                     }}
                   >
-                    <span>{displayBorrowerName(borrower, t)}</span>
+                    <span className="borrowers-row-name">{displayBorrowerName(borrower, t)}</span>
                     {/* Inline pending badge (#244 PR #2). Surfaced in the
                         default ``all`` view too so the librarian spots
                         scheduled rows just by scrolling. */}
@@ -252,30 +243,10 @@ export function BorrowersPage() {
                     )}
                   </div>
                   {borrower.contact && (
-                    <div
-                      style={{
-                        fontSize: 13,
-                        color: 'var(--sh-text-muted)',
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                      }}
-                    >
-                      {borrower.contact}
-                    </div>
+                    <div className="borrowers-row-contact">{borrower.contact}</div>
                   )}
                 </div>
-                <div
-                  style={{
-                    display: 'grid',
-                    gridAutoFlow: 'column',
-                    gap: 12,
-                    alignItems: 'center',
-                    fontSize: 12,
-                    color: 'var(--sh-text-muted)',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
+                <div className="borrowers-row-stats">
                   <span data-testid={`borrower-active-${borrower.id}`}>
                     {t('borrowers.active_count', { count: borrower.active_loans })}
                   </span>


### PR DESCRIPTION
## Souhrn
- Řádek dlužníka na `/borrowers` se na mobilních šířkách (~360–390 px) překrýval: tvrdý inline grid `minmax(0,1fr) auto` + `nowrap` statistiky přetékaly přes jméno a kontakt.
- Layout řádku přesunut z inline stylů do [BorrowersPage.css](frontend/src/pages/BorrowersPage.css): mobile-first jeden sloupec, statistiky se zalamují (`flex-wrap`); od **768 px** (stejný breakpoint jako `md-*` utility v `styles/shelfy.css`) se vrací původní dvousloupcový desktop layout — desktop je vizuálně beze změny.
- Dlouhé jméno i kontakt drží `min-width: 0` + ellipsis, takže neroztáhnou layout mimo viewport.
- Celý řádek zůstává klikací `<Link>`, pending badge beze změny.

## Testy
- Nový strukturální test v `BorrowersPage.test.tsx` pinuje CSS class hooky (row/identity/name/contact/stats) — layout samotný jsdom neověří, responzivita ověřena dle konvence breakpointu.
- `npm run lint` ✅, `npm test -- --run` ✅ (260 testů).

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved borrower list row layout and visual styling.
  * Added responsive behavior for mobile and desktop screens.
  * Long borrower names and contact details now truncate cleanly.
  * Borrower statistics remain organized and readable across screen sizes.

* **Tests**
  * Added coverage verifying borrower row structure and responsive styling hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->