### PR TITLE
feat(wishlist): interní wishlist knihovny s owner přepínačem (#309)

### DIFF
--- a/backend/alembic/versions/20260711_000025_add_wishlist.py
+++ b/backend/alembic/versions/20260711_000025_add_wishlist.py
@@ -1,0 +1,78 @@
+"""add wishlist_items table and libraries.wishlist_enabled for #309
+
+Revision ID: 20260711_000025
+Revises: 20260519_000024
+Create Date: 2026-07-11
+
+Internal wishlist: books a library wants to acquire. Rows are
+multi-tenant isolated via ``library_id`` (CASCADE, same pattern as
+``books``/``borrowers``). ``created_by_user_id`` is SET NULL so deleting
+a user account keeps the library's wishes.
+
+``libraries.wishlist_enabled`` is the per-library feature toggle —
+``server_default=true`` so every existing library has the wishlist on
+after this migration (decision from the issue refinement), no backfill
+needed.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260711_000025"
+down_revision = "20260519_000024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "libraries",
+        sa.Column(
+            "wishlist_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+    op.create_table(
+        "wishlist_items",
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
+        sa.Column(
+            "library_id",
+            sa.Uuid(as_uuid=True),
+            sa.ForeignKey("libraries.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_by_user_id",
+            sa.Uuid(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("title", sa.String(500), nullable=False),
+        sa.Column("author", sa.String(500), nullable=True),
+        sa.Column("isbn", sa.String(20), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("cover_image_url", sa.String(500), nullable=True),
+        sa.Column("publication_year", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_wishlist_items_library_id", "wishlist_items", ["library_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_wishlist_items_library_id", table_name="wishlist_items")
+    op.drop_table("wishlist_items")
+    op.drop_column("libraries", "wishlist_enabled")

--- a/backend/app/api/libraries.py
+++ b/backend/app/api/libraries.py
@@ -17,8 +17,10 @@ from app.schemas.library import (
     LibraryMemberResponse,
     LibraryResponse,
     UpdateLibraryMemberRequest,
+    UpdateLibraryRequest,
 )
 from app.services import entitlements
+from app.services.wishlist import set_wishlist_enabled
 from app.services.library import (
     add_member,
     create_library as create_library_service,
@@ -37,7 +39,12 @@ async def libraries_me(
     session: AsyncSession = Depends(get_db_session), current_user: User = Depends(get_current_user)
 ) -> list[LibraryResponse]:
     data = await list_user_libraries(session, current_user.id)
-    return [LibraryResponse(id=lib.id, name=lib.name, role=role) for lib, role in data]
+    return [
+        LibraryResponse(
+            id=lib.id, name=lib.name, role=role, wishlist_enabled=lib.wishlist_enabled
+        )
+        for lib, role in data
+    ]
 
 
 @router.post("", response_model=LibraryResponse, status_code=201)
@@ -56,7 +63,27 @@ async def create_library(
     lib = await create_library_service(session, current_user.id, payload.name)
     await session.commit()
     await session.refresh(lib)
-    return LibraryResponse(id=lib.id, name=lib.name, role=LibraryRole.OWNER)
+    return LibraryResponse(
+        id=lib.id, name=lib.name, role=LibraryRole.OWNER, wishlist_enabled=lib.wishlist_enabled
+    )
+
+
+@router.patch("/{library_id}", response_model=LibraryResponse)
+async def update_library(
+    library_id: uuid.UUID,
+    payload: UpdateLibraryRequest,
+    session: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+) -> LibraryResponse:
+    """Owner-only library settings — currently just the wishlist toggle (#309)."""
+    member = await require_library_role(session, current_user.id, library_id, LibraryRole.OWNER)
+    library = await set_wishlist_enabled(session, library_id, payload.wishlist_enabled)
+    return LibraryResponse(
+        id=library.id,
+        name=library.name,
+        role=member.role,
+        wishlist_enabled=library.wishlist_enabled,
+    )
 
 
 @router.get("/{library_id}/members", response_model=list[LibraryMemberResponse])

--- a/backend/app/api/wishlist.py
+++ b/backend/app/api/wishlist.py
@@ -1,0 +1,67 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Query, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies.auth import get_current_user
+from app.api.dependencies.library import get_library_id, require_editor_library
+from app.db.session import get_db_session
+from app.models.user import User
+from app.schemas.wishlist import (
+    WishlistItemCreateRequest,
+    WishlistItemResponse,
+    WishlistListResponse,
+)
+from app.services.wishlist import (
+    assert_wishlist_enabled,
+    create_wishlist_item,
+    delete_wishlist_item,
+    list_wishlist_items,
+)
+
+router = APIRouter(prefix="/api/v1/wishlist", tags=["wishlist"])
+
+
+@router.get("", response_model=WishlistListResponse)
+async def read_wishlist(
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(get_library_id),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+) -> WishlistListResponse:
+    """List the active library's wishes (viewer+)."""
+    await assert_wishlist_enabled(session, library_id)
+    items, total = await list_wishlist_items(session, library_id, page=page, page_size=page_size)
+    return WishlistListResponse(
+        total=total,
+        page=page,
+        page_size=page_size,
+        items=[WishlistItemResponse.model_validate(item) for item in items],
+    )
+
+
+@router.post("", response_model=WishlistItemResponse, status_code=status.HTTP_201_CREATED)
+async def create_wish(
+    payload: WishlistItemCreateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(require_editor_library),
+    current_user: User = Depends(get_current_user),
+) -> WishlistItemResponse:
+    """Add a wish (editor+)."""
+    await assert_wishlist_enabled(session, library_id)
+    item = await create_wishlist_item(
+        session, payload, library_id, actor_user_id=current_user.id
+    )
+    return WishlistItemResponse.model_validate(item)
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_wish(
+    item_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db_session),
+    library_id: uuid.UUID = Depends(require_editor_library),
+) -> Response:
+    """Remove a wish (editor+)."""
+    await assert_wishlist_enabled(session, library_id)
+    await delete_wishlist_item(session, item_id, library_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from app.api.metrics import router as metrics_router
 from app.api.scan import router as scan_router
 from app.api.settings import router as settings_router
 from app.api.telemetry import router as telemetry_router
+from app.api.wishlist import router as wishlist_router
 from app.core.config import get_settings
 from app.core.csrf import CSRFMiddleware
 from app.core.limiter import limiter
@@ -168,6 +169,7 @@ def create_app() -> FastAPI:
     app.include_router(locations_router)
     app.include_router(books_router)
     app.include_router(borrowers_router)
+    app.include_router(wishlist_router)
     app.include_router(loans_router)
     app.include_router(enrich_router)
     app.include_router(scan_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.password_reset_token import PasswordResetToken
 from app.models.processing_job import ProcessingJob
 from app.models.subscription import Subscription, UsageCounter, UsageEvent, SubscriptionPlan, SubscriptionStatus, UsageMetric
 from app.models.user import User
+from app.models.wishlist_item import WishlistItem
 
 __all__ = [
     "User", "Location", "Book", "Borrower", "BorrowerMergeUndoLog",
@@ -16,4 +17,5 @@ __all__ = [
     "Library", "LibraryMember", "LibraryRole",
     "PasswordResetToken",
     "Subscription", "UsageCounter", "UsageEvent", "SubscriptionPlan", "SubscriptionStatus", "UsageMetric",
+    "WishlistItem",
 ]

--- a/backend/app/models/library.py
+++ b/backend/app/models/library.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 import uuid
 
-from sqlalchemy import DateTime, Enum as SAEnum, ForeignKey, String, Uuid, UniqueConstraint, func
+from sqlalchemy import Boolean, DateTime, Enum as SAEnum, ForeignKey, String, Uuid, UniqueConstraint, func, true
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -24,6 +24,11 @@ class Library(Base):
     slug: Mapped[str | None] = mapped_column(String(255), nullable=True, unique=True, index=True)
     created_by_user_id: Mapped[uuid.UUID] = mapped_column(
         Uuid(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # Wishlist feature toggle (#309): default ON for existing and new
+    # libraries; only the owner may flip it (PATCH /api/v1/libraries/{id}).
+    wishlist_enabled: Mapped[bool] = mapped_column(
+        Boolean(), nullable=False, server_default=true(), default=True
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/models/wishlist_item.py
+++ b/backend/app/models/wishlist_item.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, Uuid, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class WishlistItem(Base):
+    """A book the library wants to acquire (#309).
+
+    Internal feature: wishes are created by signed-in members of the
+    library. Multi-tenant isolation follows the ``Book``/``Borrower``
+    pattern — every row hangs off ``library_id`` with CASCADE delete.
+    """
+
+    __tablename__ = "wishlist_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    library_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey("libraries.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # SET NULL so deleting a user account keeps the library's wishes.
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    author: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    isbn: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    note: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    cover_image_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    publication_year: Mapped[int | None] = mapped_column(Integer(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/schemas/library.py
+++ b/backend/app/schemas/library.py
@@ -11,6 +11,8 @@ class LibraryResponse(BaseModel):
     id: uuid.UUID
     name: str
     role: LibraryRole
+    # Per-library wishlist toggle (#309); drives the nav item + /wishlist route.
+    wishlist_enabled: bool = True
 
 
 class CreateLibraryRequest(BaseModel):
@@ -30,3 +32,9 @@ class AddLibraryMemberRequest(BaseModel):
 
 class UpdateLibraryMemberRequest(BaseModel):
     role: LibraryRole
+
+
+class UpdateLibraryRequest(BaseModel):
+    """Owner-only library settings (#309). Single field for now."""
+
+    wishlist_enabled: bool

--- a/backend/app/schemas/wishlist.py
+++ b/backend/app/schemas/wishlist.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WishlistItemCreateRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=500)
+    author: str | None = Field(default=None, min_length=1, max_length=500)
+    isbn: str | None = Field(default=None, min_length=1, max_length=20)
+    note: str | None = Field(default=None, min_length=1)
+    cover_image_url: str | None = Field(default=None, max_length=500)
+    publication_year: int | None = Field(default=None, ge=0, le=9999)
+
+
+class WishlistItemResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    library_id: uuid.UUID
+    created_by_user_id: uuid.UUID | None
+    title: str
+    author: str | None
+    isbn: str | None
+    note: str | None
+    cover_image_url: str | None
+    publication_year: int | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class WishlistListResponse(BaseModel):
+    total: int
+    page: int
+    page_size: int
+    items: list[WishlistItemResponse]

--- a/backend/app/services/wishlist.py
+++ b/backend/app/services/wishlist.py
@@ -1,0 +1,134 @@
+"""Wishlist service (#309) — books a library wants to acquire.
+
+Internal feature: every function is scoped by ``library_id`` (the router
+resolves it through the ``get_library_id`` / ``require_*_library``
+dependencies), so cross-library access dies before it reaches a query.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+import structlog
+
+from app.models.library import Library
+from app.models.wishlist_item import WishlistItem
+from app.schemas.wishlist import WishlistItemCreateRequest
+
+logger = structlog.get_logger()
+
+
+async def assert_wishlist_enabled(session: AsyncSession, library_id: uuid.UUID) -> None:
+    """403 when the owner turned the wishlist off for this library.
+
+    The frontend hides the route, but the API must not quietly keep
+    serving a feature the owner disabled.
+    """
+    enabled = (
+        await session.execute(
+            select(Library.wishlist_enabled).where(Library.id == library_id)
+        )
+    ).scalar_one_or_none()
+    if not enabled:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Wishlist is disabled for this library",
+        )
+
+
+async def list_wishlist_items(
+    session: AsyncSession,
+    library_id: uuid.UUID,
+    *,
+    page: int,
+    page_size: int,
+) -> tuple[list[WishlistItem], int]:
+    """Newest wishes first, paginated the same way as borrowers."""
+    total = (
+        await session.execute(
+            select(func.count())
+            .select_from(WishlistItem)
+            .where(WishlistItem.library_id == library_id)
+        )
+    ).scalar_one()
+    rows = (
+        await session.execute(
+            select(WishlistItem)
+            .where(WishlistItem.library_id == library_id)
+            .order_by(WishlistItem.created_at.desc(), WishlistItem.id.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+    ).scalars().all()
+    return list(rows), int(total)
+
+
+async def create_wishlist_item(
+    session: AsyncSession,
+    payload: WishlistItemCreateRequest,
+    library_id: uuid.UUID,
+    *,
+    actor_user_id: uuid.UUID | None = None,
+) -> WishlistItem:
+    item = WishlistItem(
+        library_id=library_id,
+        created_by_user_id=actor_user_id,
+        title=payload.title,
+        author=payload.author,
+        isbn=payload.isbn,
+        note=payload.note,
+        cover_image_url=payload.cover_image_url,
+        publication_year=payload.publication_year,
+    )
+    session.add(item)
+    await session.commit()
+    await session.refresh(item)
+    logger.info(
+        "wishlist_item_created",
+        wishlist_item_id=str(item.id),
+        library_id=str(library_id),
+        actor_user_id=str(actor_user_id) if actor_user_id else None,
+    )
+    return item
+
+
+async def delete_wishlist_item(
+    session: AsyncSession, item_id: uuid.UUID, library_id: uuid.UUID
+) -> None:
+    """Delete a wish; 404 when it doesn't exist *in this library*."""
+    item = (
+        await session.execute(
+            select(WishlistItem).where(
+                WishlistItem.id == item_id, WishlistItem.library_id == library_id
+            )
+        )
+    ).scalar_one_or_none()
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Wishlist item not found"
+        )
+    await session.delete(item)
+    await session.commit()
+    logger.info(
+        "wishlist_item_deleted",
+        wishlist_item_id=str(item_id),
+        library_id=str(library_id),
+    )
+
+
+async def set_wishlist_enabled(
+    session: AsyncSession, library_id: uuid.UUID, enabled: bool
+) -> Library:
+    """Flip the per-library wishlist toggle. Caller must have verified OWNER."""
+    library = await session.get(Library, library_id)
+    if library is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Library not found")
+    library.wishlist_enabled = enabled
+    await session.commit()
+    await session.refresh(library)
+    logger.info(
+        "library_wishlist_toggled", library_id=str(library_id), enabled=enabled
+    )
+    return library

--- a/backend/tests/test_wishlist.py
+++ b/backend/tests/test_wishlist.py
@@ -1,0 +1,386 @@
+"""Wishlist tests (#309): CRUD, role gating, cross-library isolation,
+owner-only toggle, and the disabled-wishlist guard.
+
+Service-level tests run next to the API tests because the coverage gate
+undercounts ASGI-async paths (see AGENTS.md notes). Isolation follows the
+Test-DB contract: the "foreign" library is a real ``Library`` row (real
+``created_by_user_id``) — the caller just has no ``LibraryMember`` there.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+import os
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+from fastapi import HTTPException
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.user import User
+from app.schemas.wishlist import WishlistItemCreateRequest
+from app.services.wishlist import (
+    assert_wishlist_enabled,
+    create_wishlist_item,
+    delete_wishlist_item,
+    list_wishlist_items,
+    set_wishlist_enabled,
+)
+
+
+def _require_test_database_url() -> str:
+    return os.environ.get("TEST_DATABASE_URL", "sqlite+aiosqlite:///./test_wishlist.db")
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(_require_test_database_url())
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "manual", "pending", "done", "failed", "partial",
+                name="book_processing_status",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "unread", "reading", "read", "lent",
+                name="reading_status",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "owner", "editor", "viewer",
+                name="library_role",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(Base.metadata.drop_all)
+        await connection.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    yield session_factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url=_require_test_database_url(),
+        jwt_secret_key="test-secret",
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(
+    test_session: async_sessionmaker[AsyncSession], test_settings: Settings
+) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        async with test_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _create_user(session: AsyncSession, email: str, password: str = "secret") -> User:
+    user = User(email=email, hashed_password=get_password_hash(password))
+    session.add(user)
+    await session.flush()
+    await session.refresh(user)
+    return user
+
+
+async def _create_library(
+    session: AsyncSession, owner: User, name: str = "My Library"
+) -> Library:
+    lib = Library(name=name, created_by_user_id=owner.id)
+    session.add(lib)
+    await session.flush()
+    session.add(LibraryMember(library_id=lib.id, user_id=owner.id, role=LibraryRole.OWNER))
+    await session.commit()
+    await session.refresh(lib)
+    return lib
+
+
+async def _add_member(
+    session: AsyncSession, library: Library, user: User, role: LibraryRole
+) -> None:
+    session.add(LibraryMember(library_id=library.id, user_id=user.id, role=role))
+    await session.commit()
+
+
+async def _login(client: AsyncClient, email: str, password: str = "secret") -> dict[str, str]:
+    response = await client.post("/api/v1/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _client() -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+# ── Service-level tests ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_service_create_list_delete_roundtrip(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        lib = await _create_library(session, owner)
+
+        item = await create_wishlist_item(
+            session,
+            WishlistItemCreateRequest(
+                title="Duna",
+                author="Frank Herbert",
+                isbn="9780441172719",
+                note="Doporučila Alice",
+                cover_image_url="https://covers.openlibrary.org/b/id/11481354-L.jpg",
+                publication_year=1965,
+            ),
+            lib.id,
+            actor_user_id=owner.id,
+        )
+        assert item.created_by_user_id == owner.id
+
+        items, total = await list_wishlist_items(session, lib.id, page=1, page_size=20)
+        assert total == 1
+        assert items[0].title == "Duna"
+
+        await delete_wishlist_item(session, item.id, lib.id)
+        _, total = await list_wishlist_items(session, lib.id, page=1, page_size=20)
+        assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_service_delete_is_library_scoped(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """A wish in another library is invisible — delete raises 404, row survives."""
+    async with test_session() as session:
+        owner_a = await _create_user(session, "a@example.com")
+        owner_b = await _create_user(session, "b@example.com")
+        lib_a = await _create_library(session, owner_a, "Library A")
+        lib_b = await _create_library(session, owner_b, "Library B")
+
+        foreign_item = await create_wishlist_item(
+            session,
+            WishlistItemCreateRequest(title="Cizí přání"),
+            lib_b.id,
+            actor_user_id=owner_b.id,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await delete_wishlist_item(session, foreign_item.id, lib_a.id)
+        assert exc.value.status_code == 404
+
+        _, total_b = await list_wishlist_items(session, lib_b.id, page=1, page_size=20)
+        assert total_b == 1
+
+
+@pytest.mark.asyncio
+async def test_service_toggle_and_guard(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        lib = await _create_library(session, owner)
+
+        # Default ON (server_default=true) — the guard passes.
+        assert lib.wishlist_enabled is True
+        await assert_wishlist_enabled(session, lib.id)
+
+        library = await set_wishlist_enabled(session, lib.id, False)
+        assert library.wishlist_enabled is False
+        with pytest.raises(HTTPException) as exc:
+            await assert_wishlist_enabled(session, lib.id)
+        assert exc.value.status_code == 403
+
+        library = await set_wishlist_enabled(session, lib.id, True)
+        assert library.wishlist_enabled is True
+
+        with pytest.raises(HTTPException) as missing:
+            await set_wishlist_enabled(session, uuid.uuid4(), True)
+        assert missing.value.status_code == 404
+
+
+# ── API tests ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_editor_creates_and_deletes_wish_viewer_reads(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        editor = await _create_user(session, "editor@example.com")
+        viewer = await _create_user(session, "viewer@example.com")
+        lib = await _create_library(session, owner)
+        await _add_member(session, lib, editor, LibraryRole.EDITOR)
+        await _add_member(session, lib, viewer, LibraryRole.VIEWER)
+
+    async with _client() as client:
+        editor_headers = await _login(client, "editor@example.com")
+        viewer_headers = await _login(client, "viewer@example.com")
+        lib_header = {"X-Library-Id": str(lib.id)}
+
+        created = await client.post(
+            "/api/v1/wishlist",
+            json={"title": "Duna", "author": "Frank Herbert"},
+            headers={**editor_headers, **lib_header},
+        )
+        assert created.status_code == 201
+        item_id = created.json()["id"]
+
+        listed = await client.get(
+            "/api/v1/wishlist", headers={**viewer_headers, **lib_header}
+        )
+        assert listed.status_code == 200
+        body = listed.json()
+        assert body["total"] == 1
+        assert body["items"][0]["title"] == "Duna"
+
+        deleted = await client.delete(
+            f"/api/v1/wishlist/{item_id}", headers={**editor_headers, **lib_header}
+        )
+        assert deleted.status_code == 204
+
+        relisted = await client.get(
+            "/api/v1/wishlist", headers={**viewer_headers, **lib_header}
+        )
+        assert relisted.json()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_viewer_cannot_write_wishlist(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        viewer = await _create_user(session, "viewer@example.com")
+        lib = await _create_library(session, owner)
+        await _add_member(session, lib, viewer, LibraryRole.VIEWER)
+        item = await create_wishlist_item(
+            session, WishlistItemCreateRequest(title="Duna"), lib.id, actor_user_id=owner.id
+        )
+
+    async with _client() as client:
+        viewer_headers = await _login(client, "viewer@example.com")
+        lib_header = {"X-Library-Id": str(lib.id)}
+
+        created = await client.post(
+            "/api/v1/wishlist",
+            json={"title": "Nadace"},
+            headers={**viewer_headers, **lib_header},
+        )
+        assert created.status_code == 403
+
+        deleted = await client.delete(
+            f"/api/v1/wishlist/{item.id}", headers={**viewer_headers, **lib_header}
+        )
+        assert deleted.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_wishlist_isolated_between_libraries(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """Real foreign Library row, no LibraryMember for the caller (Test-DB contract)."""
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        stranger = await _create_user(session, "stranger@example.com")
+        lib = await _create_library(session, owner, "Mine")
+        foreign_lib = await _create_library(session, stranger, "Foreign")
+        await create_wishlist_item(
+            session, WishlistItemCreateRequest(title="Cizí přání"), foreign_lib.id,
+            actor_user_id=stranger.id,
+        )
+
+    async with _client() as client:
+        headers = await _login(client, "owner@example.com")
+
+        # Own library: empty.
+        mine = await client.get(
+            "/api/v1/wishlist", headers={**headers, "X-Library-Id": str(lib.id)}
+        )
+        assert mine.status_code == 200
+        assert mine.json()["total"] == 0
+
+        # Foreign library: 403 from the membership dependency.
+        foreign = await client.get(
+            "/api/v1/wishlist", headers={**headers, "X-Library-Id": str(foreign_lib.id)}
+        )
+        assert foreign.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_only_owner_toggles_wishlist_and_disabled_blocks_api(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        editor = await _create_user(session, "editor@example.com")
+        lib = await _create_library(session, owner)
+        await _add_member(session, lib, editor, LibraryRole.EDITOR)
+
+    async with _client() as client:
+        owner_headers = await _login(client, "owner@example.com")
+        editor_headers = await _login(client, "editor@example.com")
+        lib_header = {"X-Library-Id": str(lib.id)}
+
+        # Non-owner cannot flip the toggle.
+        forbidden = await client.patch(
+            f"/api/v1/libraries/{lib.id}",
+            json={"wishlist_enabled": False},
+            headers=editor_headers,
+        )
+        assert forbidden.status_code == 403
+
+        # Owner disables → payload reflects it and the wishlist API locks.
+        disabled = await client.patch(
+            f"/api/v1/libraries/{lib.id}",
+            json={"wishlist_enabled": False},
+            headers=owner_headers,
+        )
+        assert disabled.status_code == 200
+        assert disabled.json()["wishlist_enabled"] is False
+
+        blocked = await client.get(
+            "/api/v1/wishlist", headers={**owner_headers, **lib_header}
+        )
+        assert blocked.status_code == 403
+
+        blocked_post = await client.post(
+            "/api/v1/wishlist",
+            json={"title": "Duna"},
+            headers={**owner_headers, **lib_header},
+        )
+        assert blocked_post.status_code == 403
+
+        # Libraries payload carries the flag for the frontend nav.
+        libraries = await client.get("/api/v1/libraries", headers=owner_headers)
+        assert libraries.status_code == 200
+        assert libraries.json()[0]["wishlist_enabled"] is False
+
+        # Owner re-enables → wishlist works again.
+        enabled = await client.patch(
+            f"/api/v1/libraries/{lib.id}",
+            json={"wishlist_enabled": True},
+            headers=owner_headers,
+        )
+        assert enabled.status_code == 200
+        assert enabled.json()["wishlist_enabled"] is True
+
+        ok = await client.get("/api/v1/wishlist", headers={**owner_headers, **lib_header})
+        assert ok.status_code == 200

--- a/backend/tests/test_wishlist.py
+++ b/backend/tests/test_wishlist.py
@@ -121,6 +121,10 @@ async def _add_member(
 async def _login(client: AsyncClient, email: str, password: str = "secret") -> dict[str, str]:
     response = await client.post("/api/v1/auth/login", json={"email": email, "password": password})
     assert response.status_code == 200
+    # Clear cookies so the last login's cookie doesn't shadow earlier users'
+    # Bearer tokens (the auth dependency prefers cookie over the header) —
+    # same pattern as tests/test_isolation.py.
+    client.cookies.clear()
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2706,6 +2706,205 @@
         }
       }
     },
+    "/api/v1/wishlist": {
+      "get": {
+        "tags": [
+          "wishlist"
+        ],
+        "summary": "Read Wishlist",
+        "description": "List the active library's wishes (viewer+).",
+        "operationId": "read_wishlist_api_v1_wishlist_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Page Size"
+            }
+          },
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WishlistListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "wishlist"
+        ],
+        "summary": "Create Wish",
+        "description": "Add a wish (editor+).",
+        "operationId": "create_wish_api_v1_wishlist_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WishlistItemCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WishlistItemResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/wishlist/{item_id}": {
+      "delete": {
+        "tags": [
+          "wishlist"
+        ],
+        "summary": "Delete Wish",
+        "description": "Remove a wish (editor+).",
+        "operationId": "delete_wish_api_v1_wishlist__item_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Item Id"
+            }
+          },
+          {
+            "name": "X-Library-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Library-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/books/{book_id}/loans": {
       "post": {
         "tags": [
@@ -3816,6 +4015,65 @@
             "OAuth2PasswordBearer": []
           }
         ]
+      }
+    },
+    "/api/v1/libraries/{library_id}": {
+      "patch": {
+        "tags": [
+          "libraries"
+        ],
+        "summary": "Update Library",
+        "description": "Owner-only library settings — currently just the wishlist toggle (#309).",
+        "operationId": "update_library_api_v1_libraries__library_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "library_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Library Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateLibraryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/libraries/{library_id}/members": {
@@ -6584,6 +6842,11 @@
           },
           "role": {
             "$ref": "#/components/schemas/LibraryRole"
+          },
+          "wishlist_enabled": {
+            "type": "boolean",
+            "title": "Wishlist Enabled",
+            "default": true
           }
         },
         "type": "object",
@@ -7474,6 +7737,20 @@
         ],
         "title": "UpdateLibraryMemberRequest"
       },
+      "UpdateLibraryRequest": {
+        "properties": {
+          "wishlist_enabled": {
+            "type": "boolean",
+            "title": "Wishlist Enabled"
+          }
+        },
+        "type": "object",
+        "required": [
+          "wishlist_enabled"
+        ],
+        "title": "UpdateLibraryRequest",
+        "description": "Owner-only library settings (#309). Single field for now."
+      },
       "UploadResponse": {
         "properties": {
           "job_id": {
@@ -7637,6 +7914,225 @@
         ],
         "title": "WalletReadinessResponse",
         "description": "Diagnostic response for ``GET /api/v1/billing/wallet-readiness``.\n\nMirrors :class:`app.services.billing.WalletReadiness`. Surfaces every\nserver-side check that determines whether Stripe will render the Apple\nPay / Google Pay button on hosted Checkout. ``ok`` is True iff\n``warnings`` is empty."
+      },
+      "WishlistItemCreateRequest": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Title"
+          },
+          "author": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author"
+          },
+          "isbn": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 20,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isbn"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "cover_image_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Image Url"
+          },
+          "publication_year": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 9999.0,
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Publication Year"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "WishlistItemCreateRequest"
+      },
+      "WishlistItemResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "library_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Library Id"
+          },
+          "created_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By User Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author"
+          },
+          "isbn": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isbn"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "cover_image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Image Url"
+          },
+          "publication_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Publication Year"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "library_id",
+          "created_by_user_id",
+          "title",
+          "author",
+          "isbn",
+          "note",
+          "cover_image_url",
+          "publication_year",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "WishlistItemResponse"
+      },
+      "WishlistListResponse": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "page_size": {
+            "type": "integer",
+            "title": "Page Size"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/WishlistItemResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "page",
+          "page_size",
+          "items"
+        ],
+        "title": "WishlistListResponse"
       }
     },
     "securitySchemes": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { PricingPage } from './pages/PricingPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { BorrowersPage } from './pages/BorrowersPage'
 import { BorrowerDetailPage } from './pages/BorrowerDetailPage'
+import { WishlistPage } from './pages/WishlistPage'
 import { LandingPage } from './pages/LandingPage'
 import { OAuthCallbackPage } from './pages/OAuthCallbackPage'
 import { PrivacyPage } from './pages/PrivacyPage'
@@ -148,6 +149,7 @@ function AppShell() {
             <Route path={ROUTES.locations} element={<Navigate to={`${ROUTES.bookshelfView}?tab=locations`} replace />} />
             <Route path={ROUTES.borrowers} element={<BorrowersPage />} />
             <Route path={ROUTES.borrowerDetail} element={<BorrowerDetailPage />} />
+            <Route path={ROUTES.wishlist} element={<WishlistPage />} />
             <Route path={ROUTES.settings} element={<SettingsPage />} />
           </Route>
         </Routes>

--- a/frontend/src/components/Navigation.demo.test.tsx
+++ b/frontend/src/components/Navigation.demo.test.tsx
@@ -7,6 +7,7 @@
  * authenticated-only controls (settings, usage meter, logout). Borrowers IS
  * shown — the loan lifecycle is fully sandboxed client-side.
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
@@ -19,6 +20,9 @@ vi.mock('react-router-dom', async (orig) => {
   return { ...actual, useNavigate: () => navigateMock }
 })
 vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ logout: vi.fn() }) }))
+// The wishlist nav item (#309) reads the libraries payload; never fetched in
+// the demo (unauthenticated), but the hook still needs the module mocked.
+vi.mock('../lib/api', () => ({ listLibraries: vi.fn(() => Promise.resolve([])) }))
 // UsageMeterCard pulls plan usage from the API — never exercised in the demo,
 // stubbed so the authenticated-mode assertions don't need a QueryClient.
 vi.mock('./UsageMeterCard', () => ({ UsageMeterCard: () => null }))
@@ -26,10 +30,13 @@ vi.mock('./UsageMeterCard', () => ({ UsageMeterCard: () => null }))
 import { Navigation } from './Navigation'
 
 function renderAt(path: string): ReactNode {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Navigation />
-    </MemoryRouter>,
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[path]}>
+        <Navigation />
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 }
 

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -4,6 +4,8 @@ import { useLocation, useNavigate } from 'react-router-dom'
 
 import { ROUTES } from '../lib/routes'
 import { useAuth } from '../contexts/AuthContext'
+import { useLibraries } from '../hooks/useLibrary'
+import { useLibraryStore } from '../store/useLibraryStore'
 import { withDemoPrefix } from '../features/demo/demoNav'
 import { BookshelfInlineIcon } from './EmptyStateIcons'
 import { UsageMeterCard } from './UsageMeterCard'
@@ -75,6 +77,14 @@ function IconBorrowers({ size = 24 }: { size?: number }) {
   )
 }
 
+function IconWishlist({ size = 24 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+    </svg>
+  )
+}
+
 function IconSettings({ size = 24 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
@@ -115,6 +125,7 @@ const iconComponents = {
   bookshelf: IconBookshelf,
   locations: IconLocations,
   borrowers: IconBorrowers,
+  wishlist: IconWishlist,
   settings: IconSettings,
 }
 
@@ -141,6 +152,14 @@ export function Navigation() {
     [isDemo],
   )
 
+  /* Wishlist nav item (#309): shown only when the active library has the
+     feature enabled. Network-backed, so the demo never shows it. */
+  const activeLibraryId = useLibraryStore((s) => s.activeLibraryId)
+  const { data: libraries } = useLibraries()
+  const activeLibrary =
+    libraries?.find((lib) => lib.id === activeLibraryId) ?? libraries?.[0] ?? null
+  const showWishlist = !isDemo && (activeLibrary?.wishlist_enabled ?? false)
+
   /* Grouped sidebar items (desktop) */
   const navGroup = useMemo<NavItem[]>(
     () => [
@@ -161,8 +180,11 @@ export function Navigation() {
   const secondaryGroup = useMemo<NavItem[]>(
     () => [
       { label: t('nav.borrowers'), icon: 'borrowers', path: prefix(ROUTES.borrowers) },
+      ...(showWishlist
+        ? [{ label: t('nav.wishlist'), icon: 'wishlist' as const, path: ROUTES.wishlist }]
+        : []),
     ],
-    [t, prefix],
+    [t, prefix, showWishlist],
   )
 
   const settingsGroup = useMemo<NavItem[]>(
@@ -187,9 +209,12 @@ export function Navigation() {
             { label: t('nav.library'), icon: 'library', path: ROUTES.books },
             { label: t('nav.bookshelf'), icon: 'bookshelf', path: ROUTES.bookshelfView },
             { label: t('nav.borrowers'), icon: 'borrowers', path: ROUTES.borrowers },
+            ...(showWishlist
+              ? [{ label: t('nav.wishlist'), icon: 'wishlist' as const, path: ROUTES.wishlist }]
+              : []),
             { label: t('nav.settings'), icon: 'settings', path: ROUTES.settings },
           ],
-    [t, isDemo, prefix],
+    [t, isDemo, prefix, showWishlist],
   )
   const mobileSplit = Math.ceil(mobileTabs.length / 2)
 

--- a/frontend/src/components/Navigation.wishlist.test.tsx
+++ b/frontend/src/components/Navigation.wishlist.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Navigation — wishlist nav item (#309).
+ *
+ * The item follows the active library's ``wishlist_enabled`` flag: shown
+ * when on, gone when the owner turned the feature off, and never shown in
+ * the demo (network-backed feature).
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true, logout: vi.fn() }),
+}))
+vi.mock('./UsageMeterCard', () => ({ UsageMeterCard: () => null }))
+vi.mock('../lib/api', () => ({ listLibraries: vi.fn() }))
+vi.mock('../store/useLibraryStore', () => ({
+  useLibraryStore: vi.fn((selector: (s: { activeLibraryId: string | null }) => unknown) =>
+    selector({ activeLibraryId: 'lib-1' })),
+}))
+
+import { listLibraries } from '../lib/api'
+import type { Library } from '../lib/types'
+import { Navigation } from './Navigation'
+
+function makeLibrary(overrides: Partial<Library> = {}): Library {
+  return { id: 'lib-1', name: 'Test Library', role: 'owner', wishlist_enabled: true, ...overrides }
+}
+
+function renderAt(path: string): ReactNode {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[path]}>
+        <Navigation />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('Navigation — wishlist item (#309)', () => {
+  it('shows the wishlist item when the active library has it enabled', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary()])
+    renderAt('/books')
+
+    await waitFor(() => {
+      expect(screen.getAllByText('nav.wishlist').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('hides the wishlist item when the owner disabled it', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary({ wishlist_enabled: false })])
+    renderAt('/books')
+
+    // Wait for the libraries query to settle, then assert absence.
+    await waitFor(() => {
+      expect(listLibraries).toHaveBeenCalled()
+    })
+    expect(screen.queryByText('nav.wishlist')).not.toBeInTheDocument()
+  })
+
+  it('never shows the wishlist item in the demo', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary()])
+    renderAt('/demo/books')
+
+    expect(screen.queryByText('nav.wishlist')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/hooks/useWishlist.ts
+++ b/frontend/src/hooks/useWishlist.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { useAuth } from '../contexts/AuthContext'
+import {
+  createWishlistItem,
+  deleteWishlistItem,
+  listWishlist,
+  updateLibrary,
+} from '../lib/api'
+import type { UpdateLibraryRequest, WishlistItemCreateRequest } from '../lib/types'
+
+export function useWishlist(page: number, pageSize = 20, enabled = true) {
+  const { isAuthenticated } = useAuth()
+  return useQuery({
+    queryKey: ['wishlist', page, pageSize],
+    queryFn: () => listWishlist(page, pageSize),
+    enabled: isAuthenticated && enabled,
+  })
+}
+
+export function useCreateWishlistItem() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: WishlistItemCreateRequest) => createWishlistItem(payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['wishlist'] })
+    },
+  })
+}
+
+export function useDeleteWishlistItem() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (itemId: string) => deleteWishlistItem(itemId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['wishlist'] })
+    },
+  })
+}
+
+/** Owner-only wishlist toggle (#309). Refreshes the libraries payload so
+ *  the nav item and the /wishlist route react immediately. */
+export function useToggleWishlist(libraryId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: UpdateLibraryRequest) => updateLibrary(libraryId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['libraries'] })
+    },
+  })
+}

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -14,7 +14,8 @@
     "add_book": "Přidat knihu",
     "scan_shelf": "Skenovat polici",
     "actions": "Akce",
-    "logout": "Odhlásit"
+    "logout": "Odhlásit",
+    "wishlist": "Wishlist"
   },
   "toast": {
     "book_saved": "Změny uloženy.",
@@ -504,7 +505,11 @@
     "remove_error": "Odebrání člena selhalo.",
     "role_update_success": "Role aktualizována.",
     "role_update_error_400": "Nelze odebrat posledního vlastníka.",
-    "role_update_error": "Aktualizace role selhala."
+    "role_update_error": "Aktualizace role selhala.",
+    "wishlist_toggle_title": "Wishlist",
+    "wishlist_toggle_desc": "Členové knihovny mohou přidávat knihy, které chcete pořídit.",
+    "wishlist_toggle_success": "Nastavení wishlistu bylo uloženo.",
+    "wishlist_toggle_error": "Nastavení wishlistu se nepodařilo uložit."
   },
   "billing": {
     "section_title": "Plán & Využití",
@@ -836,5 +841,31 @@
     "nudge_text": "Líbí se vám to? Zaregistrujte se zdarma a knihovnu si uložte.",
     "nudge_cta": "Vyzkoušet zdarma",
     "nudge_dismiss": "Zavřít"
+  },
+  "wishlist": {
+    "title": "Wishlist",
+    "subtitle": "Knihy, které chce knihovna teprve pořídit.",
+    "form_label": "Přidat přání",
+    "title_label": "Název",
+    "title_placeholder": "např. Duna",
+    "author_label": "Autor",
+    "author_placeholder": "např. Frank Herbert",
+    "note_label": "Poznámka",
+    "note_placeholder": "např. doporučila Alice",
+    "add_button": "Přidat přání",
+    "adding": "Přidávám…",
+    "add_success": "Přání bylo přidáno.",
+    "add_error": "Nepodařilo se přidat přání.",
+    "delete_button": "Smazat",
+    "delete_label": "Smazat přání {{title}}",
+    "delete_success": "Přání bylo smazáno.",
+    "delete_error": "Nepodařilo se smazat přání.",
+    "loading": "Načítám wishlist…",
+    "empty": "Zatím tu nejsou žádná přání. Přidej první!",
+    "disabled_notice": "Wishlist je pro tuto knihovnu vypnutý.",
+    "pagination_label": "Stránkování wishlistu",
+    "prev_page": "Předchozí",
+    "next_page": "Další",
+    "page_indicator": "Strana {{page}} z {{total}}"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -14,7 +14,8 @@
     "add_book": "Add book",
     "scan_shelf": "Scan shelf",
     "actions": "Actions",
-    "logout": "Logout"
+    "logout": "Logout",
+    "wishlist": "Wishlist"
   },
   "toast": {
     "book_saved": "Changes saved successfully.",
@@ -576,7 +577,11 @@
     "remove_error": "Failed to remove member.",
     "role_update_success": "Role updated.",
     "role_update_error_400": "Cannot remove the last owner.",
-    "role_update_error": "Failed to update role."
+    "role_update_error": "Failed to update role.",
+    "wishlist_toggle_title": "Wishlist",
+    "wishlist_toggle_desc": "Library members can add books you'd like to acquire.",
+    "wishlist_toggle_success": "Wishlist setting saved.",
+    "wishlist_toggle_error": "Could not save the wishlist setting."
   },
   "billing": {
     "section_title": "Plan & Usage",
@@ -830,5 +835,31 @@
     "nudge_text": "Like it? Sign up free to keep your library.",
     "nudge_cta": "Sign up free",
     "nudge_dismiss": "Dismiss"
+  },
+  "wishlist": {
+    "title": "Wishlist",
+    "subtitle": "Books the library wants to acquire.",
+    "form_label": "Add a wish",
+    "title_label": "Title",
+    "title_placeholder": "e.g. Dune",
+    "author_label": "Author",
+    "author_placeholder": "e.g. Frank Herbert",
+    "note_label": "Note",
+    "note_placeholder": "e.g. recommended by Alice",
+    "add_button": "Add wish",
+    "adding": "Adding…",
+    "add_success": "Wish added.",
+    "add_error": "Could not add the wish.",
+    "delete_button": "Delete",
+    "delete_label": "Delete wish {{title}}",
+    "delete_success": "Wish deleted.",
+    "delete_error": "Could not delete the wish.",
+    "loading": "Loading wishlist…",
+    "empty": "No wishes yet. Add the first one!",
+    "disabled_notice": "The wishlist is disabled for this library.",
+    "pagination_label": "Wishlist pagination",
+    "prev_page": "Previous",
+    "next_page": "Next",
+    "page_indicator": "Page {{page}} of {{total}}"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -57,9 +57,13 @@ import type {
   ShelfScanResponse,
   ShelfScanResultResponse,
   TokenResponse,
+  UpdateLibraryRequest,
   UpdateMemberRoleRequest,
   UploadJobResponse,
   User,
+  WishlistItem,
+  WishlistItemCreateRequest,
+  WishlistListResponse,
 } from './types'
 
 export const ACTIVE_LIBRARY_ID_KEY = 'shelfy.activeLibraryId'
@@ -742,6 +746,27 @@ export async function resetOnboarding(): Promise<OnboardingStatus> {
 export async function listLibraries(): Promise<Library[]> {
   const response = await apiClient.get<Library[]>('/api/v1/libraries')
   return response.data
+}
+
+export async function updateLibrary(libraryId: string, payload: UpdateLibraryRequest): Promise<Library> {
+  const response = await apiClient.patch<Library>(`/api/v1/libraries/${libraryId}`, payload)
+  return response.data
+}
+
+export async function listWishlist(page = 1, pageSize = 20): Promise<WishlistListResponse> {
+  const response = await apiClient.get<WishlistListResponse>('/api/v1/wishlist', {
+    params: { page, page_size: pageSize },
+  })
+  return response.data
+}
+
+export async function createWishlistItem(payload: WishlistItemCreateRequest): Promise<WishlistItem> {
+  const response = await apiClient.post<WishlistItem>('/api/v1/wishlist', payload)
+  return response.data
+}
+
+export async function deleteWishlistItem(itemId: string): Promise<void> {
+  await apiClient.delete(`/api/v1/wishlist/${itemId}`)
 }
 
 export async function listLibraryMembers(libraryId: string): Promise<LibraryMember[]> {

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -10,6 +10,7 @@ export const ROUTES = {
   demo: '/demo',
   locations: '/locations',
   borrowers: '/borrowers',
+  wishlist: '/wishlist',
   borrowerDetail: '/borrowers/:borrowerId',
   settings: '/settings',
   pricing: '/pricing',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -410,6 +410,42 @@ export interface Library {
   id: string
   name: string
   role: LibraryRole
+  /** Per-library wishlist toggle (#309); drives the nav item + /wishlist route. */
+  wishlist_enabled: boolean
+}
+
+export interface UpdateLibraryRequest {
+  wishlist_enabled: boolean
+}
+
+export interface WishlistItem {
+  id: string
+  library_id: string
+  created_by_user_id: string | null
+  title: string
+  author: string | null
+  isbn: string | null
+  note: string | null
+  cover_image_url: string | null
+  publication_year: number | null
+  created_at: string
+  updated_at: string
+}
+
+export interface WishlistListResponse {
+  total: number
+  page: number
+  page_size: number
+  items: WishlistItem[]
+}
+
+export interface WishlistItemCreateRequest {
+  title: string
+  author?: string | null
+  isbn?: string | null
+  note?: string | null
+  cover_image_url?: string | null
+  publication_year?: number | null
 }
 
 export interface LibraryMember {

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -34,6 +34,10 @@ vi.mock('../lib/api', () => ({
   createPortalSession: vi.fn(),
   ACTIVE_LIBRARY_ID_KEY: 'shelfy.activeLibraryId',
   getActiveLibraryId: vi.fn(() => null),
+  updateLibrary: vi.fn(),
+  listWishlist: vi.fn(),
+  createWishlistItem: vi.fn(),
+  deleteWishlistItem: vi.fn(),
 }))
 
 const mockLogout = vi.fn()
@@ -70,8 +74,8 @@ import { useAuth } from '../contexts/AuthContext'
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
 const LIBRARIES = [
-  { id: 'lib-1', name: 'Home Library', role: 'owner' as const },
-  { id: 'lib-2', name: 'Work Library', role: 'viewer' as const },
+  { id: 'lib-1', name: 'Home Library', role: 'owner' as const, wishlist_enabled: true },
+  { id: 'lib-2', name: 'Work Library', role: 'viewer' as const, wishlist_enabled: true },
 ]
 
 const MEMBERS = [
@@ -473,5 +477,60 @@ describe('SettingsPage – library management', () => {
     expect(screen.queryByRole('form', { name: 'add-member-form' })).not.toBeInTheDocument()
     // No comboboxes (role selects) for non-owners
     expect(screen.queryByLabelText('role-select-user-other')).not.toBeInTheDocument()
+  })
+})
+
+// ── Tests: wishlist toggle (#309) ────────────────────────────────────────────
+
+describe('SettingsPage – wishlist toggle (#309)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    resetAuthMock()
+    // Earlier describes swap the store to lib-2 via mockImplementation, which
+    // clearAllMocks does NOT undo — pin the active library back to lib-1.
+    const { useLibraryStore } = await import('../store/useLibraryStore')
+    vi.mocked(useLibraryStore).mockImplementation(
+      (selector: (s: { activeLibraryId: string | null; setActiveLibraryId: (id: string | null) => void }) => unknown) =>
+        selector({ activeLibraryId: 'lib-1', setActiveLibraryId: mockSetActiveLibraryId }),
+    )
+    vi.mocked(listLibraries).mockResolvedValue(LIBRARIES)
+    vi.mocked(listLibraryMembers).mockResolvedValue(MEMBERS)
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows the toggle to the owner, reflecting wishlist_enabled', async () => {
+    renderWithProviders(<SettingsPage />)
+    const row = await screen.findByTestId('wishlist-toggle-row')
+    const checkbox = within(row).getByRole('checkbox')
+    expect(checkbox).toBeChecked()
+  })
+
+  it('calls updateLibrary when the owner flips the toggle', async () => {
+    const { updateLibrary } = await import('../lib/api')
+    vi.mocked(updateLibrary).mockResolvedValue({
+      id: 'lib-1', name: 'Home Library', role: 'owner', wishlist_enabled: false,
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPage />)
+
+    const row = await screen.findByTestId('wishlist-toggle-row')
+    await user.click(within(row).getByRole('checkbox'))
+
+    await waitFor(() => {
+      expect(updateLibrary).toHaveBeenCalledWith('lib-1', { wishlist_enabled: false })
+    })
+  })
+
+  it('hides the toggle from non-owners', async () => {
+    // Active library is lib-1 but the caller is only a viewer there.
+    vi.mocked(listLibraries).mockResolvedValue([
+      { id: 'lib-1', name: 'Home Library', role: 'viewer', wishlist_enabled: true },
+    ])
+    renderWithProviders(<SettingsPage />)
+    await screen.findByText('Home Library')
+    expect(screen.queryByTestId('wishlist-toggle-row')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ import { Modal } from '../components/Modal'
 import { useEnrichAll } from '../hooks/useEnrich'
 import { useBillingStatus, useCreateCheckout, useCreatePortal } from '../hooks/useBilling'
 import { useAddMember, useLibraries, useLibraryMembers, useRemoveMember, useUpdateMember } from '../hooks/useLibrary'
+import { useToggleWishlist } from '../hooks/useWishlist'
 import { useResetOnboarding } from '../hooks/useOnboarding'
 import { useToastStore } from '../lib/toast-store'
 import { trackEvent } from '../lib/analytics'
@@ -73,6 +74,17 @@ function LibraryManagement() {
   const addMemberMutation = useAddMember(activeLibraryId ?? '')
   const updateMemberMutation = useUpdateMember(activeLibraryId ?? '')
   const removeMemberMutation = useRemoveMember(activeLibraryId ?? '')
+  const toggleWishlistMutation = useToggleWishlist(activeLibraryId ?? '')
+
+  function handleWishlistToggle(enabled: boolean) {
+    toggleWishlistMutation.mutate(
+      { wishlist_enabled: enabled },
+      {
+        onSuccess: () => showSuccess(t('library.wishlist_toggle_success')),
+        onError: (err) => showError(formatApiError(err) || t('library.wishlist_toggle_error')),
+      },
+    )
+  }
 
   const [newEmail, setNewEmail] = useState('')
   const [newRole, setNewRole] = useState<LibraryRole>('viewer')
@@ -166,6 +178,28 @@ function LibraryManagement() {
               </div>
             )
           })}
+        </div>
+      )}
+
+      {/* Wishlist toggle (#309) — owners only; viewers/editors just follow
+          the flag via the nav item. */}
+      {activeLibrary && isOwner && (
+        <div className='stg-row' data-testid='wishlist-toggle-row' style={{ marginTop: 16 }}>
+          <div className='stg-row-label'>
+            <p className='stg-row-title'>{t('library.wishlist_toggle_title')}</p>
+            <p className='stg-row-desc'>{t('library.wishlist_toggle_desc')}</p>
+          </div>
+          <div className='stg-row-control'>
+            <label className='stg-toggle' aria-label='wishlist-toggle'>
+              <input
+                type='checkbox'
+                checked={activeLibrary.wishlist_enabled}
+                disabled={toggleWishlistMutation.isPending}
+                onChange={(e) => handleWishlistToggle(e.target.checked)}
+              />
+              <span className='stg-toggle-track' />
+            </label>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/WishlistPage.test.tsx
+++ b/frontend/src/pages/WishlistPage.test.tsx
@@ -1,0 +1,212 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true })),
+}))
+
+vi.mock('../store/useLibraryStore', () => ({
+  useLibraryStore: vi.fn((selector: (s: { activeLibraryId: string | null }) => unknown) =>
+    selector({ activeLibraryId: 'lib-1' })),
+}))
+
+vi.mock('../lib/api', () => ({
+  listLibraries: vi.fn(),
+  listWishlist: vi.fn(),
+  createWishlistItem: vi.fn(),
+  deleteWishlistItem: vi.fn(),
+  updateLibrary: vi.fn(),
+  suggestBooks: vi.fn(),
+}))
+
+import {
+  createWishlistItem,
+  deleteWishlistItem,
+  listLibraries,
+  listWishlist,
+  suggestBooks,
+} from '../lib/api'
+import type { Library, WishlistItem, WishlistListResponse } from '../lib/types'
+import { WishlistPage } from './WishlistPage'
+
+function makeLibrary(overrides: Partial<Library> = {}): Library {
+  return { id: 'lib-1', name: 'Test Library', role: 'owner', wishlist_enabled: true, ...overrides }
+}
+
+function makeItem(overrides: Partial<WishlistItem> = {}): WishlistItem {
+  return {
+    id: 'w1',
+    library_id: 'lib-1',
+    created_by_user_id: 'u1',
+    title: 'Duna',
+    author: 'Frank Herbert',
+    isbn: null,
+    note: null,
+    cover_image_url: null,
+    publication_year: 1965,
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makePage(items: WishlistItem[]): WishlistListResponse {
+  return { total: items.length, page: 1, page_size: 20, items }
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <WishlistPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('WishlistPage (#309)', () => {
+  it('renders wishes with title, author and year', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary()])
+    vi.mocked(listWishlist).mockResolvedValue(makePage([makeItem()]))
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wishlist-list')).toBeInTheDocument()
+    })
+    const row = screen.getByTestId('wishlist-item-w1')
+    expect(row).toHaveTextContent('Duna')
+    expect(row).toHaveTextContent('Frank Herbert')
+    expect(row).toHaveTextContent('1965')
+  })
+
+  it('shows the empty state when there are no wishes', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary()])
+    vi.mocked(listWishlist).mockResolvedValue(makePage([]))
+    renderPage()
+
+    expect(await screen.findByTestId('wishlist-empty')).toBeInTheDocument()
+  })
+
+  it('submits a new wish and clears the form', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary()])
+    vi.mocked(listWishlist).mockResolvedValue(makePage([]))
+    vi.mocked(createWishlistItem).mockResolvedValue(makeItem({ id: 'w2', title: 'Nadace' }))
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wishlist-form')).toBeInTheDocument()
+    })
+
+    const user = userEvent.setup()
+    await user.type(screen.getByTestId('wishlist-title-input'), 'Nadace')
+    await user.type(screen.getByTestId('wishlist-author-input'), 'Isaac Asimov')
+    await user.click(screen.getByTestId('wishlist-submit'))
+
+    await waitFor(() => {
+      expect(createWishlistItem).toHaveBeenCalledWith({
+        title: 'Nadace',
+        author: 'Isaac Asimov',
+        note: null,
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('wishlist-title-input')).toHaveValue('')
+    })
+  })
+
+  it('prefills from a catalogue suggestion and sends silent metadata (#308 reuse)', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary()])
+    vi.mocked(listWishlist).mockResolvedValue(makePage([]))
+    vi.mocked(suggestBooks).mockResolvedValue([
+      {
+        title: 'Duna',
+        author: 'Frank Herbert',
+        isbn: '9780441172719',
+        publisher: 'Ace Books',
+        language: 'eng',
+        publication_year: 1965,
+        cover_image_url: 'https://covers.openlibrary.org/b/id/11481354-L.jpg',
+        provider: 'open_library',
+      },
+    ])
+    vi.mocked(createWishlistItem).mockResolvedValue(makeItem())
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wishlist-form')).toBeInTheDocument()
+    })
+
+    const user = userEvent.setup()
+    await user.type(screen.getByTestId('wishlist-title-input'), 'dun')
+    await waitFor(() => {
+      expect(screen.getByTestId('wishlist-suggestion-0')).toBeInTheDocument()
+    })
+    await user.pointer([
+      { keys: '[MouseLeft>]', target: screen.getByTestId('wishlist-suggestion-0') },
+      { keys: '[/MouseLeft]' },
+    ])
+
+    expect(screen.getByTestId('wishlist-title-input')).toHaveValue('Duna')
+    expect(screen.getByTestId('wishlist-author-input')).toHaveValue('Frank Herbert')
+
+    await user.click(screen.getByTestId('wishlist-submit'))
+    await waitFor(() => {
+      expect(createWishlistItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Duna',
+          isbn: '9780441172719',
+          publication_year: 1965,
+          cover_image_url: 'https://covers.openlibrary.org/b/id/11481354-L.jpg',
+        }),
+      )
+    })
+  })
+
+  it('deletes a wish', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary()])
+    vi.mocked(listWishlist).mockResolvedValue(makePage([makeItem()]))
+    vi.mocked(deleteWishlistItem).mockResolvedValue(undefined)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wishlist-delete-w1')).toBeInTheDocument()
+    })
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('wishlist-delete-w1'))
+
+    await waitFor(() => {
+      expect(deleteWishlistItem).toHaveBeenCalledWith('w1')
+    })
+  })
+
+  it('hides the add form and delete buttons for viewers', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary({ role: 'viewer' })])
+    vi.mocked(listWishlist).mockResolvedValue(makePage([makeItem()]))
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wishlist-list')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('wishlist-form')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('wishlist-delete-w1')).not.toBeInTheDocument()
+  })
+
+  it('shows the disabled notice and skips fetching when wishlist is off', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary({ wishlist_enabled: false })])
+    vi.mocked(listWishlist).mockResolvedValue(makePage([]))
+    renderPage()
+
+    expect(await screen.findByTestId('wishlist-disabled')).toBeInTheDocument()
+    expect(screen.queryByTestId('wishlist-form')).not.toBeInTheDocument()
+    expect(listWishlist).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -1,0 +1,383 @@
+import { useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useLibraries } from '../hooks/useLibrary'
+import { useLibraryStore } from '../store/useLibraryStore'
+import { MIN_SUGGEST_QUERY_LENGTH, useBookSuggestions } from '../hooks/useBookSuggestions'
+import { useCreateWishlistItem, useDeleteWishlistItem, useWishlist } from '../hooks/useWishlist'
+import { useDebounce } from '../hooks/useDebounce'
+import { useToastStore } from '../lib/toast-store'
+import type { BookSuggestion, WishlistItemCreateRequest } from '../lib/types'
+
+const PAGE_SIZE = 20
+
+/** Metadata carried over silently from a picked suggestion (#308/#309). */
+type SuggestionMeta = Pick<
+  WishlistItemCreateRequest,
+  'isbn' | 'publication_year' | 'cover_image_url'
+>
+
+export function WishlistPage() {
+  const { t } = useTranslation()
+  const showError = useToastStore((s) => s.showError)
+  const showSuccess = useToastStore((s) => s.showSuccess)
+
+  const activeLibraryId = useLibraryStore((s) => s.activeLibraryId)
+  const { data: libraries } = useLibraries()
+  const activeLibrary =
+    libraries?.find((lib) => lib.id === activeLibraryId) ?? libraries?.[0] ?? null
+  const wishlistEnabled = activeLibrary?.wishlist_enabled ?? true
+  const canEdit = activeLibrary != null && activeLibrary.role !== 'viewer'
+
+  const [page, setPage] = useState(1)
+  // Wait for the libraries payload before fetching — otherwise a library
+  // with the wishlist disabled would fire one doomed (403) request during
+  // the first render, while wishlistEnabled still holds its default.
+  const wishlistQuery = useWishlist(page, PAGE_SIZE, libraries !== undefined && wishlistEnabled)
+  const createMutation = useCreateWishlistItem()
+  const deleteMutation = useDeleteWishlistItem()
+
+  const [title, setTitle] = useState('')
+  const [author, setAuthor] = useState('')
+  const [note, setNote] = useState('')
+
+  /* Catalogue autocomplete on the title field — reuses the #308 suggester. */
+  const [suggestOpen, setSuggestOpen] = useState(false)
+  const [activeSuggestion, setActiveSuggestion] = useState(-1)
+  const [suggestMeta, setSuggestMeta] = useState<SuggestionMeta | null>(null)
+  const debouncedTitle = useDebounce(title, 250)
+  const suggestionsQuery = useBookSuggestions(debouncedTitle, suggestOpen)
+  const suggestions = suggestionsQuery.data ?? []
+  const listboxVisible = suggestOpen && suggestions.length > 0
+
+  function handleTitleChange(e: ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value
+    setTitle(value)
+    setSuggestMeta(null)
+    setActiveSuggestion(-1)
+    setSuggestOpen(value.trim().length >= MIN_SUGGEST_QUERY_LENGTH)
+  }
+
+  function applySuggestion(suggestion: BookSuggestion) {
+    setTitle(suggestion.title)
+    setAuthor(suggestion.author ?? '')
+    setSuggestMeta({
+      isbn: suggestion.isbn,
+      publication_year: suggestion.publication_year,
+      cover_image_url: suggestion.cover_image_url,
+    })
+    setSuggestOpen(false)
+    setActiveSuggestion(-1)
+  }
+
+  function handleTitleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Escape') {
+      if (listboxVisible) {
+        e.preventDefault()
+        setSuggestOpen(false)
+        setActiveSuggestion(-1)
+      }
+      return
+    }
+    if (!listboxVisible) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveSuggestion((i) => (i + 1) % suggestions.length)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveSuggestion((i) => (i <= 0 ? suggestions.length - 1 : i - 1))
+    } else if (e.key === 'Enter') {
+      if (activeSuggestion >= 0 && activeSuggestion < suggestions.length) {
+        e.preventDefault()
+        applySuggestion(suggestions[activeSuggestion])
+      }
+    }
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!title.trim()) return
+    const payload: WishlistItemCreateRequest = {
+      title: title.trim(),
+      author: author.trim() || null,
+      note: note.trim() || null,
+      ...(suggestMeta ?? {}),
+    }
+    createMutation.mutate(payload, {
+      onSuccess: () => {
+        setTitle('')
+        setAuthor('')
+        setNote('')
+        setSuggestMeta(null)
+        showSuccess(t('wishlist.add_success'))
+      },
+      onError: () => showError(t('wishlist.add_error')),
+    })
+  }
+
+  function handleDelete(itemId: string) {
+    deleteMutation.mutate(itemId, {
+      onSuccess: () => showSuccess(t('wishlist.delete_success')),
+      onError: () => showError(t('wishlist.delete_error')),
+    })
+  }
+
+  const data = wishlistQuery.data
+  const items = data?.items ?? []
+  const total = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  return (
+    <main className="sh-main" style={{ padding: 24, maxWidth: 960, margin: '0 auto' }}>
+      <header style={{ marginBottom: 16 }}>
+        <h1 className="text-h2" style={{ margin: 0 }}>{t('wishlist.title')}</h1>
+        <p style={{ margin: '4px 0 0', color: 'var(--sh-text-muted)' }}>
+          {t('wishlist.subtitle')}
+        </p>
+      </header>
+
+      {!wishlistEnabled && (
+        <p data-testid="wishlist-disabled" style={{ color: 'var(--sh-text-muted)' }}>
+          {t('wishlist.disabled_notice')}
+        </p>
+      )}
+
+      {wishlistEnabled && canEdit && (
+        <form
+          onSubmit={handleSubmit}
+          aria-label={t('wishlist.form_label')}
+          data-testid="wishlist-form"
+          style={{
+            display: 'grid',
+            gap: 12,
+            marginBottom: 24,
+            padding: 16,
+            border: '1px solid var(--sh-border)',
+            borderRadius: 'var(--sh-radius-md)',
+            background: 'var(--sh-surface)',
+          }}
+        >
+          <div style={{ position: 'relative' }}>
+            <label id="wishlist-title-label" style={{ fontSize: 13, fontWeight: 600, display: 'block', marginBottom: 6 }}>
+              {t('wishlist.title_label')} <span style={{ color: 'var(--sh-red)' }}>*</span>
+            </label>
+            <input
+              className="sh-input"
+              placeholder={t('wishlist.title_placeholder')}
+              value={title}
+              onChange={handleTitleChange}
+              onKeyDown={handleTitleKeyDown}
+              onBlur={() => { setSuggestOpen(false); setActiveSuggestion(-1) }}
+              role="combobox"
+              aria-expanded={listboxVisible}
+              aria-controls="wishlist-title-suggestions"
+              aria-autocomplete="list"
+              aria-labelledby="wishlist-title-label"
+              aria-activedescendant={
+                listboxVisible && activeSuggestion >= 0
+                  ? `wishlist-suggestion-${activeSuggestion}`
+                  : undefined
+              }
+              data-testid="wishlist-title-input"
+              required
+            />
+            {listboxVisible && (
+              <ul
+                id="wishlist-title-suggestions"
+                role="listbox"
+                aria-label={t('add_book.suggestions_label')}
+                data-testid="wishlist-suggestions"
+                style={{
+                  position: 'absolute',
+                  top: '100%',
+                  left: 0,
+                  right: 0,
+                  zIndex: 30,
+                  margin: '4px 0 0',
+                  padding: 4,
+                  listStyle: 'none',
+                  maxHeight: 280,
+                  overflowY: 'auto',
+                  background: 'var(--sh-surface)',
+                  border: '1px solid var(--sh-border)',
+                  borderRadius: 'var(--sh-radius-md)',
+                  boxShadow: 'var(--sh-shadow-lg)',
+                }}
+              >
+                {suggestions.map((suggestion, index) => (
+                  <li
+                    key={`${suggestion.title}-${suggestion.isbn ?? index}`}
+                    id={`wishlist-suggestion-${index}`}
+                    role="option"
+                    aria-selected={index === activeSuggestion}
+                    data-testid={`wishlist-suggestion-${index}`}
+                    onMouseDown={(e) => { e.preventDefault(); applySuggestion(suggestion) }}
+                    onMouseEnter={() => setActiveSuggestion(index)}
+                    style={{
+                      padding: '8px 10px',
+                      borderRadius: 'var(--sh-radius-sm, 6px)',
+                      cursor: 'pointer',
+                      background: index === activeSuggestion ? 'var(--sh-teal-bg)' : 'transparent',
+                    }}
+                  >
+                    <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--sh-text-main)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {suggestion.title}
+                    </div>
+                    <div style={{ fontSize: 12, color: 'var(--sh-text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {[suggestion.author, suggestion.publication_year].filter(Boolean).join(' · ')}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="md-grid-2">
+            <div>
+              <label style={{ fontSize: 13, fontWeight: 600, display: 'block', marginBottom: 6 }}>
+                {t('wishlist.author_label')}
+              </label>
+              <input
+                className="sh-input"
+                placeholder={t('wishlist.author_placeholder')}
+                value={author}
+                onChange={(e) => setAuthor(e.target.value)}
+                data-testid="wishlist-author-input"
+              />
+            </div>
+            <div>
+              <label style={{ fontSize: 13, fontWeight: 600, display: 'block', marginBottom: 6 }}>
+                {t('wishlist.note_label')}
+              </label>
+              <input
+                className="sh-input"
+                placeholder={t('wishlist.note_placeholder')}
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                data-testid="wishlist-note-input"
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="sh-btn-primary"
+            disabled={createMutation.isPending || !title.trim()}
+            data-testid="wishlist-submit"
+            style={{ justifySelf: 'start' }}
+          >
+            {createMutation.isPending ? t('wishlist.adding') : t('wishlist.add_button')}
+          </button>
+        </form>
+      )}
+
+      {wishlistEnabled && wishlistQuery.isLoading && (
+        <p data-testid="wishlist-loading" style={{ color: 'var(--sh-text-muted)' }}>
+          {t('wishlist.loading')}
+        </p>
+      )}
+
+      {wishlistEnabled && data !== undefined && total === 0 && (
+        <p data-testid="wishlist-empty" style={{ color: 'var(--sh-text-muted)' }}>
+          {t('wishlist.empty')}
+        </p>
+      )}
+
+      {wishlistEnabled && items.length > 0 && (
+        <ul
+          data-testid="wishlist-list"
+          style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}
+        >
+          {items.map((item) => (
+            <li
+              key={item.id}
+              data-testid={`wishlist-item-${item.id}`}
+              className="sh-card"
+              style={{
+                display: 'flex',
+                gap: 12,
+                alignItems: 'center',
+                padding: 12,
+                border: '1px solid var(--sh-border)',
+                borderRadius: 'var(--sh-radius-md)',
+                background: 'var(--sh-surface)',
+              }}
+            >
+              {item.cover_image_url && (
+                <img
+                  src={item.cover_image_url}
+                  alt=""
+                  loading="lazy"
+                  style={{ width: 40, height: 56, objectFit: 'cover', borderRadius: 4, flexShrink: 0 }}
+                />
+              )}
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{ fontWeight: 600, fontSize: 15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {item.title}
+                  {item.publication_year && (
+                    <span style={{ marginLeft: 6, fontWeight: 400, fontSize: 12, color: 'var(--sh-text-muted)' }}>
+                      ({item.publication_year})
+                    </span>
+                  )}
+                </div>
+                {item.author && (
+                  <div style={{ fontSize: 13, color: 'var(--sh-text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {item.author}
+                  </div>
+                )}
+                {item.note && (
+                  <div style={{ fontSize: 12, color: 'var(--sh-text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {item.note}
+                  </div>
+                )}
+              </div>
+              {canEdit && (
+                <button
+                  type="button"
+                  className="sh-btn-secondary"
+                  data-testid={`wishlist-delete-${item.id}`}
+                  aria-label={t('wishlist.delete_label', { title: item.title })}
+                  disabled={deleteMutation.isPending}
+                  onClick={() => handleDelete(item.id)}
+                  style={{ fontSize: 12, color: 'var(--sh-red)', flexShrink: 0 }}
+                >
+                  {t('wishlist.delete_button')}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {wishlistEnabled && totalPages > 1 && (
+        <nav
+          aria-label={t('wishlist.pagination_label')}
+          data-testid="wishlist-paginator"
+          style={{ marginTop: 16, display: 'flex', gap: 8, justifyContent: 'center', alignItems: 'center' }}
+        >
+          <button
+            type="button"
+            className="sh-btn-secondary"
+            data-testid="wishlist-prev-page"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            {t('wishlist.prev_page')}
+          </button>
+          <span style={{ color: 'var(--sh-text-muted)', fontSize: 13 }}>
+            {t('wishlist.page_indicator', { page, total: totalPages })}
+          </span>
+          <button
+            type="button"
+            className="sh-btn-secondary"
+            data-testid="wishlist-next-page"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            {t('wishlist.next_page')}
+          </button>
+        </nav>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## Souhrn
**Backend**
- Tabulka `wishlist_items` — izolace přes `library_id` (FK CASCADE, index; vzor `borrowers`), `created_by_user_id` FK users **SET NULL** (smazání účtu nezahodí přání knihovny). Sloupec `libraries.wishlist_enabled` se `server_default=true` → stávající knihovny mají wishlist zapnutý bez backfillu. [Migrace](backend/alembic/versions/20260711_000025_add_wishlist.py).
- Router [/api/v1/wishlist](backend/app/api/wishlist.py) (thin, logika v [services/wishlist.py](backend/app/services/wishlist.py)): `GET` viewer+ (stránkování po vzoru borrowers), `POST` editor+, `DELETE /{id}` editor+; vše přes `get_library_id`/`require_editor_library`. Když owner wishlist vypne, všechny wishlist endpointy vrací **403** — frontend route schová, ale API nesmí tiše obsluhovat vypnutou funkci.
- `PATCH /api/v1/libraries/{id}` (**jen owner**) přepíná `wishlist_enabled`; flag se vrací v payloadu `GET /api/v1/libraries` i v PATCH odpovědi.

**Frontend**
- Route `/wishlist` + [WishlistPage](frontend/src/pages/WishlistPage.tsx): seznam s obálkami, přidání (znovupoužitý našeptávač z #308 — combobox, tichá metadata isbn/rok/obálka), mazání pro editor+; viewer jen čte. Dotaz čeká na payload knihoven, ať vypnutý wishlist nevystřelí jeden odsouzený request.
- Nav položka (srdíčko, Lucide-style) podmíněná `wishlist_enabled` aktivní knihovny; v demu se nikdy neukazuje.
- Settings: přepínač jen pro ownera (`stg-toggle` vzor), napojený na PATCH, invaliduje `['libraries']` → nav reaguje okamžitě.
- i18n cs/en, hooky `useWishlist`/`useToggleWishlist`.

## Testy
- Backend [test_wishlist.py](backend/tests/test_wishlist.py): service-level CRUD + toggle + guard (coverage gate), API: editor přidá/smaže + viewer čte, viewer nesmí psát (403), izolace mezi knihovnami (reálná cizí `Library` bez `LibraryMember` dle Test-DB contract), neowner nesmí přepnout, vypnutí blokuje API a flag jde v payloadu, default ON.
- Frontend: 7 testů WishlistPage (render/empty/submit/suggester prefill/delete/viewer/disabled), 3 testy nav viditelnosti (on/off/demo), 3 testy Settings přepínače (owner vidí+checked, PATCH volání, neowner nevidí). Celkem 279 frontend testů zelených, lint čistý.
- Navigation demo testy dostaly QueryClientProvider (Navigation teď čte libraries payload).

## OpenAPI
- ⚠️ `docs/openapi.yaml` doplním z CI drift-checku follow-up commitem (bez lokálního Python toolchainu — stejný postup jako u #315).

## Mimo rozsah (dle issue)
- Veřejná/anonymní wishlist stránka, notifikace, priority, propojení „přání → kniha“.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)