### PR TITLE
feat(metadata): Open Library primary, Google Books za opt-in flagem (#310)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,7 +30,17 @@ class Settings(BaseSettings):
     admin_password: str | None = None
     seed_admin_on_startup: bool = False
 
+    # Book metadata providers.
+    # Open Library is the primary (and by default the only) source: the
+    # Google Books API ToS forbids charging users for an application that
+    # uses it without a separate agreement with Google, and Shelfy is a
+    # paid product. Only flip ``enable_google_books`` on if such an
+    # agreement exists; ``google_books_api_key`` stays unused until then.
+    enable_google_books: bool = False
     google_books_api_key: str | None = None
+    # Identifying User-Agent sent with Open Library requests — required
+    # etiquette and lifts the anonymous 1 req/s rate limit to 3 req/s.
+    open_library_user_agent: str = "Shelfy (https://shelfy.cz; support@shelfy.cz)"
 
     # Observability / error tracking
     # Set SENTRY_DSN in .env to enable Sentry error reporting.

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -147,7 +147,7 @@ async def send_welcome(to: str, name: str, *, locale: str | None = None) -> None
 <p>Hned můžeš:</p>
 <ul>
   <li>📷 naskenovat knihovnu pomocí AI skenu police,</li>
-  <li>🔍 doplnit obálky a metadata z Google Books,</li>
+  <li>🔍 doplnit obálky a metadata z veřejných knižních katalogů,</li>
   <li>📍 organizovat knihy podle umístění a stavu čtení.</li>
 </ul>
 <p>{_cta(f"{settings.app_url}/books", "Otevřít Shelfy →")}</p>
@@ -161,7 +161,7 @@ async def send_welcome(to: str, name: str, *, locale: str | None = None) -> None
 <p>Here's what you can do right away:</p>
 <ul>
   <li>📷 Scan your bookshelf with the AI shelf-scanning feature</li>
-  <li>🔍 Auto-enrich books with cover images &amp; metadata from Google Books</li>
+  <li>🔍 Auto-enrich books with cover images &amp; metadata from public book catalogues</li>
   <li>📍 Organise books by location and reading status</li>
 </ul>
 <p>{_cta(f"{settings.app_url}/books", "Open Shelfy →")}</p>

--- a/backend/app/services/metadata/open_library.py
+++ b/backend/app/services/metadata/open_library.py
@@ -4,6 +4,12 @@ from typing import Any
 
 import httpx
 
+from app.core.config import get_settings
+
+
+def _headers() -> dict[str, str]:
+    return {"User-Agent": get_settings().open_library_user_agent}
+
 
 async def fetch_open_library_metadata(
     client: httpx.AsyncClient,
@@ -16,6 +22,7 @@ async def fetch_open_library_metadata(
         response = await client.get(
             "https://openlibrary.org/api/books",
             params={"bibkeys": bib_key, "format": "json", "jscmd": "data"},
+            headers=_headers(),
             timeout=10.0,
         )
         response.raise_for_status()
@@ -27,6 +34,7 @@ async def fetch_open_library_metadata(
         response = await client.get(
             "https://openlibrary.org/search.json",
             params={"title": title, "author": author or "", "limit": 1},
+            headers=_headers(),
             timeout=10.0,
         )
         response.raise_for_status()
@@ -60,6 +68,8 @@ async def fetch_open_library_metadata(
 
     cover = entry.get("cover") or {}
 
+    # ``cover_image_url`` deliberately points at covers.openlibrary.org —
+    # covers are hotlinked at display time, never copied into our storage.
     return {
         "title": entry.get("title"),
         "author": (entry.get("authors") or [{}])[0].get("name"),

--- a/backend/app/services/metadata/service.py
+++ b/backend/app/services/metadata/service.py
@@ -12,7 +12,13 @@ from app.core.metrics import EXTERNAL_API_CALLS_TOTAL, observe_external_api_late
 from app.services.metadata.google_books import fetch_google_books_metadata
 from app.services.metadata.open_library import fetch_open_library_metadata
 
-CACHE_TTL_SECONDS = 24 * 60 * 60
+# Open Library allows commercial reuse of its data, so hits can be cached
+# aggressively; the long TTL also keeps us well inside its rate limits.
+CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
+# Definitive misses (the catalogue answered but has no record) are cached
+# as JSON ``null`` so unknown ISBNs don't hammer Open Library on every
+# retry. Kept shorter than hits — the catalogue grows.
+NEGATIVE_CACHE_TTL_SECONDS = 24 * 60 * 60
 logger = structlog.get_logger()
 
 
@@ -22,6 +28,48 @@ def _cache_key(isbn: str | None, title: str | None) -> str | None:
     if title and title.strip():
         return f"book-metadata:title:{title.lower().strip()}"
     return None
+
+
+async def _google_books_lookup(
+    client: httpx.AsyncClient,
+    isbn: str | None,
+    title: str | None,
+    author: str | None,
+) -> tuple[dict[str, object] | None, bool]:
+    """Returns ``(metadata, errored)``."""
+    settings = get_settings()
+    start = perf_counter()
+    try:
+        EXTERNAL_API_CALLS_TOTAL.labels(provider="google_books").inc()
+        return (
+            await fetch_google_books_metadata(
+                client, isbn, title=title, author=author, api_key=settings.google_books_api_key
+            ),
+            False,
+        )
+    except Exception as exc:
+        logger.warning("google_books_lookup_failed", isbn=isbn, title=title, author=author, error=str(exc))
+        return None, True
+    finally:
+        observe_external_api_latency("google_books", start)
+
+
+async def _open_library_lookup(
+    client: httpx.AsyncClient,
+    isbn: str | None,
+    title: str | None,
+    author: str | None,
+) -> tuple[dict[str, object] | None, bool]:
+    """Returns ``(metadata, errored)``."""
+    start = perf_counter()
+    try:
+        EXTERNAL_API_CALLS_TOTAL.labels(provider="open_library").inc()
+        return await fetch_open_library_metadata(client, isbn, title=title, author=author), False
+    except Exception as exc:
+        logger.warning("open_library_lookup_failed", isbn=isbn, title=title, author=author, error=str(exc))
+        return None, True
+    finally:
+        observe_external_api_latency("open_library", start)
 
 
 async def enrich_metadata_with_fallback(
@@ -38,35 +86,28 @@ async def enrich_metadata_with_fallback(
     try:
         cached = await redis_client.get(cache_key)
         if cached:
-            result: dict[str, object] = json.loads(cached)
+            # ``"null"`` is a cached negative result and decodes to ``None``.
+            result: dict[str, object] | None = json.loads(cached)
             return result
 
+        # Open Library is the sole default provider — Google Books ToS
+        # forbids paid applications, so it only runs behind the explicit
+        # ``enable_google_books`` opt-in (see app/core/config.py), where it
+        # keeps its legacy primary-with-fallback position.
         metadata: dict[str, object] | None = None
+        errored = False
         async with httpx.AsyncClient() as client:
-            google_start = perf_counter()
-            try:
-                EXTERNAL_API_CALLS_TOTAL.labels(provider="google_books").inc()
-                metadata = await fetch_google_books_metadata(
-                    client, isbn, title=title, author=author, api_key=settings.google_books_api_key
-                )
-            except Exception as exc:
-                logger.warning("google_books_lookup_failed", isbn=isbn, title=title, author=author, error=str(exc))
-                metadata = None
-            finally:
-                observe_external_api_latency("google_books", google_start)
-
+            if settings.enable_google_books:
+                metadata, errored = await _google_books_lookup(client, isbn, title, author)
             if metadata is None:
-                open_library_start = perf_counter()
-                try:
-                    EXTERNAL_API_CALLS_TOTAL.labels(provider="open_library").inc()
-                    metadata = await fetch_open_library_metadata(client, isbn, title=title, author=author)
-                except Exception as exc:
-                    logger.warning("open_library_lookup_failed", isbn=isbn, title=title, author=author, error=str(exc))
-                    metadata = None
-                finally:
-                    observe_external_api_latency("open_library", open_library_start)
+                metadata, open_library_errored = await _open_library_lookup(client, isbn, title, author)
+                errored = errored or open_library_errored
 
         if metadata is None:
+            # Only cache a miss when the provider actually answered —
+            # transient failures must stay retryable.
+            if not errored:
+                await redis_client.set(cache_key, json.dumps(None), ex=NEGATIVE_CACHE_TTL_SECONDS)
             return None
 
         await redis_client.set(cache_key, json.dumps(metadata), ex=CACHE_TTL_SECONDS)

--- a/backend/tests/test_metadata_services.py
+++ b/backend/tests/test_metadata_services.py
@@ -6,9 +6,56 @@ import json
 import httpx
 import pytest
 
+from app.core.config import get_settings
 from app.services.metadata.google_books import fetch_google_books_metadata
 from app.services.metadata.open_library import fetch_open_library_metadata
-from app.services.metadata.service import enrich_metadata_with_fallback
+from app.services.metadata.service import (
+    CACHE_TTL_SECONDS,
+    NEGATIVE_CACHE_TTL_SECONDS,
+    enrich_metadata_with_fallback,
+)
+
+
+class FakeRedis:
+    def __init__(self, preloaded: dict[str, str] | None = None) -> None:
+        self.storage: dict[str, str] = dict(preloaded or {})
+        self.ttls: dict[str, int] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.storage.get(key)
+
+    async def set(self, key: str, value: str, ex: int) -> None:
+        self.storage[key] = value
+        self.ttls[key] = ex
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _use_settings(monkeypatch: pytest.MonkeyPatch, **overrides: object) -> None:
+    settings = get_settings().model_copy(update=overrides)
+    monkeypatch.setattr("app.services.metadata.service.get_settings", lambda: settings)
+
+
+def _use_redis(monkeypatch: pytest.MonkeyPatch, fake: FakeRedis) -> None:
+    monkeypatch.setattr("app.services.metadata.service.redis_async.from_url", lambda *_a, **_k: fake)
+
+
+async def _fail_if_called(*_args: object, **_kwargs: object) -> None:
+    raise AssertionError("this provider must not be called")
+
+
+OPEN_LIBRARY_METADATA: dict[str, object] = {
+    "title": "Refactoring",
+    "author": "Martin Fowler",
+    "isbn": "9780201485677",
+    "publisher": "Addison-Wesley",
+    "language": "eng",
+    "description": "Improving existing code.",
+    "publication_year": 1999,
+    "cover_image_url": "https://covers.openlibrary.org/b/id/12345-L.jpg",
+    "provider": "open_library",
+}
 
 
 def test_google_books_client_returns_normalized_metadata() -> None:
@@ -46,79 +93,123 @@ def test_google_books_client_returns_normalized_metadata() -> None:
     assert metadata["provider"] == "google_books"
 
 
-def test_open_library_fallback_called_when_google_books_fails(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _google(_client: httpx.AsyncClient, _isbn: str | None, title: str | None = None, author: str | None = None, api_key: str | None = None) -> None:
-        return None
-
+def test_default_path_uses_open_library_and_never_calls_google(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _open_library(_client: httpx.AsyncClient, isbn: str | None, title: str | None = None, author: str | None = None) -> dict[str, object]:
-        return {
-            "title": "Refactoring",
-            "author": "Martin Fowler",
-            "isbn": isbn or "9780201485677",
-            "publisher": "Addison-Wesley",
-            "language": "eng",
-            "description": "Improving existing code.",
-            "publication_year": 1999,
-            "cover_image_url": "https://example.com/refactoring.jpg",
-            "provider": "open_library",
-        }
-
-    class FakeRedis:
-        def __init__(self) -> None:
-            self.storage: dict[str, str] = {}
-
-        async def get(self, key: str) -> str | None:
-            return self.storage.get(key)
-
-        async def set(self, key: str, value: str, ex: int) -> None:
-            assert ex == 24 * 60 * 60
-            self.storage[key] = value
-
-        async def aclose(self) -> None:
-            return None
+        return dict(OPEN_LIBRARY_METADATA, isbn=isbn)
 
     fake_redis = FakeRedis()
-
-    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _google)
+    _use_settings(monkeypatch, enable_google_books=False)
+    _use_redis(monkeypatch, fake_redis)
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
     monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library)
-    monkeypatch.setattr("app.services.metadata.service.redis_async.from_url", lambda *_args, **_kwargs: fake_redis)
 
     metadata = asyncio.run(enrich_metadata_with_fallback("9780201485677", title=None, author=None))
 
     assert metadata is not None
     assert metadata["provider"] == "open_library"
     assert json.loads(fake_redis.storage["book-metadata:9780201485677"])["title"] == "Refactoring"
+    assert fake_redis.ttls["book-metadata:9780201485677"] == CACHE_TTL_SECONDS
+
+
+def test_flag_enabled_restores_google_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _google(_client: httpx.AsyncClient, isbn: str | None, title: str | None = None, author: str | None = None, api_key: str | None = None) -> dict[str, object]:
+        return {"title": "Clean Code", "isbn": isbn, "provider": "google_books"}
+
+    _use_settings(monkeypatch, enable_google_books=True)
+    _use_redis(monkeypatch, FakeRedis())
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _google)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _fail_if_called)
+
+    metadata = asyncio.run(enrich_metadata_with_fallback("9780132350884", title=None, author=None))
+
+    assert metadata is not None
+    assert metadata["provider"] == "google_books"
+
+
+def test_flag_enabled_falls_back_to_open_library_when_google_misses(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def _google(_client: httpx.AsyncClient, _isbn: str | None, title: str | None = None, author: str | None = None, api_key: str | None = None) -> None:
+        calls.append("google")
+        return None
+
+    async def _open_library(_client: httpx.AsyncClient, isbn: str | None, title: str | None = None, author: str | None = None) -> dict[str, object]:
+        calls.append("open_library")
+        return dict(OPEN_LIBRARY_METADATA, isbn=isbn)
+
+    _use_settings(monkeypatch, enable_google_books=True)
+    _use_redis(monkeypatch, FakeRedis())
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _google)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library)
+
+    metadata = asyncio.run(enrich_metadata_with_fallback("9780201485677", title=None, author=None))
+
+    assert metadata is not None
+    assert metadata["provider"] == "open_library"
+    assert calls == ["google", "open_library"]
 
 
 def test_cache_hit_skips_external_calls(monkeypatch: pytest.MonkeyPatch) -> None:
-    cached_payload = {"title": "Cached Book", "provider": "google_books", "isbn": "9780134494166"}
+    cached_payload = {"title": "Cached Book", "provider": "open_library", "isbn": "9780134494166"}
+    fake_redis = FakeRedis({"book-metadata:9780134494166": json.dumps(cached_payload)})
 
-    class FakeRedis:
-        async def get(self, key: str) -> str | None:
-            if key == "book-metadata:9780134494166":
-                return json.dumps(cached_payload)
-            return None
-
-        async def set(self, _key: str, _value: str, ex: int) -> None:
-            raise AssertionError(f"cache set should not be called, got TTL {ex}")
-
-        async def aclose(self) -> None:
-            return None
-
-    async def _raise_if_called(*_args: object, **_kwargs: object) -> None:
-        raise AssertionError("external client should not be called on cache hit")
-
-    monkeypatch.setattr("app.services.metadata.service.redis_async.from_url", lambda *_args, **_kwargs: FakeRedis())
-    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _raise_if_called)
-    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _raise_if_called)
+    _use_settings(monkeypatch)
+    _use_redis(monkeypatch, fake_redis)
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _fail_if_called)
 
     metadata = asyncio.run(enrich_metadata_with_fallback("9780134494166", title=None, author=None))
 
     assert metadata == cached_payload
+    assert fake_redis.ttls == {}
 
 
-def test_open_library_client_normalizes_response() -> None:
-    def handler(_request: httpx.Request) -> httpx.Response:
+def test_definitive_miss_is_negatively_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def _open_library_miss(_client: httpx.AsyncClient, _isbn: str | None, title: str | None = None, author: str | None = None) -> None:
+        calls.append("open_library")
+        return None
+
+    fake_redis = FakeRedis()
+    _use_settings(monkeypatch)
+    _use_redis(monkeypatch, fake_redis)
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library_miss)
+
+    first = asyncio.run(enrich_metadata_with_fallback("9799999999999", title=None, author=None))
+    second = asyncio.run(enrich_metadata_with_fallback("9799999999999", title=None, author=None))
+
+    assert first is None
+    assert second is None
+    # The second lookup is served from the negative cache entry.
+    assert calls == ["open_library"]
+    assert fake_redis.storage["book-metadata:9799999999999"] == "null"
+    assert fake_redis.ttls["book-metadata:9799999999999"] == NEGATIVE_CACHE_TTL_SECONDS
+
+
+def test_provider_error_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _open_library_down(*_args: object, **_kwargs: object) -> None:
+        raise httpx.ConnectError("boom")
+
+    fake_redis = FakeRedis()
+    _use_settings(monkeypatch)
+    _use_redis(monkeypatch, fake_redis)
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library_down)
+
+    metadata = asyncio.run(enrich_metadata_with_fallback("9780201485677", title=None, author=None))
+
+    assert metadata is None
+    # Transient failures stay retryable — nothing may be written to the cache.
+    assert fake_redis.storage == {}
+
+
+def test_open_library_client_normalizes_response_and_sends_user_agent() -> None:
+    seen_user_agents: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_user_agents.append(request.headers["User-Agent"])
         return httpx.Response(
             200,
             json={
@@ -129,7 +220,7 @@ def test_open_library_client_normalizes_response() -> None:
                     "publish_date": "2017",
                     "languages": [{"key": "/languages/eng"}],
                     "description": {"value": "Software architecture patterns."},
-                    "cover": {"large": "https://example.com/clean-architecture.jpg"},
+                    "cover": {"large": "https://covers.openlibrary.org/b/id/8221256-L.jpg"},
                 }
             },
         )
@@ -143,39 +234,60 @@ def test_open_library_client_normalizes_response() -> None:
     assert metadata is not None
     assert metadata["provider"] == "open_library"
     assert metadata["publication_year"] == 2017
+    # Covers are hotlinked straight from Open Library, never rehosted.
+    assert str(metadata["cover_image_url"]).startswith("https://covers.openlibrary.org/")
+    assert seen_user_agents == [get_settings().open_library_user_agent]
 
 
-def test_title_author_fallback_without_isbn_calls_google_then_openlibrary(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_open_library_title_search_sends_user_agent() -> None:
+    seen_user_agents: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/search.json"
+        seen_user_agents.append(request.headers["User-Agent"])
+        return httpx.Response(
+            200,
+            json={
+                "docs": [
+                    {
+                        "title": "Clean Code",
+                        "author_name": ["Robert C. Martin"],
+                        "publisher": ["Prentice Hall"],
+                        "first_publish_year": 2008,
+                        "language": ["eng"],
+                        "cover_i": 12345,
+                    }
+                ]
+            },
+        )
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await fetch_open_library_metadata(client, None, title="Clean Code", author="Martin")
+
+    metadata = asyncio.run(_run())
+
+    assert metadata is not None
+    assert metadata["title"] == "Clean Code"
+    assert metadata["cover_image_url"] == "https://covers.openlibrary.org/b/id/12345-L.jpg"
+    assert seen_user_agents == [get_settings().open_library_user_agent]
+
+
+def test_title_author_lookup_without_isbn_uses_open_library_only(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[str, object, object]] = []
-
-    async def _google(_client: httpx.AsyncClient, isbn: str | None, title: str | None = None, author: str | None = None, api_key: str | None = None) -> None:
-        calls.append(("google", title, author))
-        return None
 
     async def _open_library(_client: httpx.AsyncClient, isbn: str | None, title: str | None = None, author: str | None = None) -> dict[str, object]:
         calls.append(("open_library", title, author))
         return {"title": "Clean Code", "author": "Martin", "provider": "open_library"}
 
-    class FakeRedis:
-        storage: dict[str, str] = {}
-
-        async def get(self, key: str) -> str | None:
-            return self.storage.get(key)
-
-        async def set(self, key: str, value: str, ex: int) -> None:
-            assert key == "book-metadata:title:clean code"
-            assert ex == 24 * 60 * 60
-            self.storage[key] = value
-
-        async def aclose(self) -> None:
-            return None
-
-    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _google)
+    fake_redis = FakeRedis()
+    _use_settings(monkeypatch, enable_google_books=False)
+    _use_redis(monkeypatch, fake_redis)
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
     monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library)
-    monkeypatch.setattr("app.services.metadata.service.redis_async.from_url", lambda *_args, **_kwargs: FakeRedis())
 
     metadata = asyncio.run(enrich_metadata_with_fallback(None, title="Clean Code", author="Martin"))
 
     assert metadata is not None
-    assert calls[0] == ("google", "Clean Code", "Martin")
-    assert calls[1] == ("open_library", "Clean Code", "Martin")
+    assert calls == [("open_library", "Clean Code", "Martin")]
+    assert "book-metadata:title:clean code" in fake_redis.storage

--- a/docs/adr/009-open-library-as-primary-metadata-source.md
+++ b/docs/adr/009-open-library-as-primary-metadata-source.md
@@ -1,0 +1,68 @@
+# ADR 009: Open Library as the primary (and default-only) book metadata source
+
+- **Status:** Accepted
+- **Date:** 2026-07-11
+
+## Context
+
+The metadata enrichment pipeline (backend `app/services/metadata/` and its
+duplicated copy in `worker/celery_app.py`) used **Google Books as the primary
+provider** with Open Library as fallback.
+
+The [Google Books API Terms of Service](https://developers.google.com/books/terms)
+state:
+
+> "You may not charge users any fee for the use of your application, unless
+> you have entered into a separate agreement with Google or obtained Google's
+> written permission."
+
+and "The API is not intended to be used as a replacement for commercial
+services." Shelfy is a paid product (Home/Pro/Library plans via Stripe). Even
+with a free tier, the application as a whole charges for access, which puts
+the previous default outside the ToS absent a separate agreement with Google.
+The ToS also restricts persistent storage of results and requires Google-hosted
+thumbnails to be displayed with attribution links — incompatible with our
+Redis metadata cache and stored `cover_image_url`.
+
+Open Library (Internet Archive) asserts no proprietary rights over its
+database, so metadata can be cached and reused commercially. The trade-offs
+are lower rate limits (1 req/s anonymous, 3 req/s with an identifying
+User-Agent) and weaker coverage, especially for Czech books.
+
+*This is an operational risk-reduction decision, not legal advice; a formal
+legal review is recommended before launch. Long-term licensed sources are
+tracked separately (#311).*
+
+## Decision
+
+1. **Open Library is the primary and, by default, the only metadata
+   provider** in both the backend service and the Celery worker.
+2. **Google Books stays in the codebase behind `ENABLE_GOOGLE_BOOKS`**
+   (`enable_google_books: bool = False` in `app/core/config.py` and
+   `worker/settings.py`). When enabled it restores the legacy order
+   (Google primary, Open Library fallback) — only to be flipped if an
+   agreement with Google exists. `google_books_api_key` remains but is
+   unused while the flag is off.
+3. **All Open Library requests send an identifying `User-Agent`**
+   (`open_library_user_agent` setting) to qualify for the 3 req/s limit.
+4. **Caching is strengthened** to compensate for the lower rate limits:
+   hit TTL raised from 24 h to 7 days, and definitive misses (provider
+   answered, no record) are negatively cached for 24 h as JSON `null`.
+   Provider errors are never cached, so transient failures stay retryable.
+5. **Covers are hotlinked from `covers.openlibrary.org`** — third-party
+   thumbnails are never copied into our storage (cover licensing is a grey
+   area even at Open Library; hotlinking is the safer posture).
+6. **Product copy no longer promises "Google Books"** (welcome e-mail now
+   says "public book catalogues").
+
+## Consequences
+
+- Compliance risk from the Google Books ToS is removed from the default
+  production path.
+- Czech-title coverage may degrade until a licensed source is integrated
+  (#311); the enrichment status flow (`partial` + manual retry) already
+  handles misses gracefully.
+- The book-suggestion endpoint (#308) and any future catalogue features must
+  build on Open Library, not Google Books.
+- The worker keeps its own copy of the pipeline; both copies must stay in
+  sync (flag + User-Agent are mirrored in `worker/settings.py`).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,8 +22,8 @@ flowchart LR
   R[(Redis)]
   S3[(MinIO)]
   W[Celery Worker]
-  GB[Google Books API]
   OL[Open Library API]
+  GB[Google Books API — optional, off by default]
 
   UI -->|REST + JWT| API
   API --> DB
@@ -60,7 +60,7 @@ flowchart LR
 1. Frontend uploads a cover image to `POST /api/v1/books/upload`.
 2. Backend validates type/size, stores bytes in MinIO, creates `book_images` + `processing_jobs` rows.
 3. Backend enqueues Celery task.
-4. Worker performs barcode extraction with Gemini Vision spine-recognition fallback, attempts metadata lookup (Google Books fallback to Open Library), then updates job/book rows.
+4. Worker performs barcode extraction with Gemini Vision spine-recognition fallback, attempts metadata lookup (Open Library; Google Books only behind the `ENABLE_GOOGLE_BOOKS` opt-in flag), then updates job/book rows.
 
 ## 5. Observability and operations
 

--- a/docs/assets/architecture-diagram.svg
+++ b/docs/assets/architecture-diagram.svg
@@ -42,7 +42,7 @@
 
   <rect x="860" y="320" width="180" height="90" class="box"/>
   <text x="878" y="354" class="label">External APIs</text>
-  <text x="878" y="378" class="text">Google Books / OpenLibrary</text>
+  <text x="878" y="378" class="text">Open Library</text>
 
   <path d="M230 135 L290 135" class="arrow"/>
   <path d="M520 115 L600 115" class="arrow"/>

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -105,7 +105,7 @@ Routers must stay thin. A router function should do nothing more than:
 ### Error handling rules
 
 - Never let exceptions bubble silently. Catch and handle explicitly.
-- External API failures (Google Books, OpenLibrary) must follow the
+- External API failures (OpenLibrary, Gemini Vision) must follow the
   fallback strategy defined in `docs/project-spec.md`.
 - Raise FastAPI `HTTPException` at the router layer, not in services.
   Services should raise domain-specific exceptions that routers translate.

--- a/docs/project-spec.md
+++ b/docs/project-spec.md
@@ -59,8 +59,9 @@ Backend processing pipeline (asynchronous):
 
 External APIs (with fallback):
 
-- Primary: Google Books API
-- Fallback: OpenLibrary API
+- Primary: OpenLibrary API
+- Optional (off by default, ToS-gated): Google Books API — its ToS forbids paid
+  applications, so it must stay disabled unless a separate agreement with Google exists
 
 If both APIs fail, the book is saved with only the data extracted
 locally. The user can fill in missing metadata manually.
@@ -153,8 +154,8 @@ Browser (React SPA)
         |         |
         |         +---> MinIO (image storage)
         |         |
-        |         +---> Google Books API
-        |         +---> OpenLibrary API (fallback)
+        |         +---> OpenLibrary API
+        |         +---> Google Books API (optional, off by default)
         |
         +---> MinIO (direct upload URL generation)
 ```
@@ -168,7 +169,7 @@ Browser (React SPA)
 
 2. Celery worker picks up job
    → Runs barcode detection with Gemini Vision fallback on image
-   → Queries Google Books API (or OpenLibrary fallback)
+   → Queries OpenLibrary API (Google Books only if explicitly enabled)
    → Writes book record to PostgreSQL
    → Updates job status to "done" or "failed"
 
@@ -370,9 +371,9 @@ both sources (env var takes precedence).
 ## External API Failures
 
 ```
-1. Try Google Books API
-2. On failure (timeout / 4xx / 5xx): log warning, try OpenLibrary
-3. On both failures: save book with local data only, set status="partial"
+1. Try OpenLibrary API (with Google Books first when the opt-in flag is on)
+2. On failure (timeout / 4xx / 5xx): log warning
+3. On failure of all enabled providers: save book with local data only, set status="partial"
 4. User sees a warning in the UI with option to retry enrichment
 ```
 
@@ -487,7 +488,7 @@ Target: `backend/app/services/`, `worker/`
 Examples:
 
 - ISBN extraction from Gemini Vision observed text
-- Metadata parsing from Google Books API response
+- Metadata parsing from OpenLibrary API response
 - Fallback logic when primary API fails
 - JWT token creation and validation
 

--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -629,17 +629,20 @@ async def _fetch_open_library_metadata(isbn: str | None, title: str | None = Non
     start = perf_counter()
     try:
         async with httpx.AsyncClient() as client:
+            headers = {"User-Agent": worker_settings.open_library_user_agent}
             if isbn:
                 bib_key = f"ISBN:{isbn}"
                 response = await client.get(
                     "https://openlibrary.org/api/books",
                     params={"bibkeys": bib_key, "format": "json", "jscmd": "data"},
+                    headers=headers,
                     timeout=10.0,
                 )
             elif title:
                 response = await client.get(
                     "https://openlibrary.org/search.json",
                     params={"title": title, "author": author or "", "limit": 1},
+                    headers=headers,
                     timeout=10.0,
                 )
             else:
@@ -708,10 +711,14 @@ async def _enrich_metadata_with_fallback(isbn: str | None, title: str | None = N
 
     metadata: dict[str, object] | None = None
 
-    try:
-        metadata = await _fetch_google_books_metadata(isbn, title=title, author=author)
-    except Exception:
-        metadata = None
+    # Open Library is the sole default provider — Google Books ToS forbids
+    # paid applications, so it only runs behind the explicit opt-in flag
+    # (mirrors app/services/metadata/service.py in the backend).
+    if worker_settings.enable_google_books:
+        try:
+            metadata = await _fetch_google_books_metadata(isbn, title=title, author=author)
+        except Exception:
+            metadata = None
 
     if metadata is None:
         try:

--- a/worker/settings.py
+++ b/worker/settings.py
@@ -23,11 +23,19 @@ class WorkerSettings(BaseSettings):
     sentry_dsn: str | None = None
     environment: str = "production"
 
-    # Enrichment rate limiting (SaaS-friendly defaults)
+    # Enrichment rate limiting (SaaS-friendly defaults). The per-minute cap
+    # also keeps us far below Open Library's identified 3 req/s limit.
     enrichment_delay_seconds: float = 1.5         # delay between API calls per book
     enrichment_max_per_minute: int = 30           # max enrichment API calls per minute
-    enrichment_max_per_day: int = 900             # max enrichment API calls per day (Google Books free = 1000)
-    google_books_api_key: str | None = None       # optional: increases Google Books quota
+    enrichment_max_per_day: int = 900             # max enrichment API calls per day
+
+    # Metadata providers — mirrors app/core/config.py. Google Books ToS
+    # forbids paid applications, so it stays disabled unless a separate
+    # agreement with Google exists.
+    enable_google_books: bool = False
+    google_books_api_key: str | None = None       # unused unless enable_google_books
+    # Identifying User-Agent for Open Library (lifts rate limit to 3 req/s).
+    open_library_user_agent: str = "Shelfy (https://shelfy.cz; support@shelfy.cz)"
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/worker/tests/test_celery_app.py
+++ b/worker/tests/test_celery_app.py
@@ -488,6 +488,35 @@ def test_enrichment_cache_hit_skips_external_calls(monkeypatch) -> None:
     assert result == {"title": "Cached", "provider": "google_books"}
 
 
+def test_enrichment_default_uses_open_library_and_skips_google(monkeypatch) -> None:
+    stored = {}
+
+    class FakeRedis:
+        def get(self, _key):
+            return None
+
+        def setex(self, key, ttl, payload):
+            stored[key] = payload
+
+    monkeypatch.setattr(celery_app, "_get_redis_client", lambda: FakeRedis())
+
+    async def _google_must_not_be_called(*_args, **_kwargs):
+        raise AssertionError("google books must not be called with the flag off")
+
+    async def _open_library(isbn, title=None, author=None):
+        return {"title": "Refactoring", "isbn": isbn, "provider": "open_library"}
+
+    monkeypatch.setattr(celery_app, "_fetch_google_books_metadata", _google_must_not_be_called)
+    monkeypatch.setattr(celery_app, "_fetch_open_library_metadata", _open_library)
+    monkeypatch.setattr(celery_app.worker_settings, "enable_google_books", False)
+
+    result = celery_app.asyncio.run(celery_app._enrich_metadata_with_fallback("9780201485677"))
+
+    assert result is not None
+    assert result["provider"] == "open_library"
+    assert "book-metadata:9780201485677" in stored
+
+
 def test_both_providers_failing_sets_partial_and_creates_book(monkeypatch) -> None:
     job_id = uuid.uuid4()
     book_image_id = uuid.uuid4()


### PR DESCRIPTION
## Souhrn
- **Compliance:** Google Books ToS zakazuje zpoplatněné aplikace bez samostatné dohody → default enrichment běží **jen přes Open Library**, a to v obou kopiích pipeline: [backend service](backend/app/services/metadata/service.py) i [worker](worker/celery_app.py) (worker není v issue výslovně uveden, ale bez něj by akceptační kritérium „produkční lookup nevolá Google Books" neplatilo — produkční enrichment jede právě přes Celery).
- **Feature flag** `enable_google_books` (default `False`) v `app/core/config.py` i `worker/settings.py`; se zapnutým flagem se obnoví původní pořadí (Google primární, OL fallback). `google_books_api_key` zůstává, nepoužitý.
- **User-Agent:** všechna Open Library volání posílají identifikační hlavičku (`open_library_user_agent`, konfigurovatelná) → tier 3 req/s.
- **Cache:** TTL hitů 24 h → **7 dní**; definitivní miss (katalog odpověděl, záznam nemá) se **negativně cachuje 24 h** jako JSON `null`; chyby providera se necachují (transientní výpadky zůstávají retryable).
- **Obálky:** hotlink z `covers.openlibrary.org`, nic se nerehostuje (ověřeno — žádný kód obálky nestahuje do MinIO).
- **Copy:** welcome e-mail (cs/en) už neslibuje „Google Books" → „veřejné knižní katalogy".
- **Docs:** architecture.md, project-spec.md, coding-standards.md, SVG diagram + **ADR 009**.

## Testy
- Default cesta volá jen OL a nikdy Google (assert-fail mock), flag zapnutý = legacy chování (primary + fallback), User-Agent na obou OL endpointech, cache hit/miss, negativní cache, necachování chyb, hotlink obálek.
- Worker: nový test default cesty bez Google Books.
- Bez lokálního Python toolchainu — lint/mypy/pytest ověří CI.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)