### PR TITLE
fix(db): 500 při přidání člena — expire_on_commit u AsyncSession

### DIFF
--- a/backend/app/api/libraries.py
+++ b/backend/app/api/libraries.py
@@ -115,24 +115,32 @@ async def create_member(
     # internally for that reason.
     await entitlements.assert_can_add_member(session, current_user.id, library_id, lock=True)
     member, created = await add_member(session, library_id, str(payload.email), payload.role)
+    # Capture scalars BEFORE the commit: if the session ever expires
+    # instances on commit again, a plain attribute access afterwards would
+    # lazy-load synchronously and crash with MissingGreenlet (prod 500 on
+    # this endpoint — the member row was committed, the response wasn't).
+    member_user_id = member.user_id
+    member_role = member.role
+    inviter_id = current_user.id
+    inviter_email = current_user.email
     await session.commit()
-    user = await session.get(User, member.user_id)
+    user = await session.get(User, member_user_id)
     assert user is not None
     # Notify the added user — fire-and-forget after the commit, mirroring the
     # welcome email in ``register`` (#312). Only on the first add: role
     # upserts stay silent, and owners adding themselves don't get mail.
-    if created and member.user_id != current_user.id:
+    if created and member_user_id != inviter_id:
         library = await session.get(Library, library_id)
         assert library is not None
         background_tasks.add_task(
             email_svc.send_added_to_library,
             user.email,
             library.name,
-            member.role.value,
-            current_user.email,
+            member_role.value,
+            inviter_email,
             locale=email_locale_from_request(request),
         )
-    return LibraryMemberResponse(user_id=member.user_id, email=user.email, role=member.role)
+    return LibraryMemberResponse(user_id=member_user_id, email=user.email, role=member_role)
 
 
 @router.patch("/{library_id}/members/{user_id}", response_model=LibraryMemberResponse)

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -22,7 +22,20 @@ if not settings.database_url.startswith("sqlite"):
     )
 
 engine = create_async_engine(settings.database_url, **_engine_kwargs)
-SessionLocal = async_sessionmaker(bind=engine, autocommit=False, autoflush=False, class_=AsyncSession)
+# expire_on_commit=False is mandatory with AsyncSession: with the default
+# (True) every ORM instance expires at commit, and any later attribute
+# access triggers a *synchronous* lazy refresh that dies with
+# MissingGreenlet inside async endpoints. This bit prod on
+# POST /libraries/{id}/members (500 after the member was committed) —
+# tests never caught it because every test fixture already builds its
+# sessionmaker with expire_on_commit=False.
+SessionLocal = async_sessionmaker(
+    bind=engine,
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False,
+    class_=AsyncSession,
+)
 
 
 async def get_db_session() -> AsyncGenerator[AsyncSession, None]:

--- a/backend/tests/test_library_member_email.py
+++ b/backend/tests/test_library_member_email.py
@@ -197,3 +197,49 @@ async def test_owner_adding_self_does_not_schedule_email(
 
     assert response.status_code == 200
     send_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_member_survives_expire_on_commit_sessions(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """Regression for the prod 500 (MissingGreenlet) on member add.
+
+    The app's real ``SessionLocal`` used to expire ORM instances on commit;
+    ``create_member`` then touched ``member.user_id`` after ``commit()``,
+    which lazy-loads synchronously and explodes inside the async endpoint
+    (the member row was already committed — user saw the member appear AND
+    a 500 toast). Test fixtures all use ``expire_on_commit=False``, so this
+    override reproduces the production semantics explicitly.
+    """
+    engine = test_session.kw["bind"]
+    strict_factory = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=True
+    )
+
+    async def _strict_db() -> AsyncIterator[AsyncSession]:
+        async with strict_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db_session] = _strict_db
+
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        await _create_user(session, "member@example.com")
+        lib = await _create_library_with_owner(session, owner, "Rodinná knihovna")
+        await _give_plan(session, owner, SubscriptionPlan.pro)
+        await session.commit()
+
+    send_mock = AsyncMock()
+    with patch("app.api.libraries.email_svc.send_added_to_library", send_mock):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            headers = await _login(client, "owner@example.com")
+            response = await client.post(
+                f"/api/v1/libraries/{lib.id}/members",
+                json={"email": "member@example.com", "role": "viewer"},
+                headers=headers,
+            )
+
+    assert response.status_code == 200
+    assert response.json()["role"] == "viewer"
+    send_mock.assert_awaited_once()


### PR DESCRIPTION
## Co se stalo
Patrik přidal člena do knihovny → člen se uložil, ale odpověď skončila **500** (toast „Request failed with status code 500").

Traceback z prod: `sqlalchemy.exc.MissingGreenlet` na řádku `user = await session.get(User, member.user_id)` v `create_member`. Příčina: aplikační `SessionLocal` neměl `expire_on_commit=False`, takže **commit expiroval všechny ORM instance** a následný přístup na `member.user_id` spustil synchronní lazy-load uvnitř async endpointu → MissingGreenlet. Commit už proběhl, proto se člen v seznamu objevil a jen odpověď spadla.

**Proč to CI nechytilo:** všechny test fixtures si staví sessionmaker s `expire_on_commit=False`, takže testy běžely s jinou sémantikou než prod. Latentní bug — pattern „commit → atribut" byl v `create_member` už před #312.

## Fix (dvě úrovně)
- [session.py](backend/app/db/session.py): `SessionLocal` nyní `expire_on_commit=False` — doporučená konfigurace pro AsyncSession; zabíjí celou třídu těchto chyb ve všech endpointech a srovnává prod s testy.
- [libraries.py](backend/app/api/libraries.py): `create_member` si skaláry (`member.user_id`, role, inviter id/e-mail) bere **před commitem** — endpoint je bezpečný bez ohledu na konfiguraci session.

## Test
- Regresní test v `test_library_member_email.py` explicitně přepne `get_db_session` na sessionmaker s `expire_on_commit=True` (= prod sémantika před fixem) a ověří, že POST members vrátí 200 a naplánuje e-mail.

## Dopad na Šárku
500 nastal **před** naplánováním e-mailu → notifikace jí neodešla; členství ale vzniklo. Pokud má dostat uvítací e-mail do knihovny, stačí ji po nasazení odebrat a přidat znovu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)