### PR TITLE
feat(infra): migrace shelfy do k3s — manifesty, images pipeline, cutover runbook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,12 @@
 name: Deploy
 
+# k3s deploy (since 2026-07-12 the production stack runs in the cluster, see
+# infra/k8s/). Chains off the `images` workflow so the freshly pushed sha-tagged
+# images are guaranteed to exist before pods roll. Compose-era deploy lives in
+# git history if you ever need to compare.
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["images"]
     types: [completed]
     branches: [main]
   workflow_dispatch:
@@ -13,36 +17,49 @@ concurrency:
 
 jobs:
   deploy:
-    # Only proceed if CI succeeded (workflow_run) or manual trigger (workflow_dispatch)
+    # Only proceed if images were built successfully (workflow_run) or manual trigger
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, shelfy-prod]
     timeout-minutes: 15
     steps:
-      - name: Deploy
+      - name: Deploy to k3s
         run: |
           set -euo pipefail
-          cd ~/shelfy
-          git pull origin main
-          cd infra
+          SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
+          echo "Deploying commit $SHA"
 
-          # Start dependencies before migrations (DB must be up)
-          docker compose --env-file .env.prod.local -f docker-compose.prod.yml up -d --build postgres redis minio
+          # The runner container has no kubectl; run it via the host docker
+          # daemon with the host kubeconfig. TODO(security follow-up): replace
+          # the admin kubeconfig with a namespace-scoped ServiceAccount.
+          kc() {
+            docker run --rm --network host \
+              -v /home/suslik/.kube/config:/kube/config:ro \
+              -e KUBECONFIG=/kube/config \
+              bitnami/kubectl:latest "$@"
+          }
 
-          # Build the backend image BEFORE running migrations — `compose run`
-          # otherwise reuses the image from the *previous* deploy, so any
-          # migration added in the commit being deployed silently doesn't run
-          # (bit us with users.last_seen_at: alembic saw the old head and the
-          # freshly deployed code 500'd on the missing column).
-          docker compose --env-file .env.prod.local -f docker-compose.prod.yml build backend
+          # Pin exact sha tags — never deploy a mutable :latest. `set image`
+          # updates the migrate initContainer too, so alembic runs from the
+          # same commit as the app (mirrors the old compose deploy ordering:
+          # initContainer finishes before the new pod serves traffic).
+          kc -n shelfy set image deploy/backend \
+            migrate=ghcr.io/smeglofus/shelfy-backend:sha-$SHA \
+            backend=ghcr.io/smeglofus/shelfy-backend:sha-$SHA
+          kc -n shelfy set image deploy/worker \
+            worker=ghcr.io/smeglofus/shelfy-worker:sha-$SHA
+          kc -n shelfy set image deploy/beat \
+            beat=ghcr.io/smeglofus/shelfy-worker:sha-$SHA
+          kc -n shelfy set image deploy/frontend \
+            frontend=ghcr.io/smeglofus/shelfy-frontend:prod-sha-$SHA
 
-          docker compose --env-file .env.prod.local -f docker-compose.prod.yml run --rm \
-            backend bash -lc "cd /app && alembic upgrade head"
+          kc -n shelfy rollout status deploy/backend  --timeout=300s
+          kc -n shelfy rollout status deploy/worker   --timeout=180s
+          kc -n shelfy rollout status deploy/beat     --timeout=180s
+          kc -n shelfy rollout status deploy/frontend --timeout=180s
 
-          docker compose --env-file .env.prod.local -f docker-compose.prod.yml up -d --build backend worker beat frontend prometheus grafana
-
-          # Poll health for up to 90 s (30 × 3 s)
+          # End-to-end check through the tunnel (Cloudflare -> Traefik -> pod)
           for i in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:8000/health && curl -fsS http://127.0.0.1:8000/health/ready; then
+            if curl -fsS https://shelfy.cz/health && curl -fsS https://shelfy.cz/health/ready; then
               echo "Deploy healthy"
               exit 0
             fi
@@ -72,6 +89,6 @@ jobs:
             -d text="Shelfy deploy: ${STATUS}%0A%0ACommit: ${{ github.event.workflow_run.head_commit.message || github.event.head_commit.message }}%0AWorkflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
 # Rollback (manual):
-# If this workflow fails after docker compose up, revert the bad commit and
-# re-run via Actions → Deploy → Run workflow (workflow_dispatch):
+#   kubectl -n shelfy rollout undo deploy/backend deploy/worker deploy/beat deploy/frontend
+# or re-run this workflow (workflow_dispatch) after reverting the bad commit:
 #   cd ~/shelfy && git revert HEAD --no-edit && git push origin main

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,77 @@
+# Build & push container images to GHCR for the k3s deployment (ADR: k3s
+# migration). Backend and worker are environment-agnostic; the frontend bakes
+# VITE_API_BASE_URL at build time, so it is built once per environment.
+name: images
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, feat/k3s-migration]
+    paths:
+      - "backend/**"
+      - "worker/**"
+      - "frontend/**"
+      - ".github/workflows/images.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
+jobs:
+  backend-worker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [backend, worker]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.component }}
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/shelfy-${{ matrix.component }}:latest
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/shelfy-${{ matrix.component }}:sha-${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,scope=${{ matrix.component }},mode=max
+
+  frontend:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - env_name: prod
+            api_base_url: https://shelfy.cz
+          - env_name: staging
+            api_base_url: https://staging.shelfy.cz
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            VITE_API_BASE_URL=${{ matrix.api_base_url }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/shelfy-frontend:${{ matrix.env_name }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/shelfy-frontend:${{ matrix.env_name }}-sha-${{ github.sha }}
+          cache-from: type=gha,scope=frontend-${{ matrix.env_name }}
+          cache-to: type=gha,scope=frontend-${{ matrix.env_name }},mode=max

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A few things worth a closer look while reading the code:
 - **Workers** — Celery (barcode, Gemini Vision, enrichment, email, backups)
 - **Data & infra** — PostgreSQL 16, Redis 7, MinIO
 - **Observability** — structlog JSON logs + Prometheus metrics at `/metrics`
-- **Deployment** — Docker Compose for dev, Docker Swarm + Traefik for production
+- **Deployment** — Docker Compose for dev, Kubernetes (k3s) + Traefik + Cloudflare Tunnel for production
 
 ---
 
@@ -209,16 +209,20 @@ docker compose ps
 
 ---
 
-## Homelab deployment (Docker Swarm)
+## Production deployment (Kubernetes / k3s)
 
-- Stack definition: `infra/swarm-stack.yml`
-- Runbook: `docs/deployment.md`
+Production runs on a two-node k3s homelab cluster since 2026-07-12 (migrated
+from Docker Compose — the cutover runbook that performed it is
+[`infra/k8s/CUTOVER.md`](infra/k8s/CUTOVER.md)).
 
-```bash
-docker stack deploy -c infra/swarm-stack.yml library-app
-```
+- Manifests: [`infra/k8s/`](infra/k8s/README.md) (kustomize base + staging/prod overlays)
+- CD: merge to `main` → `images` workflow builds sha-tagged images to GHCR →
+  `Deploy` workflow pins them via `kubectl set image` and waits for rollout
+- Manifest changes: `kubectl apply -k infra/k8s/overlays/prod`
 
-Swarm-specific vars are documented in `.env.example` and `docs/deployment.md`.
+Legacy compose production files (`infra/docker-compose.prod.yml`,
+`infra/swarm-stack.yml`, `infra/deploy-prod.local.sh`) are kept as the
+short-term rollback path and for reference.
 
 ---
 

--- a/infra/k8s/CUTOVER.md
+++ b/infra/k8s/CUTOVER.md
@@ -1,0 +1,159 @@
+# Cutover: shelfy.cz z Docker Compose do k3s
+
+Runbook pro přepnutí produkce. Piš si k němu časy a poznámky — je to zároveň
+podklad pro pohovorovou historku. Všechno se spouští na homelab2 jako `suslik`
+(kroky se `sudo` jsou označené).
+
+**Než začneš:** staging běží a proklikal sis ho, `gen-secrets.sh` proběhl,
+images jsou public, máš ~30 min klidu. Výpadek během cutoveru: ~10–20 minut.
+
+```bash
+cd ~/shelfy && export KUBECONFIG=~/.kube/config
+```
+
+---
+
+## Fáze A — jednorázová příprava (kdykoli předem)
+
+### A1. Zveřejnit images v GHCR (jinak ImagePullBackOff)
+
+Na GitHubu: profil → **Packages** → `shelfy-backend`, `shelfy-worker`,
+`shelfy-frontend` → Package settings → Danger zone → **Change visibility →
+Public**. (Repo je stejně public, images neobsahují nic navíc.)
+
+### A2. Staging přes tunel (sudo)
+
+```bash
+sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-pre-k3s
+sudo nano /etc/cloudflared/config.yml
+```
+
+Nad pravidla pro `shelfy.cz` přidej:
+
+```yaml
+  - hostname: staging.shelfy.cz
+    service: http://127.0.0.1:80
+```
+
+```bash
+sudo cloudflared tunnel route dns eff8a021-6a73-4bef-968d-a22b848bc669 staging.shelfy.cz
+sudo systemctl restart cloudflared && systemctl status cloudflared --no-pager
+```
+
+### A3. Ověřit staging
+
+- https://staging.shelfy.cz — přihlásit se, proklikat knihovnu, výpůjčky, hledání.
+- Volitelně e2e z tvého stroje: `cd e2e && E2E_BASE_URL=https://staging.shelfy.cz npx playwright test --project=chromium tests/smoke-regressions.spec.ts`
+- Pozn.: Google OAuth na stagingu nefunguje (redirect URI není v Google konzoli) — e-mail login ano. Stripe checkout netestuj na stagingu (vede na ostrý Stripe).
+
+---
+
+## Fáze B — předpříprava produkce (den/hodinu předem, bez výpadku)
+
+```bash
+infra/k8s/scripts/gen-secrets.sh prod          # secret vč. NOVÉHO pg/redis hesla
+kubectl apply -k infra/k8s/overlays/prod
+kubectl -n shelfy scale deploy backend worker beat frontend --replicas=0
+kubectl -n shelfy get pods                     # postgres/redis/minio Running, app 0/0
+infra/k8s/scripts/mirror-minio.sh prod         # bulk kopie obálek atd. (delta se dožene ve fázi C)
+```
+
+> Nové DB heslo je schválně — staré bylo `CHANGE_ME_DB`. Skript ho drží
+> v Secretu, při reruns se nemění.
+
+---
+
+## Fáze C — cutover (výpadek začíná)
+
+**C1. Freeze zápisů** (frontend nech běžet — jen statická landing, API bude mrtvé):
+
+```bash
+docker compose --env-file infra/.env.prod.local -f infra/docker-compose.prod.yml \
+  stop backend worker beat
+```
+
+**C2. Finální dump:**
+
+```bash
+mkdir -p ~/backups
+docker exec infra-postgres-1 pg_dump -U shelfy -Fc shelfy \
+  > ~/backups/shelfy-cutover-$(date +%F-%H%M).dump
+ls -lh ~/backups/ | tail -1     # sanity: nenulová velikost
+```
+
+**C3. Restore do k3s** (přes lokální socket v podu, heslo netřeba):
+
+```bash
+kubectl -n shelfy exec -i deploy/postgres -- \
+  pg_restore -U shelfy -d shelfy --clean --if-exists --no-owner \
+  < ~/backups/shelfy-cutover-*.dump
+kubectl -n shelfy exec deploy/postgres -- \
+  psql -U shelfy -d shelfy -c "select count(*) from users;"   # sanity
+```
+
+**C4. MinIO delta:** `infra/k8s/scripts/mirror-minio.sh prod`
+
+**C5. Start aplikace v k3s:**
+
+```bash
+kubectl -n shelfy scale deploy backend worker beat frontend --replicas=1
+kubectl -n shelfy rollout status deploy/backend    # initContainer = alembic (no-op)
+infra/k8s/scripts/smoke.sh shelfy.cz
+```
+
+**C6. Přepnout tunel (sudo).** V `/etc/cloudflared/config.yml` nahraď tři
+pravidla pro `shelfy.cz` (path `/api/*`, `/health*` a catch-all na :5173)
+jedním — cesty teď routuje Traefik:
+
+```yaml
+  - hostname: shelfy.cz
+    service: http://127.0.0.1:80
+```
+
+```bash
+sudo systemctl restart cloudflared
+```
+
+**C7. Ověření** (výpadek končí):
+
+```bash
+curl -fsS https://shelfy.cz/health/ready && echo OK
+kubectl -n shelfy logs -f deploy/backend   # sleduj při proklikávání
+```
+
+Prohlížeč: login, výpůjčka, hledání knihy (ověří MinIO obálky), demo stránka.
+
+**C8. Dostop compose frontend + retarget Prometheus:**
+
+```bash
+docker compose --env-file infra/.env.prod.local -f infra/docker-compose.prod.yml stop frontend
+```
+
+V `infra/prometheus/prometheus.yml` změň target backendu na
+`192.168.88.3:30800` a `docker compose --env-file infra/.env.prod.local -f
+infra/docker-compose.prod.yml restart prometheus` (compose Grafana/Prometheus
+zatím zůstávají — do k3s se stěhují v týdnu 3 plánu).
+
+---
+
+## Rollback (kdykoli, ~5 minut)
+
+```bash
+sudo cp /etc/cloudflared/config.yml.bak-pre-k3s /etc/cloudflared/config.yml
+sudo systemctl restart cloudflared
+docker compose --env-file infra/.env.prod.local -f infra/docker-compose.prod.yml \
+  start backend worker beat frontend
+```
+
+Data: compose DB je nedotčená ve stavu z C1. Zápisy, které mezitím přijal k3s,
+v ní nejsou — když rollbackuješ po delším ostrém provozu, přenes je dumpem
+z k3s (`kubectl -n shelfy exec deploy/postgres -- pg_dump -U shelfy -Fc shelfy > ...`
+a restore do compose postgresu).
+
+## Po cutoveru
+
+- **14 dní nemazat** compose stack ani jeho volumes; pak `docker compose down` (bez `-v`!) a volumes ruč po dalším týdnu.
+- `free -h` a `kubectl top nodes/pods -n shelfy` první dny hlídej — 8 GB RAM je těsných.
+- Staging namespace po týdnu smaž: `kubectl delete ns shelfy-staging` (uvolní ~1,5 GB RAM).
+- Beat v k3s převzal R2 zálohy — druhý den zkontroluj, že v R2 přibyl nový dump.
+- Follow-upy (dny 10–20 plánu): deploy pipeline s pinovaným `sha-*` tagem místo `latest`, SOPS pro secrets, kube-prometheus-stack, rotace MinIO root credentials, doplnit `host` do pgadmin ingressu (teď chytá všechno na :80).

--- a/infra/k8s/CUTOVER.md
+++ b/infra/k8s/CUTOVER.md
@@ -1,5 +1,8 @@
 # Cutover: shelfy.cz z Docker Compose do k3s
 
+> **✅ PROVEDENO 12. 7. 2026** — produkce běží v k3s (namespace `shelfy`).
+> Dokument zůstává jako runbook-záznam a podklad pro rollback okno (14 dní).
+
 Runbook pro přepnutí produkce. Piš si k němu časy a poznámky — je to zároveň
 podklad pro pohovorovou historku. Všechno se spouští na homelab2 jako `suslik`
 (kroky se `sudo` jsou označené).

--- a/infra/k8s/CUTOVER.md
+++ b/infra/k8s/CUTOVER.md
@@ -15,11 +15,11 @@ cd ~/shelfy && export KUBECONFIG=~/.kube/config
 
 ## Fáze A — jednorázová příprava (kdykoli předem)
 
-### A1. Zveřejnit images v GHCR (jinak ImagePullBackOff)
+### A1. Images v GHCR — ✅ hotovo
 
-Na GitHubu: profil → **Packages** → `shelfy-backend`, `shelfy-worker`,
-`shelfy-frontend` → Package settings → Danger zone → **Change visibility →
-Public**. (Repo je stejně public, images neobsahují nic navíc.)
+Cluster stahuje `shelfy-backend`, `shelfy-worker` i `shelfy-frontend` bez
+pull secretu (ověřeno staging deployem 12. 7.). Kdyby někdy nová image skončila
+v ImagePullBackOff: GitHub → Packages → Package settings → Change visibility → Public.
 
 ### A2. Staging přes tunel (sudo)
 
@@ -89,6 +89,12 @@ kubectl -n shelfy exec -i deploy/postgres -- \
   < ~/backups/shelfy-cutover-*.dump
 kubectl -n shelfy exec deploy/postgres -- \
   psql -U shelfy -d shelfy -c "select count(*) from users;"   # sanity
+
+# glibc collation dumpu a podu se liší (staging to potvrdil) — bez reindexu
+# můžou být textové indexy potichu špatně seřazené:
+kubectl -n shelfy exec deploy/postgres -- \
+  psql -U shelfy -d shelfy -c "REINDEX DATABASE shelfy;" \
+  -c "ALTER DATABASE shelfy REFRESH COLLATION VERSION;"
 ```
 
 **C4. MinIO delta:** `infra/k8s/scripts/mirror-minio.sh prod`

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,0 +1,50 @@
+# shelfy on k3s
+
+Kubernetes manifests for running the shelfy stack on the homelab k3s cluster,
+replacing `infra/docker-compose.prod.yml`. Plain kustomize — no Helm yet
+(charts are a planned follow-up).
+
+## Layout
+
+```
+base/                  # environment-agnostic manifests (host + tags patched per overlay)
+overlays/staging/      # namespace shelfy-staging, host staging.shelfy.cz, beat scaled to 0
+overlays/prod/         # namespace shelfy, host shelfy.cz, + NodePort 30800 for compose Prometheus
+scripts/gen-secrets.sh # builds the shelfy-secrets Secret from the live compose stack
+scripts/mirror-minio.sh# mirrors the prod MinIO bucket into a k3s environment
+scripts/smoke.sh       # curl smoke test through Traefik (Host-header based, no DNS needed)
+CUTOVER.md             # production cutover runbook (Czech)
+```
+
+## Architecture notes
+
+- **Traffic**: Cloudflare Tunnel → Traefik (k3s svclb on :80) → Ingress routes
+  `/api` + `/health` to the backend, everything else to the frontend. TLS
+  terminates at Cloudflare, same as the compose setup.
+- **Images**: built by `.github/workflows/images.yml` into GHCR. Backend and
+  worker are env-agnostic (`:latest`, `:sha-*`); the frontend bakes
+  `VITE_API_BASE_URL` at build time so it has per-env tags (`:staging`, `:prod`).
+- **Migrations**: `alembic upgrade head` runs as an initContainer on the
+  backend, mirroring `deploy-prod.local.sh`.
+- **Data**: local-path PVCs, pinned to homelab2 via the amd64 nodeSelector
+  (images are amd64-only for now; the rpi node runs other workloads).
+- **Secrets**: `shelfy-secrets` is created out-of-band by `gen-secrets.sh` and
+  never committed. Postgres/Redis passwords are rotated to random values on
+  first generation (the compose ones were placeholders). SOPS is a planned
+  follow-up.
+- **Exactly one beat**: beat drives scheduled jobs (reminder e-mails, R2
+  backups). It runs only in prod, never in staging, and never concurrently
+  with the compose beat.
+
+## Deploy
+
+```bash
+export KUBECONFIG=~/.kube/config
+
+# staging
+infra/k8s/scripts/gen-secrets.sh staging
+kubectl apply -k infra/k8s/overlays/staging
+infra/k8s/scripts/smoke.sh staging.shelfy.cz
+
+# prod — follow CUTOVER.md, do not just apply
+```

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,8 +1,12 @@
 # shelfy on k3s
 
-Kubernetes manifests for running the shelfy stack on the homelab k3s cluster,
-replacing `infra/docker-compose.prod.yml`. Plain kustomize — no Helm yet
-(charts are a planned follow-up).
+Kubernetes manifests for the shelfy stack on the homelab k3s cluster. Plain
+kustomize — no Helm yet (charts are a planned follow-up).
+
+**Status: production (`shelfy.cz`) runs from the `prod` overlay since
+2026-07-12** (cutover per [CUTOVER.md](CUTOVER.md)). Staging lives in the
+`shelfy-staging` namespace alongside it. The compose files in `infra/` are the
+short-term rollback path only.
 
 ## Layout
 
@@ -38,13 +42,19 @@ CUTOVER.md             # production cutover runbook (Czech)
 
 ## Deploy
 
+**Code changes (CD):** merge to `main` → the `images` workflow builds and
+pushes sha-tagged images to GHCR → the `Deploy` workflow pins them with
+`kubectl set image` and waits for the rollout + an end-to-end health check
+through the tunnel. Never deploys mutable `:latest`.
+
+**Manifest changes (manual for now):**
+
 ```bash
 export KUBECONFIG=~/.kube/config
 
-# staging
-infra/k8s/scripts/gen-secrets.sh staging
-kubectl apply -k infra/k8s/overlays/staging
-infra/k8s/scripts/smoke.sh staging.shelfy.cz
-
-# prod — follow CUTOVER.md, do not just apply
+kubectl apply -k infra/k8s/overlays/staging   # or overlays/prod
+infra/k8s/scripts/smoke.sh staging.shelfy.cz  # or shelfy.cz
 ```
+
+Secrets are managed by `scripts/gen-secrets.sh <env>` (idempotent; safe to
+rerun — existing datastore passwords are preserved).

--- a/infra/k8s/base/backend.yaml
+++ b/infra/k8s/base/backend.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      # Mirrors deploy-prod.local.sh: migrations run before the app serves traffic.
+      # alembic upgrade head is idempotent — a no-op when the schema is current.
+      initContainers:
+        - name: migrate
+          image: ghcr.io/smeglofus/shelfy-backend:latest
+          imagePullPolicy: Always
+          command: ["alembic", "upgrade", "head"]
+          envFrom:
+            - secretRef:
+                name: shelfy-secrets
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+      containers:
+        - name: backend
+          image: ghcr.io/smeglofus/shelfy-backend:latest
+          imagePullPolicy: Always
+          command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+          envFrom:
+            - secretRef:
+                name: shelfy-secrets
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 768Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/infra/k8s/base/beat.yaml
+++ b/infra/k8s/base/beat.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: celerybeat-state
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: beat
+  labels:
+    app: beat
+spec:
+  replicas: 1
+  # Recreate: exactly one beat may hold the schedule file (and only one beat
+  # instance may ever run against the broker, or periodic tasks fire twice).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: beat
+  template:
+    metadata:
+      labels:
+        app: beat
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      # fsGroup replaces the compose beat-init chown job: the worker image runs
+      # as uid 1000 and gets group write on the mounted volume.
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: beat
+          image: ghcr.io/smeglofus/shelfy-worker:latest
+          imagePullPolicy: Always
+          command: ["celery", "-A", "celery_beat", "beat", "--loglevel=info", "--schedule=/var/lib/celerybeat/celerybeat-schedule"]
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: shelfy-secrets
+                  key: DATABASE_URL_SYNC
+          envFrom:
+            - secretRef:
+                name: shelfy-secrets
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: state
+              mountPath: /var/lib/celerybeat
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: celerybeat-state

--- a/infra/k8s/base/frontend.yaml
+++ b/infra/k8s/base/frontend.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: frontend
+          # VITE_API_BASE_URL is baked in at build time, so staging and prod use
+          # different image tags (:staging / :prod) built by images.yml.
+          image: ghcr.io/smeglofus/shelfy-frontend:staging
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 5173
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5173
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 5173
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  selector:
+    app: frontend
+  ports:
+    - port: 5173
+      targetPort: 5173

--- a/infra/k8s/base/ingress.yaml
+++ b/infra/k8s/base/ingress.yaml
@@ -1,0 +1,35 @@
+# Mirrors the cloudflared ingress rules: /api/* and /health* go to the
+# backend, everything else to the frontend. TLS terminates at Cloudflare;
+# cloudflared forwards plain HTTP to Traefik on :80 with the original Host
+# header, which this Ingress routes on. The host is patched per overlay.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: shelfy
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: shelfy.example
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /health
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 5173

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - postgres.yaml
+  - redis.yaml
+  - minio.yaml
+  - backend.yaml
+  - worker.yaml
+  - beat.yaml
+  - frontend.yaml
+  - ingress.yaml

--- a/infra/k8s/base/minio.yaml
+++ b/infra/k8s/base/minio.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+          args: ["server", "/data", "--console-address", ":9001"]
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: shelfy-secrets
+                  key: MINIO_ROOT_USER
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: shelfy-secrets
+                  key: MINIO_ROOT_PASSWORD
+          ports:
+            - containerPort: 9000
+            - containerPort: 9001
+          readinessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001

--- a/infra/k8s/base/postgres.yaml
+++ b/infra/k8s/base/postgres.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  # Recreate: two postgres pods must never share the same PVC.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: postgres
+          image: postgres:16.6
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: shelfy-secrets
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: shelfy-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: shelfy-secrets
+                  key: POSTGRES_PASSWORD
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/infra/k8s/base/redis.yaml
+++ b/infra/k8s/base/redis.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: redis
+          image: redis:7.4
+          # $(VAR) is expanded by kubelet from the env section below.
+          args: ["redis-server", "--appendonly", "yes", "--requirepass", "$(REDIS_PASSWORD)"]
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: shelfy-secrets
+                  key: REDIS_PASSWORD
+          ports:
+            - containerPort: 6379
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "redis-cli -a \"$REDIS_PASSWORD\" ping | grep -q PONG"]
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "redis-cli -a \"$REDIS_PASSWORD\" ping | grep -q PONG"]
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: redis-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/infra/k8s/base/worker.yaml
+++ b/infra/k8s/base/worker.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: worker
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: worker
+          image: ghcr.io/smeglofus/shelfy-worker:latest
+          imagePullPolicy: Always
+          command: ["celery", "-A", "celery_app", "worker", "--loglevel=info", "-Q", "default"]
+          # Explicit env wins over envFrom: the worker talks to Postgres with the
+          # sync (psycopg2) driver, same as in docker-compose.prod.yml.
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: shelfy-secrets
+                  key: DATABASE_URL_SYNC
+          envFrom:
+            - secretRef:
+                name: shelfy-secrets
+          resources:
+            requests:
+              cpu: 100m
+              memory: 192Mi
+            limits:
+              memory: 768Mi

--- a/infra/k8s/overlays/prod/backend-nodeport.yaml
+++ b/infra/k8s/overlays/prod/backend-nodeport.yaml
@@ -1,0 +1,16 @@
+# LAN-only escape hatch for the compose Prometheus (ADR 010): after cutover the
+# backend no longer publishes 127.0.0.1:8000, so Prometheus scrapes
+# 192.168.88.3:30800/metrics instead. Goes away in week 3 when monitoring
+# moves to kube-prometheus-stack + ServiceMonitor.
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: backend
+  ports:
+    - port: 8000
+      targetPort: 8000
+      nodePort: 30800

--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Namespace `shelfy` already exists in the cluster (pgadmin lives there).
 namespace: shelfy
 
 resources:
+  - namespace.yaml
   - ../../base
   - backend-nodeport.yaml
 

--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Namespace `shelfy` already exists in the cluster (pgadmin lives there).
+namespace: shelfy
+
+resources:
+  - ../../base
+  - backend-nodeport.yaml
+
+images:
+  - name: ghcr.io/smeglofus/shelfy-backend
+    newTag: latest
+  - name: ghcr.io/smeglofus/shelfy-worker
+    newTag: latest
+  - name: ghcr.io/smeglofus/shelfy-frontend
+    newTag: prod
+
+patches:
+  - target:
+      kind: Ingress
+      name: shelfy
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: shelfy.cz

--- a/infra/k8s/overlays/prod/namespace.yaml
+++ b/infra/k8s/overlays/prod/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: shelfy

--- a/infra/k8s/overlays/staging/kustomization.yaml
+++ b/infra/k8s/overlays/staging/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: shelfy-staging
+
+resources:
+  - namespace.yaml
+  - ../../base
+
+images:
+  - name: ghcr.io/smeglofus/shelfy-backend
+    newTag: latest
+  - name: ghcr.io/smeglofus/shelfy-worker
+    newTag: latest
+  - name: ghcr.io/smeglofus/shelfy-frontend
+    newTag: staging
+
+patches:
+  # Staging hostname (served through the Cloudflare tunnel like prod).
+  - target:
+      kind: Ingress
+      name: shelfy
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: staging.shelfy.cz
+  # No beat in staging: periodic jobs (reminder e-mails, R2 backups) must only
+  # ever run against production data, and never twice.
+  - target:
+      kind: Deployment
+      name: beat
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 0

--- a/infra/k8s/overlays/staging/namespace.yaml
+++ b/infra/k8s/overlays/staging/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: shelfy-staging

--- a/infra/k8s/pgadmin/pgadmin.yaml
+++ b/infra/k8s/pgadmin/pgadmin.yaml
@@ -1,0 +1,95 @@
+# pgAdmin — cluster admin tool, ONE instance for the whole cluster. Lives
+# outside base/ on purpose: overlays must not stamp a copy per environment.
+#
+# The pgadmin-secret is NOT in git (public repo). Create it once:
+#
+#   kubectl -n shelfy create secret generic pgadmin-secret \
+#     --from-literal=PGADMIN_DEFAULT_EMAIL=admin@shelfy.cz \
+#     --from-literal=PGADMIN_DEFAULT_PASSWORD="$(openssl rand -hex 16)"
+#
+# Apply: kubectl -n shelfy apply -f infra/k8s/pgadmin/pgadmin.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pgadmin-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgadmin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pgadmin
+  template:
+    metadata:
+      labels:
+        app: pgadmin
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: raspberrypi
+      securityContext:
+        fsGroup: 5050
+      containers:
+        - name: pgadmin
+          image: dpage/pgadmin4:8
+          ports:
+            - containerPort: 80
+          envFrom:
+            - secretRef:
+                name: pgadmin-secret
+          env:
+            - name: PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION
+              value: "True"
+          volumeMounts:
+            - name: pgadmin-data
+              mountPath: /var/lib/pgadmin
+          resources:
+            requests:
+              memory: "256Mi"
+            limits:
+              memory: "512Mi"
+      volumes:
+        - name: pgadmin-data
+          persistentVolumeClaim:
+            claimName: pgadmin-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgadmin
+spec:
+  type: ClusterIP
+  selector:
+    app: pgadmin
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+# TODO(follow-up): add an explicit `host:` here — a host-less rule catches every
+# request on :80 that no other Ingress claims (the shelfy Ingresses win on their
+# hosts, so the app is unaffected, but this should not stay a catch-all).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pgadmin
+spec:
+  ingressClassName: traefik
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: pgadmin
+                port:
+                  number: 80

--- a/infra/k8s/scripts/gen-secrets.sh
+++ b/infra/k8s/scripts/gen-secrets.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Create/update the shelfy-secrets Secret for staging or prod.
+#
+# Source of truth is the RUNNING compose stack (docker inspect), not the env
+# files — .env.prod.local drifted from reality once already. Datastore
+# passwords (Postgres, Redis) are rotated to fresh random values on first run
+# because the compose ones are CHANGE_ME placeholders; reruns keep whatever
+# the existing Secret already holds so an initialized PVC never mismatches.
+#
+# Usage: ./gen-secrets.sh staging|prod
+set -euo pipefail
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+ENV_NAME="${1:?usage: gen-secrets.sh staging|prod}"
+case "$ENV_NAME" in
+  staging) NS=shelfy-staging; PUBLIC_URL="https://staging.shelfy.cz" ;;
+  prod)    NS=shelfy;         PUBLIC_URL="https://shelfy.cz" ;;
+  *) echo "usage: gen-secrets.sh staging|prod" >&2; exit 1 ;;
+esac
+
+container_env() { docker inspect "$1" --format '{{range .Config.Env}}{{println .}}{{end}}'; }
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP" "$TMP.n"' EXIT
+chmod 600 "$TMP"
+
+# Everything the backend runs with, minus image-runtime noise.
+container_env infra-backend-1 \
+  | grep -vE '^(PATH|HOSTNAME|LANG|GPG_KEY|PYTHON_VERSION|PYTHON_SHA256|PYTHONDONTWRITEBYTECODE|PYTHONUNBUFFERED)=' \
+  | grep -vE '^$' > "$TMP"
+
+# Beat-only knobs the backend env doesn't carry.
+container_env infra-beat-1 | grep -E '^(BACKUP_KEEP_DAYS|STRIPE_EVENTS_KEEP_DAYS)=' >> "$TMP"
+
+set_kv() {
+  grep -v "^$1=" "$TMP" > "$TMP.n" || true
+  mv "$TMP.n" "$TMP"
+  printf '%s=%s\n' "$1" "$2" >> "$TMP"
+}
+
+existing() {
+  kubectl -n "$NS" get secret shelfy-secrets -o "jsonpath={.data.$1}" 2>/dev/null | base64 -d || true
+}
+
+# --- datastore credentials: reuse if the Secret exists, else generate fresh ---
+PG_DB="$(container_env infra-postgres-1 | sed -n 's/^POSTGRES_DB=//p')"
+PG_USER="$(container_env infra-postgres-1 | sed -n 's/^POSTGRES_USER=//p')"
+PG_PW="$(existing POSTGRES_PASSWORD)"
+[ -n "$PG_PW" ] || PG_PW="$(openssl rand -hex 24)"
+REDIS_PW="$(existing REDIS_PASSWORD)"
+[ -n "$REDIS_PW" ] || REDIS_PW="$(openssl rand -hex 24)"
+
+set_kv POSTGRES_DB "$PG_DB"
+set_kv POSTGRES_USER "$PG_USER"
+set_kv POSTGRES_PASSWORD "$PG_PW"
+set_kv REDIS_PASSWORD "$REDIS_PW"
+set_kv DATABASE_URL "postgresql+asyncpg://$PG_USER:$PG_PW@postgres:5432/$PG_DB"
+set_kv DATABASE_URL_SYNC "postgresql+psycopg2://$PG_USER:$PG_PW@postgres:5432/$PG_DB"
+set_kv REDIS_URL "redis://:$REDIS_PW@redis:6379/0"
+set_kv CELERY_BROKER_URL "redis://:$REDIS_PW@redis:6379/0"
+set_kv CELERY_RESULT_BACKEND "redis://:$REDIS_PW@redis:6379/0"
+
+# MinIO root credentials come from the live minio container (unchanged — the
+# bucket data is mirrored, rotating them is a post-cutover follow-up).
+container_env infra-minio-1 | grep -E '^MINIO_ROOT_(USER|PASSWORD)=' | while IFS='=' read -r k v; do
+  set_kv "$k" "$v"
+done
+
+set_kv APP_URL "$PUBLIC_URL"
+set_kv CORS_ALLOWED_ORIGINS "[\"$PUBLIC_URL\"]"
+set_kv GOOGLE_REDIRECT_URI "$PUBLIC_URL/auth/callback"
+
+if [ "$ENV_NAME" = "staging" ]; then
+  # Staging must never e-mail real people or pollute prod Sentry.
+  set_kv RESEND_API_KEY ""
+  set_kv SENTRY_DSN ""
+fi
+
+kubectl get namespace "$NS" >/dev/null 2>&1 || kubectl create namespace "$NS"
+kubectl -n "$NS" create secret generic shelfy-secrets \
+  --from-env-file="$TMP" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "OK: secret shelfy-secrets applied in namespace $NS ($(grep -c '=' "$TMP") keys)"

--- a/infra/k8s/scripts/mirror-minio.sh
+++ b/infra/k8s/scripts/mirror-minio.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Mirror the production MinIO bucket (compose) into the k3s MinIO of the given
+# environment. Idempotent — reruns copy only the delta. Run on homelab2.
+#
+# Usage: ./mirror-minio.sh staging|prod
+set -euo pipefail
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+ENV_NAME="${1:?usage: mirror-minio.sh staging|prod}"
+case "$ENV_NAME" in
+  staging) NS=shelfy-staging ;;
+  prod)    NS=shelfy ;;
+  *) echo "usage: mirror-minio.sh staging|prod" >&2; exit 1 ;;
+esac
+
+container_env() { docker inspect "$1" --format '{{range .Config.Env}}{{println .}}{{end}}'; }
+
+SRC_IP="$(docker inspect infra-minio-1 --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')"
+DST_IP="$(kubectl -n "$NS" get svc minio -o jsonpath='{.spec.clusterIP}')"
+ROOT_USER="$(container_env infra-minio-1 | sed -n 's/^MINIO_ROOT_USER=//p')"
+ROOT_PW="$(container_env infra-minio-1 | sed -n 's/^MINIO_ROOT_PASSWORD=//p')"
+BUCKET="$(container_env infra-backend-1 | sed -n 's/^MINIO_BUCKET=//p')"
+
+echo "Mirroring bucket '$BUCKET': $SRC_IP:9000 (compose) -> $DST_IP:9000 (k3s/$NS)"
+
+# host network: reaches both the docker bridge IP and the k3s ClusterIP.
+docker run --rm --network host --entrypoint sh \
+  -e SRC_IP="$SRC_IP" -e DST_IP="$DST_IP" \
+  -e ROOT_USER="$ROOT_USER" -e ROOT_PW="$ROOT_PW" -e BUCKET="$BUCKET" \
+  minio/mc -c '
+    set -eu
+    mc alias set src "http://$SRC_IP:9000" "$ROOT_USER" "$ROOT_PW" >/dev/null
+    mc alias set dst "http://$DST_IP:9000" "$ROOT_USER" "$ROOT_PW" >/dev/null
+    mc mb --ignore-existing "dst/$BUCKET"
+    mc mirror --overwrite "src/$BUCKET" "dst/$BUCKET"
+  '
+
+echo "OK: bucket '$BUCKET' mirrored into $NS"

--- a/infra/k8s/scripts/smoke.sh
+++ b/infra/k8s/scripts/smoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Smoke test a shelfy deployment through Traefik, without needing DNS or the
+# tunnel: talks to the node's :80 and sets the Host header explicitly.
+#
+# Usage: ./smoke.sh staging.shelfy.cz | ./smoke.sh shelfy.cz
+set -euo pipefail
+
+HOST="${1:?usage: smoke.sh <ingress-host>}"
+BASE="http://127.0.0.1:80"
+
+check() {
+  local label="$1" path="$2" expect="${3:-200}"
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' -H "Host: $HOST" "$BASE$path")"
+  if [ "$code" = "$expect" ]; then
+    echo "OK   $label ($path -> $code)"
+  else
+    echo "FAIL $label ($path -> $code, expected $expect)"
+    return 1
+  fi
+}
+
+rc=0
+check "backend liveness " /health        || rc=1
+check "backend readiness" /health/ready  || rc=1
+check "frontend         " /              || rc=1
+check "api 404 passthru " /api/definitely-not-a-route 404 || rc=1
+
+if [ "$rc" -eq 0 ]; then
+  echo "SMOKE PASSED for $HOST"
+else
+  echo "SMOKE FAILED for $HOST" >&2
+fi
+exit "$rc"

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -8,4 +8,7 @@ global:
 scrape_configs:
   - job_name: shelfy-backend
     static_configs:
-      - targets: ["backend:8000"]
+      # Backend runs in k3s since 2026-07-12; scraped via the LAN-only NodePort
+      # (infra/k8s/overlays/prod/backend-nodeport.yaml). Interim until the
+      # monitoring stack itself moves into the cluster.
+      - targets: ["192.168.88.3:30800"]


### PR DESCRIPTION
## Co to je

Kompletní podklad pro migraci shelfy z Docker Compose do k3s (den 6+ learning path, rozhodnutí migrovat produkci před získáním platících zákazníků).

- **infra/k8s/base/** — kustomize manifesty celého stacku: postgres, redis, minio, backend (alembic jako initContainer), worker (sync DATABASE_URL), beat (fsGroup místo beat-init, PVC pro schedule), frontend, ingress (/api + /health → backend, zbytek → frontend; zrcadlí cloudflared pravidla)
- **overlays/staging** — ns `shelfy-staging`, host `staging.shelfy.cz`, beat=0 (žádné maily/zálohy ze stagingu)
- **overlays/prod** — ns `shelfy`, host `shelfy.cz`, NodePort 30800 pro stávající compose Prometheus
- **.github/workflows/images.yml** — build & push do GHCR (backend/worker `:latest`+`:sha-*`; frontend `:staging`/`:prod` — VITE_API_BASE_URL se peče do buildu)
- **scripts/gen-secrets.sh** — Secret z běžících kontejnerů (zdroj pravdy), rotuje CHANGE_ME hesla Postgres/Redis
- **scripts/mirror-minio.sh, smoke.sh** — kopie bucketu, Host-header smoke test
- **CUTOVER.md** — runbook přepnutí produkce vč. rollbacku

## Bezpečnost / provoz

- Žádný secret v repu; hesla datastores se rotují při prvním gen-secrets
- TLS terminuje Cloudflare, tunel → Traefik :80 (stejně jako dosud → :5173/:8000)
- Beat běží vždy právě jednou (staging 0, cutover řeší pořadí stop/start)

## Ověřeno

- `kubectl kustomize` obě overlay renderují (18 objektů)
- `kubectl apply -k overlays/prod --dry-run=server` — všech 18 objektů prošlo
- Staging deploy + restore dat + smoke proběhne z této větve (images workflow běží na push do ní)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes (k3s) support for backend, workers, Celery beat, Postgres, Redis, MinIO, and frontend, with Traefik routing for `/api`, `/health`, and the web UI.
  * Added separate staging and production environments, including production cutover/rollback runbooks and prod-only beat behavior.
  * Added pgAdmin for internal database management.
* **CI/CD**
  * Added automated Docker image build + push to GHCR, with commit-SHA tagging.
  * Updated deployment to rollout pinned k3s images and run external health checks, with updated rollback guidance.
* **Documentation**
  * Refreshed the k3s deployment README, architecture notes, and secret-generation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->