### PR TITLE
feat(telemetry): byznys metriky + Prometheus/Grafana monitoring (ADR 010)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           docker compose --env-file .env.prod.local -f docker-compose.prod.yml run --rm \
             backend bash -lc "cd /app && alembic upgrade head"
 
-          docker compose --env-file .env.prod.local -f docker-compose.prod.yml up -d --build backend worker beat frontend
+          docker compose --env-file .env.prod.local -f docker-compose.prod.yml up -d --build backend worker beat frontend prometheus grafana
 
           # Poll health for up to 90 s (30 × 3 s)
           for i in $(seq 1 30); do

--- a/backend/alembic/versions/20260712_000027_add_last_seen_at_to_users.py
+++ b/backend/alembic/versions/20260712_000027_add_last_seen_at_to_users.py
@@ -1,0 +1,35 @@
+"""add users.last_seen_at for activity telemetry
+
+Revision ID: 20260712_000027
+Revises: 20260711_000025
+Create Date: 2026-07-12
+
+Stamped (throttled to one write per 15 minutes per user, enforced in the
+UPDATE's WHERE clause) by ``services.user_activity.touch_last_seen`` on
+every authenticated request. Powers the ``shelfy_active_users{window}``
+gauges on /metrics — DAU/WAU/MAU in Grafana. Nullable, no backfill:
+NULL simply means "not seen since this feature shipped", which is the
+honest answer.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260712_000027"
+down_revision = "20260711_000025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_users_last_seen_at", "users", ["last_seen_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_last_seen_at", table_name="users")
+    op.drop_column("users", "last_seen_at")

--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -61,7 +61,10 @@ async def get_current_user(
     # Business telemetry: stamp last activity. Throttled inside the UPDATE
     # (one write per 15 min per user), commits only when it actually wrote —
     # runs before any endpoint logic, so it can't release endpoint locks.
-    await touch_last_seen(session, user.id)
+    if await touch_last_seen(session, user.id):
+        # The commit expires ``user`` under expire_on_commit=True sessions;
+        # re-load so callers never receive an expired instance.
+        await session.refresh(user)
 
     # Set Sentry user context so every error is tagged with the authenticated user.
     # Lazy import — zero cost when Sentry is not configured.

--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -8,6 +8,7 @@ from app.core.security import decode_token
 from app.db.session import get_db_session
 from app.models.user import User
 from app.services.auth import get_user_by_email
+from app.services.user_activity import touch_last_seen
 
 # auto_error=False so a missing Authorization header doesn't short-circuit
 # with a 401 before we've had a chance to look at the cookie. This keeps
@@ -56,6 +57,11 @@ async def get_current_user(
         raise credentials_exception
 
     request.state.user_id = str(user.id)
+
+    # Business telemetry: stamp last activity. Throttled inside the UPDATE
+    # (one write per 15 min per user), commits only when it actually wrote —
+    # runs before any endpoint logic, so it can't release endpoint locks.
+    await touch_last_seen(session, user.id)
 
     # Set Sentry user context so every error is tagged with the authenticated user.
     # Lazy import — zero cost when Sentry is not configured.

--- a/backend/app/api/metrics.py
+++ b/backend/app/api/metrics.py
@@ -1,14 +1,97 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 from fastapi import APIRouter, Depends, Response
-from sqlalchemy import func, select
+from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.metrics import BOOK_PROCESSING_JOBS_GAUGE, render_metrics
+from app.core.metrics import (
+    ACTIVE_LOANS_TOTAL,
+    ACTIVE_USERS,
+    BOOK_PROCESSING_JOBS_GAUGE,
+    BOOKS_TOTAL,
+    LIBRARIES_TOTAL,
+    USERS_BY_PLAN,
+    USERS_TOTAL,
+    WISHLIST_ITEMS_TOTAL,
+    render_metrics,
+)
 from app.db.session import get_db_session
 from app.models.book import Book, BookProcessingStatus
+from app.models.library import Library
+from app.models.loan import Loan
+from app.models.subscription import Subscription, SubscriptionPlan, SubscriptionStatus
+from app.models.user import User
+from app.models.wishlist_item import WishlistItem
 
 router = APIRouter(tags=["metrics"])
+
+# Effective-plan rule mirrors services.entitlements._effective_plan:
+# canceled / past_due enforce free limits, so they report as free too.
+_INACTIVE_STATUSES = {SubscriptionStatus.canceled.value, SubscriptionStatus.past_due.value}
+
+ACTIVE_USER_WINDOWS: dict[str, timedelta] = {
+    "1d": timedelta(days=1),
+    "7d": timedelta(days=7),
+    "30d": timedelta(days=30),
+}
+
+
+async def _count(session: AsyncSession, stmt: Select[tuple[int]]) -> int:
+    return int((await session.execute(stmt)).scalar_one())
+
+
+async def refresh_business_gauges(session: AsyncSession) -> None:
+    """Recompute the shelfy_* gauges from the database.
+
+    Runs on every scrape — a handful of COUNT queries, all cheap at the
+    scrape intervals Prometheus uses (>= 15 s). Every label combination
+    is set explicitly each time so stale series can't linger after e.g.
+    the last pro user downgrades.
+    """
+    USERS_TOTAL.set(await _count(session, select(func.count()).select_from(User)))
+
+    # Users by effective plan: LEFT JOIN so users without a subscription
+    # row (created before the billing epic) count as free.
+    plan_rows = (
+        await session.execute(
+            select(Subscription.plan, Subscription.status, func.count(User.id))
+            .select_from(User)
+            .join(Subscription, Subscription.user_id == User.id, isouter=True)
+            .group_by(Subscription.plan, Subscription.status)
+        )
+    ).all()
+    by_plan = {plan.value: 0 for plan in SubscriptionPlan}
+    for plan, subscription_status, count in plan_rows:
+        if plan is None or subscription_status in _INACTIVE_STATUSES:
+            effective = SubscriptionPlan.free.value
+        else:
+            effective = SubscriptionPlan(plan).value
+        by_plan[effective] += int(count)
+    for plan_value, count in by_plan.items():
+        USERS_BY_PLAN.labels(plan=plan_value).set(count)
+
+    now = datetime.now(timezone.utc)
+    for window, delta in ACTIVE_USER_WINDOWS.items():
+        ACTIVE_USERS.labels(window=window).set(
+            await _count(
+                session,
+                select(func.count()).select_from(User).where(User.last_seen_at >= now - delta),
+            )
+        )
+
+    LIBRARIES_TOTAL.set(await _count(session, select(func.count()).select_from(Library)))
+    BOOKS_TOTAL.set(await _count(session, select(func.count()).select_from(Book)))
+    ACTIVE_LOANS_TOTAL.set(
+        await _count(
+            session,
+            select(func.count()).select_from(Loan).where(Loan.returned_date.is_(None)),
+        )
+    )
+    WISHLIST_ITEMS_TOTAL.set(
+        await _count(session, select(func.count()).select_from(WishlistItem))
+    )
 
 
 @router.get("/metrics", include_in_schema=False)
@@ -23,6 +106,8 @@ async def metrics(session: AsyncSession = Depends(get_db_session)) -> Response:
         result = await session.execute(select(func.count()).select_from(Book).where(Book.processing_status == status))
         count = int(result.scalar_one())
         BOOK_PROCESSING_JOBS_GAUGE.labels(status=status).set(count)
+
+    await refresh_business_gauges(session)
 
     payload, content_type = render_metrics()
     return Response(content=payload, media_type=content_type)

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -26,6 +26,24 @@ FRONTEND_RUNTIME_ERRORS_TOTAL = Counter(
     labelnames=("kind",),
 )
 
+# ── Business gauges (computed on every /metrics scrape) ───────────────────────
+# Prefixed shelfy_ to keep them apart from the request-level counters above.
+USERS_TOTAL = Gauge("shelfy_users_total", "Registered users")
+USERS_BY_PLAN = Gauge(
+    "shelfy_users_by_plan",
+    "Users by effective subscription plan (canceled/past_due count as free)",
+    labelnames=("plan",),
+)
+ACTIVE_USERS = Gauge(
+    "shelfy_active_users",
+    "Users with last_seen_at inside the window",
+    labelnames=("window",),
+)
+LIBRARIES_TOTAL = Gauge("shelfy_libraries_total", "Libraries")
+BOOKS_TOTAL = Gauge("shelfy_books_total", "Books across all libraries")
+ACTIVE_LOANS_TOTAL = Gauge("shelfy_active_loans_total", "Loans not yet returned")
+WISHLIST_ITEMS_TOTAL = Gauge("shelfy_wishlist_items_total", "Wishlist items across all libraries")
+
 EXTERNAL_API_LATENCY_SECONDS = Histogram(
     "external_api_latency_seconds",
     "External metadata API latency",

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -50,6 +50,13 @@ class User(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # Business telemetry: stamped (throttled) on every authenticated request
+    # by ``services.user_activity.touch_last_seen``. Drives the
+    # ``shelfy_active_users`` gauges on /metrics.
+    last_seen_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+
     # ── Timestamps ───────────────────────────────────────────────────────────────
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/services/user_activity.py
+++ b/backend/app/services/user_activity.py
@@ -1,0 +1,42 @@
+"""Last-seen tracking for business telemetry.
+
+``touch_last_seen`` stamps ``users.last_seen_at`` at most once per
+``LAST_SEEN_THROTTLE`` window per user. The throttle lives in the SQL
+WHERE clause, so concurrent requests cannot double-write and the hot
+path (recently-stamped user) is a single UPDATE matching zero rows —
+no Redis round-trip, no extra SELECT.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import uuid
+
+from sqlalchemy import or_, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+
+LAST_SEEN_THROTTLE = timedelta(minutes=15)
+
+
+async def touch_last_seen(
+    session: AsyncSession, user_id: uuid.UUID, *, now: datetime | None = None
+) -> bool:
+    """Stamp the user's last activity; returns True when a write happened.
+
+    Commits only when a row was actually updated. Called from
+    ``get_current_user`` — i.e. before any endpoint logic runs — so the
+    commit never releases locks an endpoint has taken.
+    """
+    stamp = now or datetime.now(timezone.utc)
+    threshold = stamp - LAST_SEEN_THROTTLE
+    result = await session.execute(
+        update(User)
+        .where(User.id == user_id)
+        .where(or_(User.last_seen_at.is_(None), User.last_seen_at < threshold))
+        .values(last_seen_at=stamp)
+    )
+    if result.rowcount:
+        await session.commit()
+        return True
+    return False

--- a/backend/app/services/user_activity.py
+++ b/backend/app/services/user_activity.py
@@ -35,6 +35,11 @@ async def touch_last_seen(
         .where(User.id == user_id)
         .where(or_(User.last_seen_at.is_(None), User.last_seen_at < threshold))
         .values(last_seen_at=stamp)
+        # No identity-map sync: the default 'evaluate' strategy compares the
+        # WHERE clause in Python against in-session instances and dies on
+        # naive/aware datetime mixes; nothing reads last_seen_at from the
+        # session, so skipping the sync is both safe and cheaper.
+        .execution_options(synchronize_session=False)
     )
     if result.rowcount:
         await session.commit()

--- a/backend/tests/test_business_metrics.py
+++ b/backend/tests/test_business_metrics.py
@@ -1,0 +1,233 @@
+"""Business telemetry tests: users.last_seen_at touch + /metrics gauges.
+
+DB fixture pattern mirrors tests/test_isolation.py (SQLite fallback
+locally, Postgres via TEST_DATABASE_URL in CI).
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from datetime import datetime, timedelta, timezone
+import os
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import app
+from app.models.library import Library, LibraryMember, LibraryRole
+from app.models.subscription import Subscription, SubscriptionPlan, SubscriptionStatus
+from app.models.user import User
+from app.services.user_activity import LAST_SEEN_THROTTLE, touch_last_seen
+
+
+def _require_test_database_url() -> str:
+    return os.environ.get("TEST_DATABASE_URL", "sqlite+aiosqlite:///./test_biz_metrics.db")
+
+
+@pytest.fixture
+async def test_session() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(_require_test_database_url())
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "manual", "pending", "done", "failed", "partial",
+                name="book_processing_status",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "unread", "reading", "read", "lent",
+                name="reading_status",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(
+            lambda sync_conn: sa.Enum(
+                "owner", "editor", "viewer",
+                name="library_role",
+            ).create(sync_conn, checkfirst=True)  # type: ignore[no-untyped-call]
+        )
+        await connection.run_sync(Base.metadata.drop_all)
+        await connection.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    yield session_factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def test_settings() -> Settings:
+    return Settings(
+        database_url=_require_test_database_url(),
+        jwt_secret_key="test-secret",
+    )
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(
+    test_session: async_sessionmaker[AsyncSession], test_settings: Settings
+) -> Iterator[None]:
+    async def _get_db() -> AsyncIterator[AsyncSession]:
+        async with test_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db_session] = _get_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+async def _create_user(
+    session: AsyncSession,
+    email: str,
+    *,
+    last_seen_at: datetime | None = None,
+    plan: SubscriptionPlan | None = None,
+    subscription_status: SubscriptionStatus = SubscriptionStatus.active,
+) -> User:
+    user = User(
+        email=email,
+        hashed_password=get_password_hash("secret"),
+        last_seen_at=last_seen_at,
+    )
+    session.add(user)
+    await session.flush()
+    if plan is not None:
+        session.add(Subscription(user_id=user.id, plan=plan, status=subscription_status))
+    await session.refresh(user)
+    return user
+
+
+def _metric_value(payload: str, name: str, labels: str = "") -> float:
+    needle = f"{name}{labels} "
+    for line in payload.splitlines():
+        if line.startswith(needle):
+            return float(line.split()[-1])
+    raise AssertionError(f"metric {name}{labels} not found in payload")
+
+
+# ── touch_last_seen ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_touch_last_seen_writes_then_throttles(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        user = await _create_user(session, "active@example.com")
+        await session.commit()
+
+        t0 = datetime.now(timezone.utc)
+        assert await touch_last_seen(session, user.id, now=t0) is True
+
+        # Second touch inside the throttle window is a no-op.
+        t1 = t0 + timedelta(minutes=1)
+        assert await touch_last_seen(session, user.id, now=t1) is False
+
+        # After the window it writes again.
+        t2 = t0 + LAST_SEEN_THROTTLE + timedelta(seconds=1)
+        assert await touch_last_seen(session, user.id, now=t2) is True
+
+        refreshed = await session.get(User, user.id)
+        assert refreshed is not None
+        assert refreshed.last_seen_at is not None
+
+
+@pytest.mark.asyncio
+async def test_authenticated_request_stamps_last_seen(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    """End-to-end: login + any authenticated call → last_seen_at is set."""
+    async with test_session() as session:
+        user = await _create_user(session, "active@example.com")
+        lib = Library(name="L", created_by_user_id=user.id)
+        session.add(lib)
+        await session.flush()
+        session.add(LibraryMember(library_id=lib.id, user_id=user.id, role=LibraryRole.OWNER))
+        await session.commit()
+        user_id = user.id
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        login = await client.post(
+            "/api/v1/auth/login", json={"email": "active@example.com", "password": "secret"}
+        )
+        assert login.status_code == 200
+        headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+        response = await client.get("/api/v1/libraries", headers=headers)
+        assert response.status_code == 200
+
+    async with test_session() as session:
+        refreshed = await session.get(User, user_id)
+        assert refreshed is not None
+        assert refreshed.last_seen_at is not None
+
+
+# ── /metrics business gauges ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_metrics_reports_users_by_plan_and_activity_windows(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    now = datetime.now(timezone.utc)
+    async with test_session() as session:
+        # free: no subscription row at all.
+        await _create_user(session, "free@example.com", last_seen_at=now - timedelta(hours=2))
+        # pro, active sub, seen 3 days ago (counts for 7d + 30d).
+        await _create_user(
+            session, "pro@example.com",
+            plan=SubscriptionPlan.pro, last_seen_at=now - timedelta(days=3),
+        )
+        # library plan but canceled → effective free; seen 12 days ago (30d only).
+        await _create_user(
+            session, "churned@example.com",
+            plan=SubscriptionPlan.library,
+            subscription_status=SubscriptionStatus.canceled,
+            last_seen_at=now - timedelta(days=12),
+        )
+        # library plan, active, never seen.
+        await _create_user(session, "lib@example.com", plan=SubscriptionPlan.library)
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/metrics")
+
+    assert response.status_code == 200
+    payload = response.text
+
+    assert _metric_value(payload, "shelfy_users_total") == 4
+    assert _metric_value(payload, "shelfy_users_by_plan", '{plan="free"}') == 2
+    assert _metric_value(payload, "shelfy_users_by_plan", '{plan="pro"}') == 1
+    assert _metric_value(payload, "shelfy_users_by_plan", '{plan="library"}') == 1
+    assert _metric_value(payload, "shelfy_users_by_plan", '{plan="home"}') == 0
+
+    assert _metric_value(payload, "shelfy_active_users", '{window="1d"}') == 1
+    assert _metric_value(payload, "shelfy_active_users", '{window="7d"}') == 2
+    assert _metric_value(payload, "shelfy_active_users", '{window="30d"}') == 3
+
+
+@pytest.mark.asyncio
+async def test_metrics_reports_inventory_totals(
+    test_session: async_sessionmaker[AsyncSession],
+) -> None:
+    async with test_session() as session:
+        owner = await _create_user(session, "owner@example.com")
+        lib = Library(name="L", created_by_user_id=owner.id)
+        session.add(lib)
+        await session.flush()
+        session.add(LibraryMember(library_id=lib.id, user_id=owner.id, role=LibraryRole.OWNER))
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/metrics")
+
+    assert response.status_code == 200
+    payload = response.text
+    assert _metric_value(payload, "shelfy_libraries_total") == 1
+    assert _metric_value(payload, "shelfy_books_total") == 0
+    assert _metric_value(payload, "shelfy_active_loans_total") == 0
+    assert _metric_value(payload, "shelfy_wishlist_items_total") == 0

--- a/backend/tests/test_business_metrics.py
+++ b/backend/tests/test_business_metrics.py
@@ -132,7 +132,9 @@ async def test_touch_last_seen_writes_then_throttles(
         t2 = t0 + LAST_SEEN_THROTTLE + timedelta(seconds=1)
         assert await touch_last_seen(session, user.id, now=t2) is True
 
-        refreshed = await session.get(User, user.id)
+        # synchronize_session=False leaves the identity-map instance stale
+        # on purpose — force a re-SELECT to observe the written value.
+        refreshed = await session.get(User, user.id, populate_existing=True)
         assert refreshed is not None
         assert refreshed.last_seen_at is not None
 

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -127,6 +127,10 @@ async def test_metrics_endpoint_returns_prometheus_payload() -> None:
         def scalar_one(self) -> int:
             return 0
 
+        def all(self) -> list[object]:
+            # The users-by-plan GROUP BY in refresh_business_gauges.
+            return []
+
     class _FakeSession:
         async def execute(self, _statement: object) -> _FakeResult:
             return _FakeResult()

--- a/docs/adr/010-prometheus-grafana-monitoring.md
+++ b/docs/adr/010-prometheus-grafana-monitoring.md
@@ -1,0 +1,65 @@
+# ADR 010: Prometheus + Grafana for business and system monitoring
+
+- **Status:** Accepted
+- **Date:** 2026-07-12
+
+## Context
+
+The backend has exported Prometheus metrics on `/metrics` since early on
+(HTTP request counters, external-API calls/latency, processing-job
+gauges), but nothing scraped them and no business-level telemetry
+existed: no answer to "how many users per tier", "how many come back",
+or "when was a user last active". The product owner wants these visible
+in Grafana, together with basic system monitoring.
+
+Constraints:
+
+- Prod runs via docker compose on a single host behind a Cloudflare
+  tunnel that only routes `/api/*` and `/health*` to the backend —
+  `/metrics` is *not* publicly reachable, so business gauges can ride on
+  the existing endpoint without leaking.
+- Ports 9090/9091 (another project's Prometheus/pushgateway) and 3000
+  (AdGuard) are already taken on the host.
+
+## Decision
+
+1. **Business gauges on the existing `/metrics` endpoint**, recomputed
+   from Postgres on every scrape (a handful of indexed COUNTs at a 60 s
+   scrape interval): `shelfy_users_total`, `shelfy_users_by_plan{plan}`
+   (effective plan — canceled/past_due report as free, mirroring
+   entitlements), `shelfy_active_users{window="1d|7d|30d"}`, plus
+   inventory totals (libraries, books, active loans, wishlist items).
+   Prometheus turns those point-in-time gauges into history, which is
+   what makes retention visible — no event pipeline needed.
+2. **`users.last_seen_at`** column stamped by
+   `services.user_activity.touch_last_seen` from `get_current_user`,
+   throttled to one write per 15 minutes per user *inside the UPDATE's
+   WHERE clause* (no Redis round-trip, race-free, zero-row match on the
+   hot path).
+3. **Prometheus (180 d retention) + Grafana as compose services** in
+   `infra/docker-compose.prod.yml`, deployed by the standard deploy
+   workflow. Bound to localhost only: Prometheus on `127.0.0.1:9092`,
+   Grafana on `127.0.0.1:3300`. Grafana is fully provisioned from the
+   repo (datasource + two dashboards: *Shelfy · Byznys*, *Shelfy ·
+   Systém*), so a wiped volume rebuilds itself; admin password comes
+   from `GRAFANA_ADMIN_PASSWORD` in `.env.prod.local`.
+
+## Alternatives considered
+
+- **Grafana → Postgres datasource with raw SQL dashboards.** More
+  ad-hoc flexibility, but requires a read-only DB role and puts query
+  cost into Grafana refreshes; gauges + Prometheus give history for
+  free and keep the DB contract in code. Can still be added later.
+- **Product-analytics tools (PostHog/Umami).** Answers different
+  questions (funnels, page views) at the cost of another stateful
+  service; the asked-for metrics are all derivable from the DB.
+
+## Consequences
+
+- Grafana is reachable only from the host (or an SSH tunnel /
+  Cloudflare Access hostname if added later).
+- `/metrics` must stay off the public tunnel ingress; anyone adding a
+  catch-all route to the backend would expose business numbers.
+- The `shelfy_*` gauges are point-in-time: Grafana history starts the
+  day this ships, and `last_seen_at` is NULL for users who haven't
+  visited since — both intentional.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,15 @@ flowchart LR
 
 ## 5. Observability and operations
 
+Monitoring (ADR 010): Prometheus (`127.0.0.1:9092`, 180d retention)
+scrapes the backend `/metrics` endpoint every 60 s; Grafana
+(`127.0.0.1:3300`, provisioned from `infra/grafana/`) ships two
+dashboards — *Shelfy · Byznys* (users by tier, DAU/WAU/MAU from
+`users.last_seen_at`, inventory totals) and *Shelfy · Systém* (request
+rates, 5xx ratio, external-API latency, processing jobs). `/metrics` is
+not exposed through the Cloudflare tunnel.
+
+
 - JSON structured logs are emitted by backend and worker via structlog.
 - `/metrics` endpoint exports Prometheus-compatible counters/histograms.
 - Health endpoints:

--- a/infra/grafana/dashboards/shelfy-business.json
+++ b/infra/grafana/dashboards/shelfy-business.json
@@ -1,0 +1,508 @@
+{
+  "uid": "shelfy-business",
+  "title": "Shelfy · Byznys",
+  "tags": [
+    "shelfy",
+    "business"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "refresh": "1m",
+  "timezone": "browser",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Registrovaní uživatelé",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_users_total",
+          "legendFormat": "celkem",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 2,
+      "title": "Aktivní dnes (DAU)",
+      "type": "stat",
+      "gridPos": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_active_users{window=\"1d\"}",
+          "legendFormat": "1d",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 3,
+      "title": "Aktivní 7 dní (WAU)",
+      "type": "stat",
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_active_users{window=\"7d\"}",
+          "legendFormat": "7d",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 4,
+      "title": "Aktivní 30 dní (MAU)",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 4,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_active_users{window=\"30d\"}",
+          "legendFormat": "30d",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 5,
+      "title": "Vracející se uživatelé (DAU/MAU)",
+      "type": "gauge",
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_active_users{window=\"1d\"} / clamp_min(shelfy_active_users{window=\"30d\"}, 1)",
+          "legendFormat": "stickiness",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "green",
+                "value": 0.2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 6,
+      "title": "Uživatelé podle tarifu",
+      "type": "piechart",
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_users_by_plan",
+          "legendFormat": "{{plan}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Vývoj uživatelů podle tarifu",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 8,
+        "y": 5,
+        "w": 16,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_users_by_plan",
+          "legendFormat": "{{plan}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 8,
+      "title": "Aktivní uživatelé v čase",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 13,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_active_users",
+          "legendFormat": "{{window}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 9,
+      "title": "Růst registrací (přírůstek/den)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 13,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "delta(shelfy_users_total[1d])",
+          "legendFormat": "noví/den",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 10,
+      "title": "Knihy",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_books_total",
+          "legendFormat": "knihy",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 11,
+      "title": "Knihovny",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 21,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_libraries_total",
+          "legendFormat": "knihovny",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 12,
+      "title": "Aktivní výpůjčky",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 21,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_active_loans_total",
+          "legendFormat": "výpůjčky",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 13,
+      "title": "Přání na wishlistech",
+      "type": "stat",
+      "gridPos": {
+        "x": 18,
+        "y": 21,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "shelfy_wishlist_items_total",
+          "legendFormat": "přání",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    }
+  ]
+}

--- a/infra/grafana/dashboards/shelfy-system.json
+++ b/infra/grafana/dashboards/shelfy-system.json
@@ -1,0 +1,283 @@
+{
+  "uid": "shelfy-system",
+  "title": "Shelfy · Systém",
+  "tags": [
+    "shelfy",
+    "system"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "refresh": "1m",
+  "timezone": "browser",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Požadavky/s podle statusu",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 2,
+      "title": "Podíl 5xx odpovědí",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 6,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[15m])) / clamp_min(sum(rate(http_requests_total[15m])), 0.000001)",
+          "legendFormat": "5xx ratio",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 3,
+      "title": "Chyby frontendu/min",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 18,
+        "y": 0,
+        "w": 6,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (kind) (rate(frontend_runtime_errors_total[15m])) * 60",
+          "legendFormat": "{{kind}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 4,
+      "title": "Externí API volání/min (Open Library…)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (provider) (rate(external_api_calls_total[15m])) * 60",
+          "legendFormat": "{{provider}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 5,
+      "title": "Externí API latence p95",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, provider) (rate(external_api_latency_seconds_bucket[15m])))",
+          "legendFormat": "{{provider}} p95",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 6,
+      "title": "Zpracování knih (jobs podle stavu)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "book_processing_jobs_total",
+          "legendFormat": "{{status}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 7,
+      "title": "Nejvytíženější endpointy (req/s)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "topk(8, sum by (endpoint) (rate(http_requests_total[15m])))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    }
+  ]
+}

--- a/infra/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: shelfy
+    folder: Shelfy
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 60
+    options:
+      path: /var/lib/grafana/dashboards

--- a/infra/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+# Shelfy monitoring (ADR 010). Scrapes the backend's /metrics endpoint —
+# the endpoint is intentionally NOT exposed through the Cloudflare tunnel
+# (only /api/* and /health* are), so business gauges stay private.
+global:
+  scrape_interval: 60s
+  evaluation_interval: 60s
+
+scrape_configs:
+  - job_name: shelfy-backend
+    static_configs:
+      - targets: ["backend:8000"]


### PR DESCRIPTION
## Souhrn
Odpověď na „kolik je uživatelů dle tieru, kolik se jich vrací, kdy byli naposledy aktivní — a sledovat to v Grafaně".

**Backend**
- Nový sloupec `users.last_seen_at` ([migrace](backend/alembic/versions/20260712_000027_add_last_seen_at_to_users.py)) — razítkuje ho `touch_last_seen` z `get_current_user` při každém autentizovaném requestu, **throttle 15 min na uživatele přímo ve WHERE klauzuli UPDATE** (žádný Redis, race-free, hot path = UPDATE na 0 řádků).
- `/metrics` při každém scrape dopočítá byznys gauges: `shelfy_users_total`, `shelfy_users_by_plan{plan}` (efektivní plán — canceled/past_due se počítá jako free, zrcadlí entitlements), `shelfy_active_users{window=1d|7d|30d}`, + celkové počty knihoven/knih/aktivních výpůjček/přání. Labely se nastavují všechny explicitně → žádné zombie série.
- `/metrics` **není veřejný** — Cloudflare tunel pouští jen `/api/*` a `/health*` (ověřeno v ingress konfiguraci).

**Infra** ([ADR 010](docs/adr/010-prometheus-grafana-monitoring.md))
- `prometheus` (retence 180 dní, scrape 60 s) na `127.0.0.1:9092` a `grafana` na `127.0.0.1:3300` — porty 9090/3000 na hostu zabírají jiné projekty.
- Grafana plně provisionovaná z repa: datasource + **Shelfy · Byznys** (uživatelé celkem, DAU/WAU/MAU, stickiness DAU/MAU, tarify donut + vývoj v čase, růst registrací, inventář) a **Shelfy · Systém** (req/s dle statusu, podíl 5xx, chyby frontendu, Open Library volání + p95 latence, processing joby, top endpointy).
- Deploy workflow rozšířen o `prometheus grafana`; admin heslo z `GRAFANA_ADMIN_PASSWORD` (doplněno do lokálního `.env.prod.local`, gitignored).

## Testy
- `test_business_metrics.py`: throttle logika touch (píše → nepíše → po okně píše), e2e „přihlášený request razítkuje last_seen", gauges dle tarifů vč. canceled→free a users bez subscription řádku, okna aktivity 1d/7d/30d, inventární počty.
- Retence/DAU historie začne nabíhat od nasazení (gauges jsou point-in-time, Prometheus z nich dělá historii).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Prometheus business metrics for users, activity, plans, libraries, books, loans, and wishlist items.
  - Added Grafana dashboards for business and system monitoring.
  - User activity is now reflected through last-seen tracking.
  - Prometheus and Grafana start automatically during deployment.

- **Documentation**
  - Added monitoring architecture documentation and an architecture decision record.

- **Tests**
  - Added coverage for activity tracking, authentication updates, and business metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->