### PR TITLE
feat(wishlist): tlačítko Přidat — přání → kniha s výběrem lokace

### DIFF
--- a/frontend/src/components/WishlistAcquireModal.tsx
+++ b/frontend/src/components/WishlistAcquireModal.tsx
@@ -1,0 +1,188 @@
+import { useState, type FormEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useCreateBook } from '../hooks/useBooks'
+import { useLocations } from '../hooks/useLocations'
+import { useDeleteWishlistItem } from '../hooks/useWishlist'
+import { useToastStore } from '../lib/toast-store'
+import type { BookCreateRequest, ReadingStatus, WishlistItem } from '../lib/types'
+import { Modal } from './Modal'
+
+interface WishlistAcquireModalProps {
+  wish: WishlistItem
+  onClose: () => void
+}
+
+/**
+ * "Acquired" flow: turn a wish into a real book. Prefills the create
+ * payload from the wish (title/author editable; ISBN, year and cover ride
+ * along silently), lets the user pick a location + reading status, and on
+ * success removes the wish. Create and delete are two calls — if the wish
+ * removal fails the book already exists, so we surface a soft warning
+ * instead of rolling anything back.
+ */
+export function WishlistAcquireModal({ wish, onClose }: WishlistAcquireModalProps) {
+  const { t } = useTranslation()
+  const showError = useToastStore((s) => s.showError)
+  const showSuccess = useToastStore((s) => s.showSuccess)
+  const { data: locations = [] } = useLocations()
+  const createBookMutation = useCreateBook()
+  const deleteWishMutation = useDeleteWishlistItem()
+
+  const [title, setTitle] = useState(wish.title)
+  const [author, setAuthor] = useState(wish.author ?? '')
+  const [reading, setReading] = useState<ReadingStatus>('unread')
+
+  // Three-level location picker — same cascade as AddBookPage.
+  const [selRoom, setSelRoom] = useState('')
+  const [selFurniture, setSelFurniture] = useState('')
+  const [selShelf, setSelShelf] = useState('')
+
+  const rooms = [...new Set(locations.map((l) => l.room))]
+  const furnitures = [...new Set(locations.filter((l) => l.room === selRoom).map((l) => l.furniture))]
+  const shelves = [...new Set(locations.filter((l) => l.room === selRoom && l.furniture === selFurniture).map((l) => l.shelf))]
+  const resolvedId =
+    locations.find((l) => l.room === selRoom && l.furniture === selFurniture && l.shelf === selShelf)?.id ?? null
+
+  const isPending = createBookMutation.isPending || deleteWishMutation.isPending
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!title.trim()) return
+    const payload: BookCreateRequest = {
+      title: title.trim(),
+      author: author.trim() || null,
+      isbn: wish.isbn,
+      publication_year: wish.publication_year,
+      cover_image_url: wish.cover_image_url,
+      location_id: resolvedId,
+      reading_status: reading,
+    }
+    createBookMutation.mutate(payload, {
+      onSuccess: () => {
+        deleteWishMutation.mutate(wish.id, {
+          onSuccess: () => {
+            showSuccess(t('wishlist.acquire_success'))
+            onClose()
+          },
+          onError: () => {
+            // The book was created; only the wish cleanup failed.
+            showError(t('wishlist.acquire_cleanup_error'))
+            onClose()
+          },
+        })
+      },
+      onError: () => showError(t('wishlist.acquire_error')),
+    })
+  }
+
+  const fieldLabelStyle = {
+    fontSize: 13,
+    fontWeight: 600,
+    color: 'var(--sh-text-main)',
+    display: 'block',
+    marginBottom: 6,
+  } as const
+
+  return (
+    <Modal open onClose={onClose} label={t('wishlist.acquire_title')} size="md">
+      <h3 className="text-h3" style={{ marginTop: 0 }}>{t('wishlist.acquire_title')}</h3>
+      <p className="text-p" style={{ marginTop: 4, marginBottom: 16, color: 'var(--sh-text-muted)' }}>
+        {t('wishlist.acquire_subtitle')}
+      </p>
+
+      <form onSubmit={handleSubmit} data-testid="wishlist-acquire-form" style={{ display: 'grid', gap: 14 }}>
+        <div>
+          <label style={fieldLabelStyle}>
+            {t('wishlist.title_label')} <span style={{ color: 'var(--sh-red)' }}>*</span>
+          </label>
+          <input
+            className="sh-input"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            data-testid="acquire-title-input"
+            required
+          />
+        </div>
+
+        <div>
+          <label style={fieldLabelStyle}>{t('wishlist.author_label')}</label>
+          <input
+            className="sh-input"
+            value={author}
+            onChange={(e) => setAuthor(e.target.value)}
+            data-testid="acquire-author-input"
+          />
+        </div>
+
+        <div>
+          <label style={fieldLabelStyle}>
+            {t('add_book.location_label')}{' '}
+            <span style={{ color: 'var(--sh-text-muted)', fontWeight: 400 }}>
+              ({t('add_book.location_optional')})
+            </span>
+          </label>
+          <div className="sh-location-grid">
+            <select
+              className="sh-select"
+              value={selRoom}
+              aria-label={t('add_book.room_label')}
+              onChange={(e) => { setSelRoom(e.target.value); setSelFurniture(''); setSelShelf('') }}
+            >
+              <option value="">{t('add_book.no_room_option')}</option>
+              {rooms.map((r) => <option key={r} value={r}>{r}</option>)}
+            </select>
+            <select
+              className="sh-select"
+              value={selFurniture}
+              aria-label={t('add_book.furniture_label')}
+              disabled={!selRoom}
+              onChange={(e) => { setSelFurniture(e.target.value); setSelShelf('') }}
+            >
+              <option value="">{t('add_book.no_furniture_option')}</option>
+              {furnitures.map((f) => <option key={f} value={f}>{f}</option>)}
+            </select>
+            <select
+              className="sh-select"
+              value={selShelf}
+              aria-label={t('add_book.shelf_label')}
+              disabled={!selFurniture}
+              onChange={(e) => setSelShelf(e.target.value)}
+            >
+              <option value="">{t('add_book.no_shelf_option')}</option>
+              {shelves.map((s) => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label style={fieldLabelStyle}>{t('add_book.status_label')}</label>
+          <select
+            className="sh-select"
+            value={reading}
+            aria-label={t('add_book.status_label')}
+            onChange={(e) => setReading(e.target.value as ReadingStatus)}
+          >
+            <option value="unread">{t('reading_status.unread')}</option>
+            <option value="reading">{t('reading_status.reading')}</option>
+            <option value="read">{t('reading_status.read')}</option>
+          </select>
+        </div>
+
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'flex-end', marginTop: 4 }}>
+          <button type="button" className="sh-btn-secondary" onClick={onClose} disabled={isPending}>
+            {t('common.cancel')}
+          </button>
+          <button
+            type="submit"
+            className="sh-btn-primary"
+            data-testid="acquire-submit"
+            disabled={isPending || !title.trim()}
+          >
+            {isPending ? t('wishlist.acquiring') : t('wishlist.acquire_submit')}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -866,6 +866,15 @@
     "pagination_label": "Stránkování wishlistu",
     "prev_page": "Předchozí",
     "next_page": "Další",
-    "page_indicator": "Strana {{page}} z {{total}}"
+    "page_indicator": "Strana {{page}} z {{total}}",
+    "acquire_button": "Přidat",
+    "acquire_label": "Přidat {{title}} do knihovny",
+    "acquire_title": "Přidat do knihovny",
+    "acquire_subtitle": "Kniha se přidá do knihovny a přání se odškrtne z wishlistu.",
+    "acquire_submit": "Přidat do knihovny",
+    "acquiring": "Přidávám…",
+    "acquire_success": "Kniha byla přidána do knihovny a přání odebráno.",
+    "acquire_error": "Nepodařilo se přidat knihu do knihovny.",
+    "acquire_cleanup_error": "Kniha byla přidána, ale přání se nepodařilo odebrat z wishlistu."
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -860,6 +860,15 @@
     "pagination_label": "Wishlist pagination",
     "prev_page": "Previous",
     "next_page": "Next",
-    "page_indicator": "Page {{page}} of {{total}}"
+    "page_indicator": "Page {{page}} of {{total}}",
+    "acquire_button": "Add",
+    "acquire_label": "Add {{title}} to the library",
+    "acquire_title": "Add to library",
+    "acquire_subtitle": "The book is added to the library and the wish is checked off the wishlist.",
+    "acquire_submit": "Add to library",
+    "acquiring": "Adding…",
+    "acquire_success": "Book added to the library and the wish removed.",
+    "acquire_error": "Could not add the book to the library.",
+    "acquire_cleanup_error": "The book was added, but the wish could not be removed from the wishlist."
   }
 }

--- a/frontend/src/pages/WishlistPage.test.tsx
+++ b/frontend/src/pages/WishlistPage.test.tsx
@@ -22,6 +22,20 @@ vi.mock('../lib/api', () => ({
   suggestBooks: vi.fn(),
 }))
 
+// The acquire modal creates the book through the shared hooks — mocked so
+// this suite doesn't have to re-enumerate the whole books API surface.
+const mockCreateBookMutate = vi.fn()
+vi.mock('../hooks/useBooks', () => ({
+  useCreateBook: () => ({ mutate: mockCreateBookMutate, isPending: false }),
+}))
+vi.mock('../hooks/useLocations', () => ({
+  useLocations: () => ({
+    data: [
+      { id: 'loc-1', room: 'Obývák', furniture: 'Knihovna', shelf: 'Police 1' },
+    ],
+  }),
+}))
+
 import {
   createWishlistItem,
   deleteWishlistItem,
@@ -198,6 +212,78 @@ describe('WishlistPage (#309)', () => {
     })
     expect(screen.queryByTestId('wishlist-form')).not.toBeInTheDocument()
     expect(screen.queryByTestId('wishlist-delete-w1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('wishlist-acquire-w1')).not.toBeInTheDocument()
+  })
+
+  it('acquires a wish: modal prefills, creates the book with silent metadata and removes the wish', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary()])
+    vi.mocked(listWishlist).mockResolvedValue(makePage([
+      makeItem({
+        isbn: '9780441172719',
+        cover_image_url: 'https://covers.openlibrary.org/b/id/11481354-L.jpg',
+      }),
+    ]))
+    vi.mocked(deleteWishlistItem).mockResolvedValue(undefined)
+    // Simulate a successful create so the modal proceeds to the wish cleanup.
+    mockCreateBookMutate.mockImplementation(
+      (_payload: unknown, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.(),
+    )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wishlist-acquire-w1')).toBeInTheDocument()
+    })
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('wishlist-acquire-w1'))
+
+    // Modal prefilled from the wish.
+    expect(screen.getByTestId('acquire-title-input')).toHaveValue('Duna')
+    expect(screen.getByTestId('acquire-author-input')).toHaveValue('Frank Herbert')
+
+    // Pick a location through the cascade.
+    await user.selectOptions(screen.getByLabelText('add_book.room_label'), 'Obývák')
+    await user.selectOptions(screen.getByLabelText('add_book.furniture_label'), 'Knihovna')
+    await user.selectOptions(screen.getByLabelText('add_book.shelf_label'), 'Police 1')
+
+    await user.click(screen.getByTestId('acquire-submit'))
+
+    expect(mockCreateBookMutate).toHaveBeenCalledTimes(1)
+    expect(mockCreateBookMutate.mock.calls[0][0]).toMatchObject({
+      title: 'Duna',
+      author: 'Frank Herbert',
+      isbn: '9780441172719',
+      publication_year: 1965,
+      cover_image_url: 'https://covers.openlibrary.org/b/id/11481354-L.jpg',
+      location_id: 'loc-1',
+      reading_status: 'unread',
+    })
+    await waitFor(() => {
+      expect(deleteWishlistItem).toHaveBeenCalledWith('w1')
+    })
+    // Modal closes after the flow completes.
+    await waitFor(() => {
+      expect(screen.queryByTestId('wishlist-acquire-form')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not remove the wish when creating the book fails', async () => {
+    vi.mocked(listLibraries).mockResolvedValue([makeLibrary()])
+    vi.mocked(listWishlist).mockResolvedValue(makePage([makeItem()]))
+    mockCreateBookMutate.mockImplementation(
+      (_payload: unknown, opts?: { onError?: () => void }) => opts?.onError?.(),
+    )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wishlist-acquire-w1')).toBeInTheDocument()
+    })
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('wishlist-acquire-w1'))
+    await user.click(screen.getByTestId('acquire-submit'))
+
+    expect(deleteWishlistItem).not.toHaveBeenCalled()
+    // Modal stays open for a retry.
+    expect(screen.getByTestId('wishlist-acquire-form')).toBeInTheDocument()
   })
 
   it('shows the disabled notice and skips fetching when wishlist is off', async () => {

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -1,13 +1,14 @@
 import { useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { WishlistAcquireModal } from '../components/WishlistAcquireModal'
 import { useLibraries } from '../hooks/useLibrary'
 import { useLibraryStore } from '../store/useLibraryStore'
 import { MIN_SUGGEST_QUERY_LENGTH, useBookSuggestions } from '../hooks/useBookSuggestions'
 import { useCreateWishlistItem, useDeleteWishlistItem, useWishlist } from '../hooks/useWishlist'
 import { useDebounce } from '../hooks/useDebounce'
 import { useToastStore } from '../lib/toast-store'
-import type { BookSuggestion, WishlistItemCreateRequest } from '../lib/types'
+import type { BookSuggestion, WishlistItem, WishlistItemCreateRequest } from '../lib/types'
 
 const PAGE_SIZE = 20
 
@@ -40,6 +41,9 @@ export function WishlistPage() {
   const [title, setTitle] = useState('')
   const [author, setAuthor] = useState('')
   const [note, setNote] = useState('')
+
+  /* "Acquired" flow: wish → real book with a location (modal). */
+  const [acquireWish, setAcquireWish] = useState<WishlistItem | null>(null)
 
   /* Catalogue autocomplete on the title field — reuses the #308 suggester. */
   const [suggestOpen, setSuggestOpen] = useState(false)
@@ -332,21 +336,37 @@ export function WishlistPage() {
                 )}
               </div>
               {canEdit && (
-                <button
-                  type="button"
-                  className="sh-btn-secondary"
-                  data-testid={`wishlist-delete-${item.id}`}
-                  aria-label={t('wishlist.delete_label', { title: item.title })}
-                  disabled={deleteMutation.isPending}
-                  onClick={() => handleDelete(item.id)}
-                  style={{ fontSize: 12, color: 'var(--sh-red)', flexShrink: 0 }}
-                >
-                  {t('wishlist.delete_button')}
-                </button>
+                <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+                  <button
+                    type="button"
+                    className="sh-btn-primary"
+                    data-testid={`wishlist-acquire-${item.id}`}
+                    aria-label={t('wishlist.acquire_label', { title: item.title })}
+                    onClick={() => setAcquireWish(item)}
+                    style={{ fontSize: 12 }}
+                  >
+                    {t('wishlist.acquire_button')}
+                  </button>
+                  <button
+                    type="button"
+                    className="sh-btn-secondary"
+                    data-testid={`wishlist-delete-${item.id}`}
+                    aria-label={t('wishlist.delete_label', { title: item.title })}
+                    disabled={deleteMutation.isPending}
+                    onClick={() => handleDelete(item.id)}
+                    style={{ fontSize: 12, color: 'var(--sh-red)' }}
+                  >
+                    {t('wishlist.delete_button')}
+                  </button>
+                </div>
               )}
             </li>
           ))}
         </ul>
+      )}
+
+      {acquireWish && (
+        <WishlistAcquireModal wish={acquireWish} onClose={() => setAcquireWish(null)} />
       )}
 
       {wishlistEnabled && totalPages > 1 && (


### PR DESCRIPTION
## Souhrn
Follow-up k #309 na přání Patrika: u každého přání ve wishlistu přibylo vedle **Smazat** tlačítko **Přidat**.

- Otevře modal ([WishlistAcquireModal](frontend/src/components/WishlistAcquireModal.tsx)) předvyplněný z přání — název a autor editovatelné, ISBN/rok/obálka se přenesou tiše.
- Výběr **lokace** stejnou třístupňovou kaskádou (místnost → knihovna → police) jako na AddBookPage, volitelně stav čtení (default nepřečteno).
- Potvrzení vytvoří knihu přes existující `POST /api/v1/books` (plan limity hlídá backend) a **přání se z wishlistu odebere**. Když selže jen úklid přání, kniha zůstává a zobrazí se měkké varování — nic se neroluje zpět.
- Tlačítko jen pro editor+ (stejně jako mazání); žádná změna backendu ani OpenAPI.

## Testy
- 2 nové testy: celý flow (prefill → lokace → createBook s tichými metadaty + location_id → delete přání → zavření modalu) a selhání create (přání zůstává, modal otevřený pro retry). Viewer test rozšířen o absenci tlačítka.
- `npm run lint` ✅, `npm test -- --run` ✅ (281 testů).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Acquire” action for wishlist items.
  * Users can edit the book’s title and author, choose a reading status, and assign a room, furniture, and shelf location.
  * Successfully acquired items are added to the library and removed from the wishlist.
  * Added success, error, and warning notifications, including retry support when acquisition fails.

* **Bug Fixes**
  * Acquisition controls are hidden for viewers without permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->