### PR TITLE
fix(deploy): migrace běžely ze staré image (o deploy pozadu)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,13 @@ jobs:
           # Start dependencies before migrations (DB must be up)
           docker compose --env-file .env.prod.local -f docker-compose.prod.yml up -d --build postgres redis minio
 
+          # Build the backend image BEFORE running migrations — `compose run`
+          # otherwise reuses the image from the *previous* deploy, so any
+          # migration added in the commit being deployed silently doesn't run
+          # (bit us with users.last_seen_at: alembic saw the old head and the
+          # freshly deployed code 500'd on the missing column).
+          docker compose --env-file .env.prod.local -f docker-compose.prod.yml build backend
+
           docker compose --env-file .env.prod.local -f docker-compose.prod.yml run --rm \
             backend bash -lc "cd /app && alembic upgrade head"
 


### PR DESCRIPTION
## Co se dělo
Deploy pouští `alembic upgrade head` přes `docker compose run backend` **před** `up -d --build backend` — `compose run` ale nebuildí, takže migrace běžely z image **předchozího** deploye. Každá nová migrace se tak reálně aplikovala až o jeden deploy později. Dnes to poprvé kouslo: deploy #322 nasadil kód čtoucí `users.last_seen_at`, ale migrace (v čerstvém commitu) ve staré image nebyla → `/metrics` vracel 500, dokud jsem migraci nedohnal ručně.

## Fix
Explicitní `docker compose build backend` před migračním krokem. (Prod DB už je na `20260712_000027` po ruční nápravě — tento PR opravuje pipeline do budoucna.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)