### PR TITLE
feat(frontend): založení nové knihovny v Nastavení

### DIFF
--- a/frontend/src/hooks/useLibrary.ts
+++ b/frontend/src/hooks/useLibrary.ts
@@ -2,13 +2,14 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import {
   addLibraryMember,
+  createLibrary,
   listLibraries,
   listLibraryMembers,
   removeLibraryMember,
   updateLibraryMember,
 } from '../lib/api'
 import { useAuth } from '../contexts/AuthContext'
-import type { AddMemberRequest, LibraryRole } from '../lib/types'
+import type { AddMemberRequest, CreateLibraryRequest, LibraryRole } from '../lib/types'
 
 export function useLibraries() {
   const { isAuthenticated } = useAuth()
@@ -16,6 +17,16 @@ export function useLibraries() {
     queryKey: ['libraries'],
     queryFn: listLibraries,
     enabled: isAuthenticated,
+  })
+}
+
+export function useCreateLibrary() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: CreateLibraryRequest) => createLibrary(payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['libraries'] })
+    },
   })
 }
 

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -509,7 +509,15 @@
     "wishlist_toggle_title": "Wishlist",
     "wishlist_toggle_desc": "Členové knihovny mohou přidávat knihy, které chcete pořídit.",
     "wishlist_toggle_success": "Nastavení wishlistu bylo uloženo.",
-    "wishlist_toggle_error": "Nastavení wishlistu se nepodařilo uložit."
+    "wishlist_toggle_error": "Nastavení wishlistu se nepodařilo uložit.",
+    "create_button": "+ Nová knihovna",
+    "create_name_label": "Název knihovny",
+    "create_name_placeholder": "např. Chata",
+    "create_submit": "Vytvořit",
+    "creating": "Vytvářím…",
+    "create_success": "Knihovna byla vytvořena a přepnuta jako aktivní.",
+    "create_error": "Knihovnu se nepodařilo vytvořit.",
+    "create_error_403": "Dosáhl jsi limitu knihoven svého tarifu. Vyšší tarif umožní více knihoven — mrkni do Nastavení → Předplatné."
   },
   "billing": {
     "section_title": "Plán & Využití",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -581,7 +581,15 @@
     "wishlist_toggle_title": "Wishlist",
     "wishlist_toggle_desc": "Library members can add books you'd like to acquire.",
     "wishlist_toggle_success": "Wishlist setting saved.",
-    "wishlist_toggle_error": "Could not save the wishlist setting."
+    "wishlist_toggle_error": "Could not save the wishlist setting.",
+    "create_button": "+ New library",
+    "create_name_label": "Library name",
+    "create_name_placeholder": "e.g. Cottage",
+    "create_submit": "Create",
+    "creating": "Creating…",
+    "create_success": "Library created and set as active.",
+    "create_error": "Could not create the library.",
+    "create_error_403": "You've reached your plan's library limit. Upgrade to create more — see Settings → Billing."
   },
   "billing": {
     "section_title": "Plan & Usage",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   BorrowerMergeResult,
   BorrowerUpdateRequest,
   CheckoutResponse,
+  CreateLibraryRequest,
   CsvImportConfirmRequest,
   CsvImportConfirmResponse,
   CsvImportPreviewResponse,
@@ -745,6 +746,11 @@ export async function resetOnboarding(): Promise<OnboardingStatus> {
 // Libraries
 export async function listLibraries(): Promise<Library[]> {
   const response = await apiClient.get<Library[]>('/api/v1/libraries')
+  return response.data
+}
+
+export async function createLibrary(payload: CreateLibraryRequest): Promise<Library> {
+  const response = await apiClient.post<Library>('/api/v1/libraries', payload)
   return response.data
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -418,6 +418,10 @@ export interface UpdateLibraryRequest {
   wishlist_enabled: boolean
 }
 
+export interface CreateLibraryRequest {
+  name: string
+}
+
 export interface WishlistItem {
   id: string
   library_id: string

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../lib/api', () => ({
   listWishlist: vi.fn(),
   createWishlistItem: vi.fn(),
   deleteWishlistItem: vi.fn(),
+  createLibrary: vi.fn(),
 }))
 
 const mockLogout = vi.fn()
@@ -532,5 +533,78 @@ describe('SettingsPage – wishlist toggle (#309)', () => {
     renderWithProviders(<SettingsPage />)
     await screen.findByText('Home Library')
     expect(screen.queryByTestId('wishlist-toggle-row')).not.toBeInTheDocument()
+  })
+})
+
+// ── Tests: create library ────────────────────────────────────────────────────
+
+describe('SettingsPage – create library', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    resetAuthMock()
+    const { useLibraryStore } = await import('../store/useLibraryStore')
+    vi.mocked(useLibraryStore).mockImplementation(
+      (selector: (s: { activeLibraryId: string | null; setActiveLibraryId: (id: string | null) => void }) => unknown) =>
+        selector({ activeLibraryId: 'lib-1', setActiveLibraryId: mockSetActiveLibraryId }),
+    )
+    vi.mocked(listLibraries).mockResolvedValue(LIBRARIES)
+    vi.mocked(listLibraryMembers).mockResolvedValue(MEMBERS)
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows the button and expands into the form', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPage />)
+
+    const button = await screen.findByTestId('create-library-button')
+    await user.click(button)
+
+    expect(screen.getByTestId('create-library-form')).toBeInTheDocument()
+    expect(screen.getByLabelText('new-library-name')).toBeInTheDocument()
+  })
+
+  it('creates the library and switches to it as active', async () => {
+    const { createLibrary } = await import('../lib/api')
+    vi.mocked(createLibrary).mockResolvedValue({
+      id: 'lib-new', name: 'Chata', role: 'owner', wishlist_enabled: true,
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPage />)
+
+    await user.click(await screen.findByTestId('create-library-button'))
+    await user.type(screen.getByLabelText('new-library-name'), 'Chata')
+    await user.click(screen.getByTestId('create-library-submit'))
+
+    await waitFor(() => {
+      expect(createLibrary).toHaveBeenCalledWith({ name: 'Chata' })
+    })
+    await waitFor(() => {
+      expect(mockSetActiveLibraryId).toHaveBeenCalledWith('lib-new')
+    })
+    // Form collapses back to the button.
+    await waitFor(() => {
+      expect(screen.queryByTestId('create-library-form')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not switch libraries when the plan limit rejects the create (403)', async () => {
+    const { createLibrary } = await import('../lib/api')
+    vi.mocked(createLibrary).mockRejectedValue({ response: { status: 403 } })
+    const user = userEvent.setup()
+    renderWithProviders(<SettingsPage />)
+
+    await user.click(await screen.findByTestId('create-library-button'))
+    await user.type(screen.getByLabelText('new-library-name'), 'Čtvrtá knihovna')
+    await user.click(screen.getByTestId('create-library-submit'))
+
+    await waitFor(() => {
+      expect(createLibrary).toHaveBeenCalled()
+    })
+    expect(mockSetActiveLibraryId).not.toHaveBeenCalled()
+    // Form stays open so the user can rename / retry after upgrading.
+    expect(screen.getByTestId('create-library-form')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -9,7 +9,7 @@ import { ImportCsvModal } from '../components/ImportCsvModal'
 import { Modal } from '../components/Modal'
 import { useEnrichAll } from '../hooks/useEnrich'
 import { useBillingStatus, useCreateCheckout, useCreatePortal } from '../hooks/useBilling'
-import { useAddMember, useLibraries, useLibraryMembers, useRemoveMember, useUpdateMember } from '../hooks/useLibrary'
+import { useAddMember, useCreateLibrary, useLibraries, useLibraryMembers, useRemoveMember, useUpdateMember } from '../hooks/useLibrary'
 import { useToggleWishlist } from '../hooks/useWishlist'
 import { useResetOnboarding } from '../hooks/useOnboarding'
 import { useToastStore } from '../lib/toast-store'
@@ -88,6 +88,36 @@ function LibraryManagement() {
 
   const [newEmail, setNewEmail] = useState('')
   const [newRole, setNewRole] = useState<LibraryRole>('viewer')
+
+  /* Create-library form. The backend enforces the per-plan library limit
+     (free/home 1, pro 3, library 10) — the client doesn't duplicate the
+     numbers, it just translates the 403 into an upgrade hint. */
+  const createLibraryMutation = useCreateLibrary()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [newLibraryName, setNewLibraryName] = useState('')
+
+  function handleCreateLibrary(e: FormEvent) {
+    e.preventDefault()
+    const name = newLibraryName.trim()
+    if (!name) return
+    createLibraryMutation.mutate(
+      { name },
+      {
+        onSuccess: (library) => {
+          setNewLibraryName('')
+          setCreateOpen(false)
+          // Jump straight into the new library — matches the invite flow.
+          setActiveLibraryId(library.id)
+          showSuccess(t('library.create_success'))
+        },
+        onError: (err) => {
+          const status = extractStatusCode(err)
+          if (status === 403) showError(t('library.create_error_403'))
+          else showError(formatApiError(err) || t('library.create_error'))
+        },
+      },
+    )
+  }
 
   function handleAddMember(e: FormEvent) {
     e.preventDefault()
@@ -180,6 +210,59 @@ function LibraryManagement() {
           })}
         </div>
       )}
+
+      {/* Create a new library — account-level, gated by the plan limit on
+          the backend. */}
+      <div style={{ marginTop: 12 }}>
+        {!createOpen ? (
+          <button
+            type='button'
+            className='sh-btn-secondary'
+            data-testid='create-library-button'
+            style={{ fontSize: 13 }}
+            onClick={() => setCreateOpen(true)}
+          >
+            {t('library.create_button')}
+          </button>
+        ) : (
+          <form
+            onSubmit={handleCreateLibrary}
+            aria-label='create-library-form'
+            data-testid='create-library-form'
+            className='stg-add-form'
+          >
+            <div className='stg-add-form-field'>
+              <label>{t('library.create_name_label')}</label>
+              <input
+                className='sh-input'
+                placeholder={t('library.create_name_placeholder')}
+                value={newLibraryName}
+                onChange={(e) => setNewLibraryName(e.target.value)}
+                aria-label='new-library-name'
+                maxLength={200}
+                required
+              />
+            </div>
+            <button
+              type='submit'
+              className='sh-btn-primary'
+              data-testid='create-library-submit'
+              disabled={createLibraryMutation.isPending || !newLibraryName.trim()}
+              style={{ height: 38, alignSelf: 'flex-end' }}
+            >
+              {createLibraryMutation.isPending ? t('library.creating') : t('library.create_submit')}
+            </button>
+            <button
+              type='button'
+              className='sh-btn-secondary'
+              onClick={() => { setCreateOpen(false); setNewLibraryName('') }}
+              style={{ height: 38, alignSelf: 'flex-end' }}
+            >
+              {t('common.cancel')}
+            </button>
+          </form>
+        )}
+      </div>
 
       {/* Wishlist toggle (#309) — owners only; viewers/editors just follow
           the flag via the nav item. */}


### PR DESCRIPTION
## Souhrn
Backend `POST /api/v1/libraries` existoval (limity dle tarifu: free/home 1, **pro 3, library 10**), ale frontend ho nikdy nevolal — placené tarify prodávaly víc knihoven, které šly založit jen přes API nebo pozvánkou.

- V **Nastavení → Knihovna** pod seznamem knihoven tlačítko **„+ Nová knihovna"** → rozbalí formulář s názvem (vzor add-member formuláře).
- Po vytvoření se nová knihovna rovnou **přepne jako aktivní** (stejně jako po přijetí pozvánky) a invaliduje se `['libraries']`.
- Limit tarifu hlídá backend; klient čísla neduplikuje — **403 se přeloží na hlášku s doporučením upgradu** (Nastavení → Předplatné), formulář zůstane otevřený pro retry.
- Tlačítko je viditelné vždy (i na free) — záměrně: free uživatel dostane srozumitelný upsell místo skryté funkce.
- Nové: `createLibrary` v api.ts, `useCreateLibrary` hook, typ `CreateLibraryRequest`, i18n cs/en.

## Testy
- 3 nové testy: rozbalení formuláře, úspěšné vytvoření (volání API + přepnutí aktivní knihovny + sbalení formuláře), 403 z plan gate (nepřepíná knihovnu, formulář zůstává).
- `npm run lint` ✅, `npm test -- --run` ✅ (284 testů). Bez změny backendu/OpenAPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create a new library directly from Settings.
  * Added library name entry, validation, submit, cancel, and loading states.
  * Newly created libraries are automatically selected.
  * Added success and error notifications, including plan-limit messaging.

* **Tests**
  * Added coverage for successful creation and handling plan-limit errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->