### PR TITLE
fix(deploy): kubectl v CD čte kubeconfig (uid 1000) + rebuild images při změně deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,11 @@ jobs:
           # The runner container has no kubectl; run it via the host docker
           # daemon with the host kubeconfig. TODO(security follow-up): replace
           # the admin kubeconfig with a namespace-scoped ServiceAccount.
+          # --user 1000 matches the kubeconfig owner on the host (the image's
+          # default uid 1001 can't read the 600-mode file); HOME=/tmp gives
+          # kubectl a writable cache dir.
           kc() {
-            docker run --rm --network host \
+            docker run --rm --network host --user 1000 -e HOME=/tmp \
               -v /home/suslik/.kube/config:/kube/config:ro \
               -e KUBECONFIG=/kube/config \
               bitnami/kubectl:latest "$@"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -12,6 +12,9 @@ on:
       - "worker/**"
       - "frontend/**"
       - ".github/workflows/images.yml"
+      # deploy.yml chains off this workflow (workflow_run) and pins sha tags —
+      # rebuilding here guarantees the tag for HEAD exists before it deploys.
+      - ".github/workflows/deploy.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
První ostrý běh k3s CD (run 29203614843) spadl na `open /kube/config: permission denied` — bitnami/kubectl běží jako uid 1001, host kubeconfig je 600/uid 1000. Fix: `--user 1000 -e HOME=/tmp`. Ověřeno lokálně identickým docker run příkazem.

Druhá změna: `deploy.yml` přidán do paths `images.yml`, aby merge změny deploy workflow vždy postavil images pro daný sha (Deploy pinuje `sha-*` tagy a jinak by neměl co nasadit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)