### PR TITLE
feat(books): našeptávač z katalogu na poli Název (#308)

### DIFF
--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -15,7 +15,7 @@ from app.models.user import User
 from app.services import entitlements
 from app.models.processing_job import ProcessingJob, ProcessingJobStatus
 from app.schemas.book import (
-    BookCreateRequest, BookListResponse, BookResponse, BookUpdateRequest,
+    BookCreateRequest, BookListResponse, BookResponse, BookSuggestion, BookUpdateRequest,
     BulkDeleteRequest, BulkMoveRequest, BulkOperationResponse, BulkReorderRequest, BulkStatusRequest,
     CsvImportConfirmRequest, CsvImportConfirmResponse, CsvImportPreviewResponse,
     RetryEnrichmentResponse,
@@ -27,6 +27,7 @@ from app.services.book import (
     list_all_books_for_shelf, list_books, update_book,
 )
 from app.services.csv_import import build_books_export_csv, confirm_csv_import, preview_csv_import
+from app.services.metadata.search import suggest_books
 from app.services.job import create_upload_job
 from app.services.job_queue import get_celery_client
 from app.services.storage import delete_image_bytes
@@ -124,6 +125,26 @@ async def export_books_csv(
     response = StreamingResponse(iter([content]), media_type="text/csv; charset=utf-8")
     response.headers["Content-Disposition"] = 'attachment; filename="shelfy-export.csv"'
     return response
+
+
+@router.get("/suggest", response_model=list[BookSuggestion])
+async def suggest_books_endpoint(
+    q: str = Query(default="", max_length=200),
+    limit: int = Query(default=8, ge=1, le=20),
+    redis_client: aioredis.Redis = Depends(get_redis),
+    _current_user: User = Depends(get_current_user),
+) -> list[BookSuggestion]:
+    """Autocomplete candidates from the external catalogue (Open Library).
+
+    Queries shorter than 3 characters return ``[]`` without an external
+    call; results are Redis-cached server-side and the client debounces,
+    so keystrokes never map 1:1 to Open Library requests.
+
+    NOTE: like ``/shelf``, this route must stay registered before the
+    ``/{book_id}`` dynamic path.
+    """
+    suggestions = await suggest_books(q, limit, redis_client)
+    return [BookSuggestion.model_validate(s) for s in suggestions]
 
 
 @router.post(

--- a/backend/app/schemas/book.py
+++ b/backend/app/schemas/book.py
@@ -151,6 +151,19 @@ class RetryEnrichmentResponse(BaseModel):
     status: str
 
 
+class BookSuggestion(BaseModel):
+    """Lightweight external-catalogue candidate for the add-book autocomplete (#308)."""
+
+    title: str
+    author: str | None = None
+    isbn: str | None = None
+    publisher: str | None = None
+    language: str | None = None
+    publication_year: int | None = None
+    cover_image_url: str | None = None
+    provider: str
+
+
 # ── Bulk operations ────────────────────────────────────────────────────────────
 
 class BulkDeleteRequest(BaseModel):

--- a/backend/app/services/metadata/search.py
+++ b/backend/app/services/metadata/search.py
@@ -1,0 +1,118 @@
+"""Multi-candidate book search against Open Library (#308).
+
+Backs the ``GET /api/v1/books/suggest`` autocomplete endpoint. Unlike
+``enrich_metadata_with_fallback`` (single best hit for a known book), this
+returns several lightweight candidates for a partial title/author query.
+Open Library only — Google Books is ToS-gated, see ADR 009 / #310.
+"""
+from __future__ import annotations
+
+import json
+from time import perf_counter
+from typing import Any
+
+import httpx
+import redis.asyncio as aioredis
+import structlog
+
+from app.core.config import get_settings
+from app.core.metrics import EXTERNAL_API_CALLS_TOTAL, observe_external_api_latency
+
+MIN_QUERY_LENGTH = 3
+# Suggest queries are keystroke-shaped and repeat heavily across users; a
+# few hours of staleness is invisible for catalogue data while the cache
+# (with the client-side debounce) keeps us inside Open Library rate limits.
+SUGGEST_CACHE_TTL_SECONDS = 6 * 60 * 60
+
+# Trim the search payload to what BookSuggestion needs — Open Library docs
+# otherwise carry hundreds of edition keys per hit.
+_SEARCH_FIELDS = "title,author_name,isbn,publisher,first_publish_year,language,cover_i"
+
+logger = structlog.get_logger()
+
+
+def _cache_key(query: str, limit: int) -> str:
+    return f"book-suggest:{limit}:{query.lower()}"
+
+
+def _pick_isbn(values: Any) -> str | None:
+    if not isinstance(values, list):
+        return None
+    isbns = [v for v in values if isinstance(v, str) and v]
+    for value in isbns:
+        if len(value) == 13:
+            return value
+    return isbns[0] if isbns else None
+
+
+async def search_open_library_books(
+    client: httpx.AsyncClient, query: str, limit: int
+) -> list[dict[str, Any]]:
+    """Fetch and normalize up to ``limit`` candidates from Open Library search."""
+    settings = get_settings()
+    response = await client.get(
+        "https://openlibrary.org/search.json",
+        params={"q": query, "limit": limit, "fields": _SEARCH_FIELDS},
+        headers={"User-Agent": settings.open_library_user_agent},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    docs = payload.get("docs") or []
+
+    suggestions: list[dict[str, Any]] = []
+    for doc in docs[:limit]:
+        title = doc.get("title")
+        if not isinstance(title, str) or not title.strip():
+            continue
+        cover_id = doc.get("cover_i")
+        # Covers are hotlinked from covers.openlibrary.org, never rehosted.
+        suggestions.append(
+            {
+                "title": title,
+                "author": (doc.get("author_name") or [None])[0],
+                "isbn": _pick_isbn(doc.get("isbn")),
+                "publisher": (doc.get("publisher") or [None])[0],
+                "language": (doc.get("language") or [None])[0],
+                "publication_year": doc.get("first_publish_year"),
+                "cover_image_url": f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg" if cover_id else None,
+                "provider": "open_library",
+            }
+        )
+    return suggestions
+
+
+async def suggest_books(
+    query: str, limit: int, redis_client: aioredis.Redis
+) -> list[dict[str, Any]]:
+    """Return autocomplete candidates, Redis-cached per (query, limit).
+
+    Queries shorter than ``MIN_QUERY_LENGTH`` return ``[]`` without any
+    external call. Provider failures also return ``[]`` (an autocomplete
+    must never break the form) and are not cached, so transient outages
+    stay retryable. Empty result sets from a healthy provider *are*
+    cached — they are definitive for the TTL window.
+    """
+    normalized = query.strip()
+    if len(normalized) < MIN_QUERY_LENGTH:
+        return []
+
+    cache_key = _cache_key(normalized, limit)
+    cached = await redis_client.get(cache_key)
+    if cached:
+        result: list[dict[str, Any]] = json.loads(cached)
+        return result
+
+    start = perf_counter()
+    try:
+        EXTERNAL_API_CALLS_TOTAL.labels(provider="open_library").inc()
+        async with httpx.AsyncClient() as client:
+            suggestions = await search_open_library_books(client, normalized, limit)
+    except Exception as exc:
+        logger.warning("open_library_suggest_failed", query=normalized, error=str(exc))
+        return []
+    finally:
+        observe_external_api_latency("open_library", start)
+
+    await redis_client.set(cache_key, json.dumps(suggestions), ex=SUGGEST_CACHE_TTL_SECONDS)
+    return suggestions

--- a/backend/tests/test_book_suggest.py
+++ b/backend/tests/test_book_suggest.py
@@ -1,0 +1,312 @@
+"""Service + API tests for the add-book autocomplete (#308).
+
+Service-level tests exercise ``suggest_books`` directly — the coverage
+gate undercounts ASGI-async paths, so the cache/error branches are pinned
+here rather than only through the endpoint.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+import asyncio
+import json
+import os
+from typing import Any
+
+from httpx import ASGITransport, AsyncClient
+import httpx
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.api.dependencies.redis import get_redis
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.user import User
+from app.services.metadata.search import (
+    MIN_QUERY_LENGTH,
+    SUGGEST_CACHE_TTL_SECONDS,
+    search_open_library_books,
+    suggest_books,
+)
+
+# ── Service-level tests ────────────────────────────────────────────────────────
+
+
+class FakeRedis:
+    def __init__(self, preloaded: dict[str, str] | None = None) -> None:
+        self.storage: dict[str, str] = dict(preloaded or {})
+        self.ttls: dict[str, int] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.storage.get(key)
+
+    async def set(self, key: str, value: str, ex: int) -> None:
+        self.storage[key] = value
+        self.ttls[key] = ex
+
+    async def aclose(self) -> None:
+        return None
+
+
+DUNE_DOC = {
+    "title": "Dune",
+    "author_name": ["Frank Herbert"],
+    "isbn": ["0441172717", "9780441172719"],
+    "publisher": ["Ace Books"],
+    "first_publish_year": 1965,
+    "language": ["eng"],
+    "cover_i": 11481354,
+}
+
+
+def test_search_open_library_books_normalizes_docs_and_sends_user_agent() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"docs": [DUNE_DOC, {"title": ""}, {"no_title": True}]})
+
+    async def _run() -> list[dict[str, Any]]:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await search_open_library_books(client, "dune", 8)
+
+    suggestions = asyncio.run(_run())
+
+    assert len(seen) == 1
+    assert seen[0].url.path == "/search.json"
+    assert seen[0].url.params["q"] == "dune"
+    assert seen[0].url.params["limit"] == "8"
+    assert seen[0].headers["User-Agent"] == get_settings().open_library_user_agent
+
+    # Docs without a usable title are dropped.
+    assert len(suggestions) == 1
+    dune = suggestions[0]
+    assert dune["title"] == "Dune"
+    assert dune["author"] == "Frank Herbert"
+    # ISBN-13 preferred over ISBN-10.
+    assert dune["isbn"] == "9780441172719"
+    assert dune["publication_year"] == 1965
+    assert dune["cover_image_url"] == "https://covers.openlibrary.org/b/id/11481354-L.jpg"
+    assert dune["provider"] == "open_library"
+
+
+def test_suggest_books_short_query_skips_external_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fail(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("external search must not run for short queries")
+
+    monkeypatch.setattr("app.services.metadata.search.search_open_library_books", _fail)
+    fake_redis = FakeRedis()
+
+    short = "d" * (MIN_QUERY_LENGTH - 1)
+    assert asyncio.run(suggest_books(short, 8, fake_redis)) == []  # type: ignore[arg-type]
+    assert asyncio.run(suggest_books("   ", 8, fake_redis)) == []  # type: ignore[arg-type]
+    assert fake_redis.storage == {}
+
+
+def test_suggest_books_caches_results_per_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def _search(_client: httpx.AsyncClient, query: str, _limit: int) -> list[dict[str, Any]]:
+        calls.append(query)
+        return [{"title": "Dune", "provider": "open_library"}]
+
+    monkeypatch.setattr("app.services.metadata.search.search_open_library_books", _search)
+    fake_redis = FakeRedis()
+
+    first = asyncio.run(suggest_books("Dune ", 8, fake_redis))  # type: ignore[arg-type]
+    second = asyncio.run(suggest_books("dune", 8, fake_redis))  # type: ignore[arg-type]
+
+    assert first == second == [{"title": "Dune", "provider": "open_library"}]
+    # Second lookup is a cache hit — the normalized key ignores case/whitespace.
+    assert calls == ["Dune"]
+    assert fake_redis.ttls["book-suggest:8:dune"] == SUGGEST_CACHE_TTL_SECONDS
+
+
+def test_suggest_books_provider_error_returns_empty_and_is_not_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _down(*_args: object, **_kwargs: object) -> None:
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr("app.services.metadata.search.search_open_library_books", _down)
+    fake_redis = FakeRedis()
+
+    assert asyncio.run(suggest_books("dune", 8, fake_redis)) == []  # type: ignore[arg-type]
+    assert fake_redis.storage == {}
+
+
+def test_suggest_books_empty_result_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def _search(_client: httpx.AsyncClient, query: str, _limit: int) -> list[dict[str, Any]]:
+        calls.append(query)
+        return []
+
+    monkeypatch.setattr("app.services.metadata.search.search_open_library_books", _search)
+    fake_redis = FakeRedis()
+
+    assert asyncio.run(suggest_books("neznama kniha", 8, fake_redis)) == []  # type: ignore[arg-type]
+    assert asyncio.run(suggest_books("neznama kniha", 8, fake_redis)) == []  # type: ignore[arg-type]
+    assert calls == ["neznama kniha"]
+    assert fake_redis.storage["book-suggest:8:neznama kniha"] == json.dumps([])
+
+
+# ── API tests ─────────────────────────────────────────────────────────────────
+# DB fixture pattern mirrors tests/test_books.py (SQLite fallback locally,
+# Postgres via TEST_DATABASE_URL in CI).
+
+
+def _require_test_database_url() -> str:
+    return os.environ.get("TEST_DATABASE_URL", "sqlite+aiosqlite:///./test_suggest.db")
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(_require_test_database_url())
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "manual", "pending", "done", "failed", "partial",
+                name="book_processing_status",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "unread", "reading", "read", "lent",
+                name="reading_status",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "owner", "editor", "viewer",
+                name="library_role",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(Base.metadata.drop_all)
+        await connection.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    yield session_factory
+
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url=_require_test_database_url(),
+        jwt_secret_key="test-secret",
+    )
+
+
+@pytest.fixture
+def fake_redis() -> FakeRedis:
+    return FakeRedis()
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(
+    test_session: async_sessionmaker[AsyncSession],
+    test_settings: Settings,
+    fake_redis: FakeRedis,
+) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        async with test_session() as session:
+            yield session
+
+    async def _get_redis() -> AsyncIterator[FakeRedis]:
+        yield fake_redis
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_redis] = _get_redis
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _auth_headers(client: AsyncClient, session: AsyncSession) -> dict[str, str]:
+    existing = (
+        await session.execute(select(User).where(User.email == "admin@example.com"))
+    ).scalar_one_or_none()
+    if existing is None:
+        session.add(User(email="admin@example.com", hashed_password=get_password_hash("secret")))
+        await session.commit()
+    login_response = await client.post(
+        "/api/v1/auth/login", json={"email": "admin@example.com", "password": "secret"}
+    )
+    assert login_response.status_code == 200
+    token = login_response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_suggest_endpoint_requires_auth() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/v1/books/suggest", params={"q": "dune"})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_suggest_endpoint_returns_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async def _search(_client: httpx.AsyncClient, query: str, limit: int) -> list[dict[str, Any]]:
+        assert query == "dune"
+        assert limit == 8
+        return [
+            {
+                "title": "Dune",
+                "author": "Frank Herbert",
+                "isbn": "9780441172719",
+                "publisher": "Ace Books",
+                "language": "eng",
+                "publication_year": 1965,
+                "cover_image_url": "https://covers.openlibrary.org/b/id/11481354-L.jpg",
+                "provider": "open_library",
+            }
+        ]
+
+    monkeypatch.setattr("app.services.metadata.search.search_open_library_books", _search)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+        response = await client.get(
+            "/api/v1/books/suggest", params={"q": "dune"}, headers=headers
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["title"] == "Dune"
+    assert body[0]["isbn"] == "9780441172719"
+    assert body[0]["provider"] == "open_library"
+
+
+@pytest.mark.asyncio
+async def test_suggest_endpoint_short_query_returns_empty_without_external_call(
+    monkeypatch: pytest.MonkeyPatch,
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async def _fail(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("external search must not run for short queries")
+
+    monkeypatch.setattr("app.services.metadata.search.search_open_library_books", _fail)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with test_session() as session:
+            headers = await _auth_headers(client, session)
+        response = await client.get(
+            "/api/v1/books/suggest", params={"q": "du"}, headers=headers
+        )
+
+    assert response.status_code == 200
+    assert response.json() == []

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1125,6 +1125,72 @@
         }
       }
     },
+    "/api/v1/books/suggest": {
+      "get": {
+        "tags": [
+          "books"
+        ],
+        "summary": "Suggest Books Endpoint",
+        "description": "Autocomplete candidates from the external catalogue (Open Library).\n\nQueries shorter than 3 characters return ``[]`` without an external\ncall; results are Redis-cached server-side and the client debounces,\nso keystrokes never map 1:1 to Open Library requests.\n\nNOTE: like ``/shelf``, this route must stay registered before the\n``/{book_id}`` dynamic path.",
+        "operationId": "suggest_books_endpoint_api_v1_books_suggest_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 200,
+              "default": "",
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 20,
+              "minimum": 1,
+              "default": 8,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BookSuggestion"
+                  },
+                  "title": "Response Suggest Books Endpoint Api V1 Books Suggest Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/books/import/preview": {
       "post": {
         "tags": [
@@ -4640,6 +4706,91 @@
           "updated_at"
         ],
         "title": "BookResponse"
+      },
+      "BookSuggestion": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author"
+          },
+          "isbn": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isbn"
+          },
+          "publisher": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Publisher"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "publication_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Publication Year"
+          },
+          "cover_image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Image Url"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "provider"
+        ],
+        "title": "BookSuggestion",
+        "description": "Lightweight external-catalogue candidate for the add-book autocomplete (#308)."
       },
       "BookUpdateRequest": {
         "properties": {

--- a/frontend/src/hooks/useBookSuggestions.ts
+++ b/frontend/src/hooks/useBookSuggestions.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { suggestBooks } from '../lib/api'
+import type { BookSuggestion } from '../lib/types'
+
+/** Minimum typed characters before the catalogue is queried (#308). */
+export const MIN_SUGGEST_QUERY_LENGTH = 3
+
+/**
+ * Autocomplete candidates for the add-book form (#308).
+ *
+ * Pass an already-debounced query (the caller owns the debounce — see
+ * `useDebounce`, 250ms, same as BorrowersPage search). The query only
+ * fires once the trimmed input reaches 3 characters and `enabled` is
+ * true, so the demo mode / closed dropdown never hit the network.
+ */
+export function useBookSuggestions(query: string, enabled: boolean) {
+  const trimmed = query.trim()
+  return useQuery<BookSuggestion[]>({
+    queryKey: ['book-suggestions', trimmed],
+    queryFn: () => suggestBooks(trimmed),
+    enabled: enabled && trimmed.length >= MIN_SUGGEST_QUERY_LENGTH,
+    // Server caches per-query too; keeping results fresh client-side for a
+    // few minutes avoids re-fetching while the user edits back and forth.
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -417,7 +417,8 @@
     "location_optional_hint": "Nemusíš vybírat umístění hned. Kniha se uloží i bez něj a můžeš ji zařadit později v detailu knihy.",
     "no_room_option": "Bez místnosti / zařadit později",
     "no_furniture_option": "Bez knihovny / zařadit později",
-    "no_shelf_option": "Bez police / zařadit později"
+    "no_shelf_option": "Bez police / zařadit později",
+    "suggestions_label": "Návrhy z katalogu"
   },
   "enrich": {
     "enriching": "Obohacuji…",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -489,7 +489,8 @@
     "location_optional_hint": "You do not have to pick a location now. The book will save without it and you can place it later from the book detail.",
     "no_room_option": "No room / place later",
     "no_furniture_option": "No bookshelf / place later",
-    "no_shelf_option": "No shelf / place later"
+    "no_shelf_option": "No shelf / place later",
+    "suggestions_label": "Catalogue suggestions"
   },
   "enrich": {
     "enriching": "Enriching…",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   Book,
   BookCreateRequest,
   BookListParams,
+  BookSuggestion,
   BookListResponse,
   BookUpdateRequest,
   BulkDeleteRequest,
@@ -440,6 +441,13 @@ export async function getBook(id: string): Promise<Book> {
 
 export async function createBook(payload: BookCreateRequest): Promise<Book> {
   const response = await apiClient.post<Book>('/api/v1/books', payload)
+  return response.data
+}
+
+export async function suggestBooks(q: string, limit = 8): Promise<BookSuggestion[]> {
+  const response = await apiClient.get<BookSuggestion[]>('/api/v1/books/suggest', {
+    params: { q, limit },
+  })
   return response.data
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -199,6 +199,18 @@ export interface BookListParams {
   pageSize?: number
 }
 
+/** External-catalogue candidate returned by GET /api/v1/books/suggest (#308). */
+export interface BookSuggestion {
+  title: string
+  author: string | null
+  isbn: string | null
+  publisher: string | null
+  language: string | null
+  publication_year: number | null
+  cover_image_url: string | null
+  provider: string
+}
+
 export interface BookCreateRequest {
   title: string
   author?: string | null

--- a/frontend/src/pages/AddBookPage.test.tsx
+++ b/frontend/src/pages/AddBookPage.test.tsx
@@ -1,0 +1,211 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mockCreateMutate = vi.fn()
+
+vi.mock('../hooks/useBooks', () => ({
+  useCreateBook: () => ({ mutate: mockCreateMutate, isPending: false }),
+  useUploadBookImage: () => ({ mutate: vi.fn(), isPending: false }),
+  useJobStatus: () => ({ data: undefined }),
+}))
+
+vi.mock('../hooks/useLocations', () => ({
+  useLocations: () => ({ data: [] }),
+}))
+
+const mockUseIsDemoMode = vi.fn(() => false)
+vi.mock('../features/demo/DemoContext', () => ({
+  useIsDemoMode: () => mockUseIsDemoMode(),
+}))
+
+vi.mock('../features/demo/demoNav', () => ({
+  useAppNavigate: () => vi.fn(),
+}))
+
+vi.mock('../features/demo/useDemoActivity', () => ({
+  useDemoActivity: { getState: () => ({ recordAdd: vi.fn(() => 0) }) },
+}))
+
+vi.mock('../lib/demoAnalytics', () => ({
+  trackDemoAddBook: vi.fn(),
+}))
+
+vi.mock('../lib/api', () => ({
+  suggestBooks: vi.fn(),
+}))
+
+import { suggestBooks } from '../lib/api'
+import type { BookSuggestion } from '../lib/types'
+import { AddBookPage } from './AddBookPage'
+
+const DUNE: BookSuggestion = {
+  title: 'Dune',
+  author: 'Frank Herbert',
+  isbn: '9780441172719',
+  publisher: 'Ace Books',
+  language: 'eng',
+  publication_year: 1965,
+  cover_image_url: 'https://covers.openlibrary.org/b/id/11481354-L.jpg',
+  provider: 'open_library',
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <AddBookPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+function titleInput(): HTMLInputElement {
+  return screen.getByTestId('add-book-title-input')
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  mockUseIsDemoMode.mockReturnValue(false)
+})
+
+describe('AddBookPage title autocomplete (#308)', () => {
+  it('queries the catalogue after 3+ typed characters and shows suggestions', async () => {
+    vi.mocked(suggestBooks).mockResolvedValue([DUNE])
+    renderPage()
+
+    const user = userEvent.setup()
+    await user.type(titleInput(), 'dun')
+
+    // 250ms debounce settles inside waitFor's default budget.
+    await waitFor(() => {
+      expect(screen.getByTestId('add-book-suggestions')).toBeInTheDocument()
+    })
+    expect(suggestBooks).toHaveBeenCalledWith('dun')
+    expect(screen.getByTestId('add-book-suggestion-0')).toHaveTextContent('Dune')
+    expect(titleInput()).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('does not query for fewer than 3 characters', async () => {
+    vi.mocked(suggestBooks).mockResolvedValue([DUNE])
+    renderPage()
+
+    const user = userEvent.setup()
+    await user.type(titleInput(), 'du')
+    // Give the debounce comfortably more than 250ms to prove nothing fires.
+    await new Promise((resolve) => setTimeout(resolve, 400))
+
+    expect(suggestBooks).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('add-book-suggestions')).not.toBeInTheDocument()
+  })
+
+  it('never queries the catalogue in demo mode', async () => {
+    mockUseIsDemoMode.mockReturnValue(true)
+    vi.mocked(suggestBooks).mockResolvedValue([DUNE])
+    renderPage()
+
+    const user = userEvent.setup()
+    await user.type(titleInput(), 'dune')
+    await new Promise((resolve) => setTimeout(resolve, 400))
+
+    expect(suggestBooks).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('add-book-suggestions')).not.toBeInTheDocument()
+  })
+
+  it('prefills the visible fields and sends silent metadata on submit after a click pick', async () => {
+    vi.mocked(suggestBooks).mockResolvedValue([DUNE])
+    renderPage()
+
+    const user = userEvent.setup()
+    await user.type(titleInput(), 'dun')
+    await waitFor(() => {
+      expect(screen.getByTestId('add-book-suggestion-0')).toBeInTheDocument()
+    })
+
+    // Selection happens on mousedown so it beats the input blur.
+    await user.pointer([
+      { keys: '[MouseLeft>]', target: screen.getByTestId('add-book-suggestion-0') },
+      { keys: '[/MouseLeft]' },
+    ])
+
+    expect(titleInput()).toHaveValue('Dune')
+    expect(screen.getByPlaceholderText('add_book.author_placeholder')).toHaveValue('Frank Herbert')
+    expect(screen.getByPlaceholderText('add_book.isbn_placeholder')).toHaveValue('9780441172719')
+    expect(screen.queryByTestId('add-book-suggestions')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'add_book.submit' }))
+
+    expect(mockCreateMutate).toHaveBeenCalledTimes(1)
+    expect(mockCreateMutate.mock.calls[0][0]).toMatchObject({
+      title: 'Dune',
+      author: 'Frank Herbert',
+      isbn: '9780441172719',
+      publisher: 'Ace Books',
+      language: 'eng',
+      publication_year: 1965,
+      cover_image_url: 'https://covers.openlibrary.org/b/id/11481354-L.jpg',
+    })
+  })
+
+  it('supports keyboard selection (ArrowDown + Enter) and Escape to close', async () => {
+    vi.mocked(suggestBooks).mockResolvedValue([DUNE])
+    renderPage()
+
+    const user = userEvent.setup()
+    await user.type(titleInput(), 'dun')
+    await waitFor(() => {
+      expect(screen.getByTestId('add-book-suggestions')).toBeInTheDocument()
+    })
+
+    await user.keyboard('{ArrowDown}')
+    expect(screen.getByTestId('add-book-suggestion-0')).toHaveAttribute('aria-selected', 'true')
+    expect(titleInput()).toHaveAttribute(
+      'aria-activedescendant',
+      'add-book-suggestion-0',
+    )
+
+    await user.keyboard('{Enter}')
+    expect(titleInput()).toHaveValue('Dune')
+    expect(screen.getByPlaceholderText('add_book.author_placeholder')).toHaveValue('Frank Herbert')
+    // Enter on an active option must pick, not submit the form.
+    expect(mockCreateMutate).not.toHaveBeenCalled()
+
+    // Reopen by editing, then Escape closes without changing the value.
+    await user.type(titleInput(), 'x')
+    await waitFor(() => {
+      expect(screen.getByTestId('add-book-suggestions')).toBeInTheDocument()
+    })
+    await user.keyboard('{Escape}')
+    expect(screen.queryByTestId('add-book-suggestions')).not.toBeInTheDocument()
+    expect(titleInput()).toHaveValue('Dunex')
+  })
+
+  it('drops silent metadata again when the title is edited after a pick', async () => {
+    vi.mocked(suggestBooks).mockResolvedValue([DUNE])
+    renderPage()
+
+    const user = userEvent.setup()
+    await user.type(titleInput(), 'dun')
+    await waitFor(() => {
+      expect(screen.getByTestId('add-book-suggestion-0')).toBeInTheDocument()
+    })
+    await user.pointer([
+      { keys: '[MouseLeft>]', target: screen.getByTestId('add-book-suggestion-0') },
+      { keys: '[/MouseLeft]' },
+    ])
+    expect(titleInput()).toHaveValue('Dune')
+
+    await user.type(titleInput(), ' II')
+    await user.click(screen.getByRole('button', { name: 'add_book.submit' }))
+
+    expect(mockCreateMutate).toHaveBeenCalledTimes(1)
+    const payload = mockCreateMutate.mock.calls[0][0]
+    expect(payload.title).toBe('Dune II')
+    expect(payload.publication_year).toBeUndefined()
+    expect(payload.cover_image_url).toBeUndefined()
+  })
+})

--- a/frontend/src/pages/AddBookPage.tsx
+++ b/frontend/src/pages/AddBookPage.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from 'react'
+import { useEffect, useRef, useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ProcessingIcon } from '../components/EmptyStateIcons'
 import { useCreateBook, useUploadBookImage, useJobStatus } from '../hooks/useBooks'
+import { MIN_SUGGEST_QUERY_LENGTH, useBookSuggestions } from '../hooks/useBookSuggestions'
+import { useDebounce } from '../hooks/useDebounce'
 import { useLocations } from '../hooks/useLocations'
 import { useIsDemoMode } from '../features/demo/DemoContext'
 import { useAppNavigate } from '../features/demo/demoNav'
@@ -9,7 +11,13 @@ import { useDemoActivity } from '../features/demo/useDemoActivity'
 import { trackDemoAddBook } from '../lib/demoAnalytics'
 import { useToastStore } from '../lib/toast-store'
 import { ROUTES } from '../lib/routes'
-import type { BookCreateRequest, ReadingStatus } from '../lib/types'
+import type { BookCreateRequest, BookSuggestion, ReadingStatus } from '../lib/types'
+
+/** Metadata carried over silently from a picked suggestion (#308). */
+type SuggestionMeta = Pick<
+  BookCreateRequest,
+  'publisher' | 'language' | 'publication_year' | 'cover_image_url'
+>
 
 export function AddBookPage() {
   const { t } = useTranslation()
@@ -27,6 +35,66 @@ export function AddBookPage() {
   const [author, setAuthor]           = useState('')
   const [isbn, setIsbn]               = useState('')
   const [reading, setReading]         = useState<ReadingStatus>('unread')
+
+  /* Catalogue autocomplete on the title field (#308). Debounce matches the
+     BorrowersPage search cadence; the demo has no backend so it never
+     queries. `suggestMeta` carries the picked candidate's year/cover/
+     publisher/language silently into the create payload. */
+  const [suggestOpen, setSuggestOpen]       = useState(false)
+  const [activeSuggestion, setActiveSuggestion] = useState(-1)
+  const [suggestMeta, setSuggestMeta]       = useState<SuggestionMeta | null>(null)
+  const debouncedTitle = useDebounce(title, 250)
+  const suggestionsQuery = useBookSuggestions(debouncedTitle, !isDemo && suggestOpen)
+  const suggestions = suggestionsQuery.data ?? []
+  const listboxVisible = suggestOpen && !isDemo && suggestions.length > 0
+
+  function handleTitleChange(e: ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value
+    setTitle(value)
+    // Any manual edit invalidates metadata copied from a previous pick —
+    // otherwise a stale cover/year would ride along with a different book.
+    setSuggestMeta(null)
+    setActiveSuggestion(-1)
+    setSuggestOpen(value.trim().length >= MIN_SUGGEST_QUERY_LENGTH)
+  }
+
+  function applySuggestion(suggestion: BookSuggestion) {
+    setTitle(suggestion.title)
+    setAuthor(suggestion.author ?? '')
+    setIsbn(suggestion.isbn ?? '')
+    setSuggestMeta({
+      publisher: suggestion.publisher,
+      language: suggestion.language,
+      publication_year: suggestion.publication_year,
+      cover_image_url: suggestion.cover_image_url,
+    })
+    setSuggestOpen(false)
+    setActiveSuggestion(-1)
+  }
+
+  function handleTitleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Escape') {
+      if (listboxVisible) {
+        e.preventDefault()
+        setSuggestOpen(false)
+        setActiveSuggestion(-1)
+      }
+      return
+    }
+    if (!listboxVisible) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveSuggestion((i) => (i + 1) % suggestions.length)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveSuggestion((i) => (i <= 0 ? suggestions.length - 1 : i - 1))
+    } else if (e.key === 'Enter') {
+      if (activeSuggestion >= 0 && activeSuggestion < suggestions.length) {
+        e.preventDefault()
+        applySuggestion(suggestions[activeSuggestion])
+      }
+    }
+  }
 
   // Three-level location picker
   const [selRoom, setSelRoom]       = useState('')
@@ -68,6 +136,9 @@ export function AddBookPage() {
       isbn:           isbn.trim()   || null,
       location_id:    resolvedId,
       reading_status: reading,
+      // Silent metadata from a picked catalogue suggestion (#308) — the
+      // created book carries its cover/year/publisher/language right away.
+      ...(suggestMeta ?? {}),
     }
     createMutation.mutate(payload, {
       onSuccess: () => {
@@ -149,9 +220,79 @@ export function AddBookPage() {
       {/* Form */}
       <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
         <div className="md-grid-2">
-          <div>
-            <label style={{ fontSize: 13, fontWeight: 600, color: 'var(--sh-text-main)', display: 'block', marginBottom: 8 }}>{t('add_book.title_label')} <span style={{ color: 'var(--sh-red)' }}>*</span></label>
-            <input className="sh-input" placeholder={t('add_book.title_placeholder')} value={title} onChange={e => setTitle(e.target.value)} required />
+          <div style={{ position: 'relative' }}>
+            <label id="add-book-title-label" style={{ fontSize: 13, fontWeight: 600, color: 'var(--sh-text-main)', display: 'block', marginBottom: 8 }}>{t('add_book.title_label')} <span style={{ color: 'var(--sh-red)' }}>*</span></label>
+            <input
+              className="sh-input"
+              placeholder={t('add_book.title_placeholder')}
+              value={title}
+              onChange={handleTitleChange}
+              onKeyDown={handleTitleKeyDown}
+              onBlur={() => { setSuggestOpen(false); setActiveSuggestion(-1) }}
+              role="combobox"
+              aria-expanded={listboxVisible}
+              aria-controls="add-book-title-suggestions"
+              aria-autocomplete="list"
+              aria-labelledby="add-book-title-label"
+              aria-activedescendant={
+                listboxVisible && activeSuggestion >= 0
+                  ? `add-book-suggestion-${activeSuggestion}`
+                  : undefined
+              }
+              data-testid="add-book-title-input"
+              required
+            />
+            {listboxVisible && (
+              <ul
+                id="add-book-title-suggestions"
+                role="listbox"
+                aria-label={t('add_book.suggestions_label')}
+                data-testid="add-book-suggestions"
+                style={{
+                  position: 'absolute',
+                  top: '100%',
+                  left: 0,
+                  right: 0,
+                  zIndex: 30,
+                  margin: '4px 0 0',
+                  padding: 4,
+                  listStyle: 'none',
+                  maxHeight: 280,
+                  overflowY: 'auto',
+                  background: 'var(--sh-surface)',
+                  border: '1px solid var(--sh-border)',
+                  borderRadius: 'var(--sh-radius-md)',
+                  boxShadow: 'var(--sh-shadow-lg)',
+                }}
+              >
+                {suggestions.map((suggestion, index) => (
+                  <li
+                    key={`${suggestion.title}-${suggestion.isbn ?? index}`}
+                    id={`add-book-suggestion-${index}`}
+                    role="option"
+                    aria-selected={index === activeSuggestion}
+                    data-testid={`add-book-suggestion-${index}`}
+                    // mousedown (not click) so the pick wins over the input's
+                    // blur handler closing the listbox first.
+                    onMouseDown={(e) => { e.preventDefault(); applySuggestion(suggestion) }}
+                    onMouseEnter={() => setActiveSuggestion(index)}
+                    style={{
+                      padding: '8px 10px',
+                      borderRadius: 'var(--sh-radius-sm, 6px)',
+                      cursor: 'pointer',
+                      background: index === activeSuggestion ? 'var(--sh-teal-bg)' : 'transparent',
+                    }}
+                  >
+                    <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--sh-text-main)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {suggestion.title}
+                    </div>
+                    <div style={{ fontSize: 12, color: 'var(--sh-text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {[suggestion.author, suggestion.publication_year].filter(Boolean).join(' · ')}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
 
           <div>


### PR DESCRIPTION
## Souhrn
**Backend**
- Nová service funkce [search.py](backend/app/services/metadata/search.py): `search_open_library_books` + `suggest_books` — Open Library `search.json?q=…&limit=N` s identifikačním `User-Agent` (dle #310/ADR 009), ořezané `fields`, metriky `EXTERNAL_API_CALLS_TOTAL`.
- Redis cache `book-suggest:<limit>:<q>` (TTL 6 h, cachují se i prázdné výsledky); chyba providera → `[]` bez cache (transientní výpadek zůstává retryable).
- `GET /api/v1/books/suggest?q=&limit=8` — thin router, autentizovaný, `q` < 3 znaky → `[]` bez externího volání; registrován před `/{book_id}`.
- Nové schéma `BookSuggestion`.

**Frontend**
- `useBookSuggestions` hook (react-query, enabled gate ≥ 3 znaky), debounce 250 ms přes existující `useDebounce`.
- Pole *Název* v AddBookPage je ARIA combobox (`role=combobox/listbox/option`, `aria-activedescendant`, šipky + Enter/Esc, zavření na blur/klik mimo).
- Výběr předvyplní název/autora/ISBN a tiše přenese publisher/language/rok/obálku do payloadu; ruční editace názvu po výběru tichá metadata zahodí (žádná cizí obálka u jiné knihy).
- V demo módu se nic nevolá (`useIsDemoMode` guard).

## Testy
- Backend: [test_book_suggest.py](backend/tests/test_book_suggest.py) — normalizace + User-Agent, cache hit/miss, krátké q, chyba providera, prázdný výsledek cachovaný; API: auth required, tvar odpovědi, krátké q bez externího volání. Service-level testy kvůli coverage gate.
- Frontend: 6 nových testů v AddBookPage.test.tsx (dotaz po 3 znacích, < 3 nic, demo guard, prefill klikem + silent metadata, klávesnice, zahození metadat po editaci). `npm run lint` ✅, `npm test -- --run` ✅ (266).

## OpenAPI
- ⚠️ `docs/openapi.yaml` doplním z CI drift-checku (lokálně není Python toolchain) — první běh `backend / lint` spadne na drift, diff aplikuji follow-up commitem.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalogue-powered book title autocomplete to the Add Book form.
  * Suggestions appear after entering at least three characters and include metadata such as author, ISBN, publisher, and language.
  * Selecting a suggestion pre-fills available book details and carries metadata into the created book.
  * Added keyboard navigation for suggestions, including arrow keys, Enter, and Escape.
  * Added localized labels for catalogue suggestions.

* **Documentation**
  * Documented the new authenticated book suggestions API and response schema.

* **Tests**
  * Added coverage for autocomplete behavior, keyboard selection, caching, authentication, and provider failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->