### PR TITLE
feat(email): e-mail při přidání člena do knihovny (#312)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -37,6 +37,7 @@ from app.schemas.auth import (
     TokenResponse,
     UserResponse,
 )
+from app.api.dependencies.locale import email_locale_from_request
 from app.services import billing as billing_svc
 from app.services import email as email_svc
 from app.services.auth import authenticate_user, issue_token_pair, read_refresh_token_subject, register_user
@@ -60,17 +61,6 @@ router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 SETTINGS = get_settings()
 
 
-def _email_locale_from_request(request: Request) -> str:
-    """Best-effort email locale from the SPA language cookie or browser headers."""
-    cookie_locale = request.cookies.get("shelfy_language")
-    if cookie_locale:
-        return email_svc.normalize_locale(cookie_locale)
-
-    accept_language = request.headers.get("accept-language", "")
-    first_language = accept_language.split(",", maxsplit=1)[0].strip()
-    return email_svc.normalize_locale(first_language)
-
-
 # ── Standard auth ──────────────────────────────────────────────────────────────
 
 @router.post("/register", response_model=UserResponse, status_code=201)
@@ -84,7 +74,7 @@ async def register(
     user = await register_user(session, str(payload.email), payload.password)
     # Fire-and-forget welcome email — never blocks the response
     name = user.email.split("@")[0]
-    background_tasks.add_task(email_svc.send_welcome, user.email, name, locale=_email_locale_from_request(request))
+    background_tasks.add_task(email_svc.send_welcome, user.email, name, locale=email_locale_from_request(request))
     return UserResponse.model_validate(user)
 
 
@@ -197,7 +187,7 @@ async def request_password_reset(
         requested_user_agent=request.headers.get("user-agent"),
     )
     reset_url = f"{settings.app_url}/reset-password?token={plaintext_token}"
-    background_tasks.add_task(email_svc.send_password_reset, user.email, reset_url, locale=_email_locale_from_request(request))
+    background_tasks.add_task(email_svc.send_password_reset, user.email, reset_url, locale=email_locale_from_request(request))
     await session.commit()
     logger.info("password_reset_request", email_hash=email_hash, outcome="token_created")
     return {"status": "ok"}

--- a/backend/app/api/dependencies/locale.py
+++ b/backend/app/api/dependencies/locale.py
@@ -1,0 +1,22 @@
+"""Best-effort request → email-locale resolution.
+
+Shared by every endpoint that fires a transactional email (register,
+password reset, added-to-library, …) so the cookie/header heuristic
+lives in exactly one place.
+"""
+from __future__ import annotations
+
+from fastapi import Request
+
+from app.services import email as email_svc
+
+
+def email_locale_from_request(request: Request) -> str:
+    """Resolve the email locale from the SPA language cookie or browser headers."""
+    cookie_locale = request.cookies.get("shelfy_language")
+    if cookie_locale:
+        return email_svc.normalize_locale(cookie_locale)
+
+    accept_language = request.headers.get("accept-language", "")
+    first_language = accept_language.split(",", maxsplit=1)[0].strip()
+    return email_svc.normalize_locale(first_language)

--- a/backend/app/api/libraries.py
+++ b/backend/app/api/libraries.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies.auth import get_current_user
+from app.api.dependencies.locale import email_locale_from_request
 from app.db.session import get_db_session
-from app.models.library import LibraryRole
+from app.models.library import Library, LibraryRole
 from app.models.user import User
+from app.services import email as email_svc
 from app.schemas.library import (
     AddLibraryMemberRequest,
     CreateLibraryRequest,
@@ -72,6 +74,8 @@ async def get_members(
 async def create_member(
     library_id: uuid.UUID,
     payload: AddLibraryMemberRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db_session),
     current_user: User = Depends(get_current_user),
 ) -> LibraryMemberResponse:
@@ -83,10 +87,24 @@ async def create_member(
     # until this endpoint commits below; ``add_member`` no longer commits
     # internally for that reason.
     await entitlements.assert_can_add_member(session, current_user.id, library_id, lock=True)
-    member = await add_member(session, library_id, str(payload.email), payload.role)
+    member, created = await add_member(session, library_id, str(payload.email), payload.role)
     await session.commit()
     user = await session.get(User, member.user_id)
     assert user is not None
+    # Notify the added user — fire-and-forget after the commit, mirroring the
+    # welcome email in ``register`` (#312). Only on the first add: role
+    # upserts stay silent, and owners adding themselves don't get mail.
+    if created and member.user_id != current_user.id:
+        library = await session.get(Library, library_id)
+        assert library is not None
+        background_tasks.add_task(
+            email_svc.send_added_to_library,
+            user.email,
+            library.name,
+            member.role.value,
+            current_user.email,
+            locale=email_locale_from_request(request),
+        )
     return LibraryMemberResponse(user_id=member.user_id, email=user.email, role=member.role)
 
 

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -11,6 +11,7 @@ Usage:
 Email catalogue
 ---------------
 welcome                — sent once on registration
+added_to_library       — user added to a shared library by its owner (#312)
 trial_ending_day10     — 4 days left on trial  (sent by beat task)
 trial_ending_day13     — 1 day left on trial   (sent by beat task)
 limit_approaching      — user at ≥ 80 % of a monthly quota (beat task)
@@ -168,6 +169,51 @@ async def send_welcome(to: str, name: str, *, locale: str | None = None) -> None
 <p style="color:#555">Happy reading,<br>The Shelfy team</p>
 """, locale=lang)
         subject = "Welcome to Shelfy 📚"
+    await _send(to=to, subject=subject, html=html)
+
+
+async def send_added_to_library(
+    to: str,
+    library_name: str,
+    role: str,
+    inviter_email: str | None = None,
+    *,
+    locale: str | None = None,
+) -> None:
+    """Sent when an owner adds an already-registered user to a shared library (#312).
+
+    Fired only on the first add — role upserts and self-adds don't notify
+    (guarded at the ``create_member`` call site).
+    """
+    settings = get_settings()
+    lang = normalize_locale(locale)
+    role_labels = {
+        "cs": {"owner": "správce", "editor": "editor", "viewer": "čtenář"},
+        "en": {"owner": "owner", "editor": "editor", "viewer": "viewer"},
+    }[lang]
+    role_label = role_labels.get(role, role)
+    if lang == "cs":
+        inviter_note = f" (přidal/a tě {inviter_email})" if inviter_email else ""
+        html = _base(f"""
+<p>Ahoj,</p>
+<p>právě jsi získal/a přístup do sdílené knihovny <strong>{library_name}</strong>
+   v roli <strong>{role_label}</strong>{inviter_note}.</p>
+<p>Knihovnu najdeš po přihlášení mezi svými knihovnami.</p>
+<p>{_cta(f"{settings.app_url}/books", "Otevřít Shelfy →")}</p>
+<p style="color:#555">Příjemné čtení,<br>tým Shelfy</p>
+""", locale=lang)
+        subject = f"Byl/a jsi přidán/a do knihovny „{library_name}“ 📚"
+    else:
+        inviter_note = f" (added by {inviter_email})" if inviter_email else ""
+        html = _base(f"""
+<p>Hey,</p>
+<p>you've just been given access to the shared library <strong>{library_name}</strong>
+   as <strong>{role_label}</strong>{inviter_note}.</p>
+<p>You'll find it among your libraries the next time you sign in.</p>
+<p>{_cta(f"{settings.app_url}/books", "Open Shelfy →")}</p>
+<p style="color:#555">Happy reading,<br>The Shelfy team</p>
+""", locale=lang)
+        subject = f'You\'ve been added to "{library_name}" 📚'
     await _send(to=to, subject=subject, html=html)
 
 

--- a/backend/app/services/library.py
+++ b/backend/app/services/library.py
@@ -132,8 +132,14 @@ async def list_members(session: AsyncSession, library_id: uuid.UUID) -> list[tup
     return [(member, user) for member, user in res.all()]
 
 
-async def add_member(session: AsyncSession, library_id: uuid.UUID, email: str, role: LibraryRole) -> LibraryMember:
+async def add_member(
+    session: AsyncSession, library_id: uuid.UUID, email: str, role: LibraryRole
+) -> tuple[LibraryMember, bool]:
     """Insert or update a library membership.
+
+    Returns ``(member, created)`` — ``created`` is False on the upsert
+    branch (role change of an existing member), which the endpoint uses to
+    send the added-to-library email only on the first add (#312).
 
     The caller owns the transaction boundary — this function flushes but does
     not commit. That invariant matters for issue #119: the endpoint takes a
@@ -151,6 +157,7 @@ async def add_member(session: AsyncSession, library_id: uuid.UUID, email: str, r
             )
         )
     ).scalar_one_or_none()
+    created = member is None
     if member is None:
         member = LibraryMember(library_id=library_id, user_id=user.id, role=role)
         session.add(member)
@@ -158,7 +165,7 @@ async def add_member(session: AsyncSession, library_id: uuid.UUID, email: str, r
         member.role = role
     await session.flush()
     await session.refresh(member)
-    return member
+    return member, created
 
 
 async def _owner_count(session: AsyncSession, library_id: uuid.UUID) -> int:

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -22,6 +22,7 @@ from pytest import LogCaptureFixture
 from app.services.email import (
     _send,
     normalize_locale,
+    send_added_to_library,
     send_limit_approaching,
     send_password_reset,
     send_welcome,
@@ -277,3 +278,52 @@ async def test_send_swallows_resend_errors() -> None:
         await _send(to="user@example.com", subject="Boom", html="<p>Hi</p>")
 
     response.raise_for_status.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_send_added_to_library_renders_czech_copy() -> None:
+    """cs locale: subject and body carry the library name, role label and inviter."""
+    send_mock = AsyncMock()
+    with patch("app.services.email._send", send_mock):
+        await send_added_to_library(
+            "member@example.com",
+            "Rodinná knihovna",
+            "editor",
+            "owner@example.com",
+            locale="cs",
+        )
+
+    send_mock.assert_awaited_once()
+    assert send_mock.await_args is not None
+    kwargs = send_mock.await_args.kwargs
+    assert kwargs["to"] == "member@example.com"
+    assert "Rodinná knihovna" in kwargs["subject"]
+    assert "Byl/a jsi přidán/a" in kwargs["subject"]
+    assert "Rodinná knihovna" in kwargs["html"]
+    assert "editor" in kwargs["html"]
+    assert "owner@example.com" in kwargs["html"]
+    assert 'lang="cs"' in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_send_added_to_library_falls_back_to_english_copy() -> None:
+    """Unknown locale falls back to English; inviter note is omitted when absent."""
+    send_mock = AsyncMock()
+    with patch("app.services.email._send", send_mock):
+        await send_added_to_library(
+            "member@example.com", "Family Library", "viewer", None, locale="de"
+        )
+
+    send_mock.assert_awaited_once()
+    assert send_mock.await_args is not None
+    kwargs = send_mock.await_args.kwargs
+    assert 'You\'ve been added to "Family Library"' in kwargs["subject"]
+    assert "viewer" in kwargs["html"]
+    assert "added by" not in kwargs["html"]
+    assert 'lang="en"' in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_send_added_to_library_noops_without_api_key() -> None:
+    """No RESEND_API_KEY in the test env — the real _send guard returns silently."""
+    await send_added_to_library("member@example.com", "Family Library", "viewer")

--- a/backend/tests/test_library_member_email.py
+++ b/backend/tests/test_library_member_email.py
@@ -1,0 +1,199 @@
+"""API tests for the added-to-library notification (#312).
+
+POST /api/v1/libraries/{id}/members schedules ``send_added_to_library``
+as a fire-and-forget background task — only for a *new* membership, not
+for a role upsert, and not when the owner adds themselves. ASGITransport
+runs FastAPI BackgroundTasks after the response, so the patched mock is
+awaited by the time the client call returns.
+
+DB fixture pattern mirrors tests/test_isolation.py (SQLite fallback
+locally, Postgres via TEST_DATABASE_URL in CI).
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+import os
+from unittest.mock import AsyncMock, patch
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.subscription import Subscription, SubscriptionPlan, SubscriptionStatus
+from app.models.user import User
+
+
+def _require_test_database_url() -> str:
+    return os.environ.get("TEST_DATABASE_URL", "sqlite+aiosqlite:///./test_member_email.db")
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(_require_test_database_url())
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "manual", "pending", "done", "failed", "partial",
+                name="book_processing_status",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "unread", "reading", "read", "lent",
+                name="reading_status",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "owner", "editor", "viewer",
+                name="library_role",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(Base.metadata.drop_all)
+        await connection.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    yield session_factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url=_require_test_database_url(),
+        jwt_secret_key="test-secret",
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(
+    test_session: async_sessionmaker[AsyncSession], test_settings: Settings
+) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        async with test_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _create_user(session: AsyncSession, email: str, password: str = "secret") -> User:
+    user = User(email=email, hashed_password=get_password_hash(password))
+    session.add(user)
+    await session.flush()
+    await session.refresh(user)
+    return user
+
+
+async def _create_library_with_owner(
+    session: AsyncSession, owner: User, name: str = "Shared Library"
+) -> Library:
+    lib = Library(name=name, created_by_user_id=owner.id)
+    session.add(lib)
+    await session.flush()
+    session.add(LibraryMember(library_id=lib.id, user_id=owner.id, role=LibraryRole.OWNER))
+    return lib
+
+
+async def _give_plan(session: AsyncSession, user: User, plan: SubscriptionPlan) -> None:
+    session.add(
+        Subscription(user_id=user.id, plan=plan, status=SubscriptionStatus.active)
+    )
+
+
+async def _login(client: AsyncClient, email: str, password: str = "secret") -> dict[str, str]:
+    response = await client.post("/api/v1/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+@pytest.mark.asyncio
+async def test_new_member_schedules_added_to_library_email(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        await _create_user(session, "member@example.com")
+        lib = await _create_library_with_owner(session, owner, "Rodinná knihovna")
+        await _give_plan(session, owner, SubscriptionPlan.pro)
+        await session.commit()
+
+    send_mock = AsyncMock()
+    with patch("app.api.libraries.email_svc.send_added_to_library", send_mock):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            headers = await _login(client, "owner@example.com")
+            response = await client.post(
+                f"/api/v1/libraries/{lib.id}/members",
+                json={"email": "member@example.com", "role": "editor"},
+                headers=headers,
+                cookies={"shelfy_language": "cs"},
+            )
+
+    assert response.status_code == 200
+    send_mock.assert_awaited_once_with(
+        "member@example.com",
+        "Rodinná knihovna",
+        "editor",
+        "owner@example.com",
+        locale="cs",
+    )
+
+
+@pytest.mark.asyncio
+async def test_role_upsert_does_not_schedule_email(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        member = await _create_user(session, "member@example.com")
+        lib = await _create_library_with_owner(session, owner)
+        session.add(LibraryMember(library_id=lib.id, user_id=member.id, role=LibraryRole.VIEWER))
+        await _give_plan(session, owner, SubscriptionPlan.pro)
+        await session.commit()
+
+    send_mock = AsyncMock()
+    with patch("app.api.libraries.email_svc.send_added_to_library", send_mock):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            headers = await _login(client, "owner@example.com")
+            response = await client.post(
+                f"/api/v1/libraries/{lib.id}/members",
+                json={"email": "member@example.com", "role": "editor"},
+                headers=headers,
+            )
+
+    assert response.status_code == 200
+    assert response.json()["role"] == "editor"
+    send_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_owner_adding_self_does_not_schedule_email(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        lib = await _create_library_with_owner(session, owner)
+        await _give_plan(session, owner, SubscriptionPlan.pro)
+        await session.commit()
+
+    send_mock = AsyncMock()
+    with patch("app.api.libraries.email_svc.send_added_to_library", send_mock):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            headers = await _login(client, "owner@example.com")
+            response = await client.post(
+                f"/api/v1/libraries/{lib.id}/members",
+                json={"email": "owner@example.com", "role": "owner"},
+                headers=headers,
+            )
+
+    assert response.status_code == 200
+    send_mock.assert_not_awaited()

--- a/backend/tests/test_library_service.py
+++ b/backend/tests/test_library_service.py
@@ -198,11 +198,12 @@ async def test_add_member_creates_new_membership(test_session: AsyncSession) -> 
     new_user = await _make_user(test_session, "new@example.com")
     await test_session.commit()
 
-    member = await add_member(test_session, lib.id, "new@example.com", LibraryRole.VIEWER)
+    member, created = await add_member(test_session, lib.id, "new@example.com", LibraryRole.VIEWER)
     await test_session.commit()
 
     assert member.user_id == new_user.id
     assert member.role == LibraryRole.VIEWER
+    assert created is True
 
 
 @pytest.mark.asyncio
@@ -213,10 +214,12 @@ async def test_add_member_updates_existing_role(test_session: AsyncSession) -> N
     test_session.add(LibraryMember(library_id=lib.id, user_id=existing.id, role=LibraryRole.VIEWER))
     await test_session.commit()
 
-    member = await add_member(test_session, lib.id, "existing@example.com", LibraryRole.EDITOR)
+    member, created = await add_member(test_session, lib.id, "existing@example.com", LibraryRole.EDITOR)
     await test_session.commit()
 
     assert member.role == LibraryRole.EDITOR
+    # Upsert branch — create_member uses this flag to skip the notification.
+    assert created is False
 
 
 # ── update_member_role ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Souhrn
- Nová šablona `send_added_to_library(to, library_name, role, inviter_email, locale=…)` v [email.py](backend/app/services/email.py) — cs/en podle vzoru `send_welcome` (`_base` + `_cta` na `{app_url}/books`), lokalizované role (správce/editor/čtenář), volitelná zmínka kdo přidal.
- `create_member` v [libraries.py](backend/app/api/libraries.py) plánuje e-mail přes `BackgroundTasks.add_task` **po commitu** (vzor `register`) — fire-and-forget, bez `RESEND_API_KEY` tichý no-op (stávající guard v `_send`).
- `add_member` ve service vrací `(member, created)`: e-mail jen při **prvním** přidání — změna role existujícího člena nic neposílá, owner sám sobě také ne (`member.user_id != current_user.id`).
- Helper `_email_locale_from_request` přesunut z `auth.py` do sdíleného [app/api/dependencies/locale.py](backend/app/api/dependencies/locale.py) (žádná duplikace); `auth.py` přepnut na sdílenou verzi.
- Pozvánky pro neregistrované e-maily beze změny (endpoint dál vrací 404) — mimo rozsah.

## Testy
- [test_library_member_email.py](backend/tests/test_library_member_email.py): nový člen → naplánováno s přesnými argumenty (jméno knihovny, role, inviter, cs locale z cookie); role upsert → neposílá; self-add → neposílá.
- `test_email_service.py`: render šablony cs + en (fallback z neznámého locale, vynechání inviter note), no-op bez API klíče.
- `test_library_service.py`: rozšířeno o assert `created` flagu.
- Žádná změna OpenAPI (wire kontrakt beze změny). Lint/mypy/pytest ověří CI.

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)