### PR TITLE
security: hosted CI runner, pgAdmin host, scoped deploy RBAC (C1/H3/H4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,21 @@ concurrency:
 # run as independent jobs so a lint failure never suppresses test results.
 # Both are required checks for branch protection (see bottom of this file).
 #
-# Runner placement (issue: CI-minute pressure on the Free tier):
+# Runner placement:
 #
-#   - lint / backend tests / frontend / security-scan run on the self-hosted
-#     runner attached to the homelab box (label `shelfy`). Cheap, fast, and
-#     the host has plenty of CPU + caches.
-#   - e2e / e2e-p0-mobile stay on `ubuntu-latest`. Playwright + headless
-#     browsers want ~2 GB on top of the test process which is more than
-#     this 7.5 GB host can spare alongside prod.
+#   All CI jobs run on GitHub-hosted `ubuntu-latest`. Standard hosted runners
+#   are FREE and unmetered on public repositories, so there is no minute
+#   pressure to offload onto a self-hosted runner — and doing so was a real
+#   security risk: the self-hosted CI runner mounted /var/run/docker.sock (root
+#   on the prod box) and CI runs on `pull_request`, i.e. potentially untrusted
+#   fork code. Hosted runners are ephemeral and isolated, so that whole class
+#   of "malicious PR -> RCE on production" goes away.
 #
-# See infra/docker-compose.runner.yml for the runner compose definition.
+#   Only the Deploy workflow (.github/workflows/deploy.yml) stays on a
+#   self-hosted runner (label `shelfy-prod`) — it must run on the box that
+#   holds cluster access, and it only ever runs trusted `main`/dispatch code,
+#   never fork PRs. The old CI runner (infra/docker-compose.runner.yml) is no
+#   longer referenced and can be torn down.
 
 jobs:
 
@@ -44,7 +49,7 @@ jobs:
   # No Postgres needed — pure static analysis.
   backend-lint:
     name: backend / lint
-    runs-on: [self-hosted, shelfy]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -82,44 +87,27 @@ jobs:
   # prevents tests from producing a result (which was the original blind spot).
   backend-tests:
     name: backend / tests
-    runs-on: [self-hosted, shelfy]
-    # ``services:`` deliberately not used here — on the self-hosted runner
-    # GHA creates a per-run ``github_network_*`` for service containers
-    # that the runner itself isn't on, and the job runs *on the runner*
-    # (not in a sibling container), so neither localhost nor the service
-    # DNS name resolves. Using ``container:`` to fix that hits another
-    # pothole: the ``myoung34/github-runner`` image puts its externals
-    # in a non-standard path, so GHA can't inject node20 into a job
-    # container and ``actions/checkout`` blows up on the first step.
-    #
-    # Workaround: spawn postgres ourselves on the same Docker network the
-    # runner already lives on (``infra_default``), reach it by container
-    # name. Robust against both GHA-hosted and self-hosted runtimes —
-    # the ``services:`` block was a convenience, not a contract.
+    runs-on: ubuntu-latest
+    # Postgres as a service container. GitHub-hosted runners publish service
+    # containers on localhost, so the test process reaches them directly — no
+    # host Docker socket required (that socket, on the old self-hosted runner,
+    # was the RCE vector this migration removes).
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: shelfy_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test -d shelfy_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
 
     steps:
-      - name: Start postgres container
-        # Unique name per run lets parallel jobs co-exist on the same host.
-        run: |
-          docker run -d \
-            --name ci-postgres-${{ github.run_id }} \
-            --network infra_default \
-            -e POSTGRES_USER=test \
-            -e POSTGRES_PASSWORD=test \
-            -e POSTGRES_DB=shelfy_test \
-            postgres:16
-          # Health-check loop, max 30s.
-          for i in $(seq 1 30); do
-            if docker exec ci-postgres-${{ github.run_id }} pg_isready -U test -d shelfy_test >/dev/null 2>&1; then
-              echo "Postgres ready after ${i}s"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "Postgres failed to become ready" >&2
-          docker logs ci-postgres-${{ github.run_id }}
-          exit 1
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -136,21 +124,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
 
-      - name: Install postgresql-client
-        # GHA-hosted ubuntu-latest ships psql preinstalled; the self-hosted
-        # runner image (myoung34/github-runner) does not. Apt cache makes
-        # this <5s on warm hosts.
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends postgresql-client
-
       - name: Install pg_trgm extension
-        run: psql postgresql://test:test@ci-postgres-${{ github.run_id }}:5432/shelfy_test -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+        # psql ships preinstalled on ubuntu-latest.
+        run: psql postgresql://test:test@localhost:5432/shelfy_test -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
 
       - name: Pytest with coverage gate
         working-directory: backend
         env:
-          TEST_DATABASE_URL: postgresql+asyncpg://test:test@ci-postgres-${{ github.run_id }}:5432/shelfy_test
+          TEST_DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/shelfy_test
           TESTING: "true"
         run: |
           echo "::group::pytest output"
@@ -160,17 +141,13 @@ jobs:
       - name: Check shelf ordering integrity
         working-directory: backend
         env:
-          DATABASE_URL: postgresql+asyncpg://test:test@ci-postgres-${{ github.run_id }}:5432/shelfy_test
+          DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/shelfy_test
         run: python ../scripts/check_shelf_ordering_integrity.py
-
-      - name: Stop postgres container
-        if: always()
-        run: docker rm -f ci-postgres-${{ github.run_id }} || true
 
   # ── Frontend (lint + test + build + bundle checks) ────────────────────────
   frontend:
     name: frontend
-    runs-on: [self-hosted, shelfy]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -213,7 +190,7 @@ jobs:
   # if-no-files-found: ignore on upload handles the case where install fails.
   security-scan:
     name: security-scan
-    runs-on: [self-hosted, shelfy]
+    runs-on: ubuntu-latest
     continue-on-error: true
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,16 +29,20 @@ jobs:
           echo "Deploying commit $SHA"
 
           # The runner container has no kubectl; run it via the host docker
-          # daemon with the host kubeconfig. TODO(security follow-up): replace
-          # the admin kubeconfig with a namespace-scoped ServiceAccount.
-          # --user 1000 matches the kubeconfig owner on the host (the image's
-          # default uid 1001 can't read the 600-mode file); HOME=/tmp gives
+          # daemon. Uses a namespace-scoped ServiceAccount kubeconfig
+          # (infra/k8s/deploy-rbac.yaml) — NOT the cluster-admin config — so a
+          # compromised deploy can only patch Deployments / read Pods in the
+          # `shelfy` namespace, never read Secrets or reach other namespaces.
+          # kubectl tag is pinned (no mutable :latest); keep it within ±1 minor
+          # of the k3s server version (`kubectl version`). --user 1000 matches
+          # the kubeconfig owner on the host (600-mode file); HOME=/tmp gives
           # kubectl a writable cache dir.
+          # One-time setup: docs/runbooks/deploy-rbac-setup.md
           kc() {
             docker run --rm --network host --user 1000 -e HOME=/tmp \
-              -v /home/suslik/.kube/config:/kube/config:ro \
+              -v /home/suslik/.kube/deploy-config:/kube/config:ro \
               -e KUBECONFIG=/kube/config \
-              bitnami/kubectl:latest "$@"
+              bitnami/kubectl:1.31.3 "$@"
           }
 
           # Pin exact sha tags — never deploy a mutable :latest. `set image`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,10 @@ jobs:
           # (infra/k8s/deploy-rbac.yaml) — NOT the cluster-admin config — so a
           # compromised deploy can only patch Deployments / read Pods in the
           # `shelfy` namespace, never read Secrets or reach other namespaces.
-          # kubectl tag is pinned (no mutable :latest); keep it within ±1 minor
-          # of the k3s server version (`kubectl version`). --user 1000 matches
+          # kubectl tag is pinned (no mutable :latest) and matches the k3s
+          # server (v1.36.2+k3s1) — keep within ±1 minor on upgrades
+          # (`kubectl version`). rancher/kubectl is the k3s-native image
+          # (bitnami/kubectl tags are no longer pullable). --user 1000 matches
           # the kubeconfig owner on the host (600-mode file); HOME=/tmp gives
           # kubectl a writable cache dir.
           # One-time setup: docs/runbooks/deploy-rbac-setup.md
@@ -42,7 +44,7 @@ jobs:
             docker run --rm --network host --user 1000 -e HOME=/tmp \
               -v /home/suslik/.kube/deploy-config:/kube/config:ro \
               -e KUBECONFIG=/kube/config \
-              bitnami/kubectl:1.31.3 "$@"
+              rancher/kubectl:v1.36.2 "$@"
           }
 
           # Pin exact sha tags — never deploy a mutable :latest. `set image`

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ e2e/tmp_*.js
 # Local-only docs (ops PII, business strategy, internal audits — kept out of
 # the public repo but the directory can hold them on your working copy).
 .private/
+
+# Internal security audit — its findings reference secret locations, infra
+# paths and unremediated weaknesses; must never be published on the public
+# repo. Lives in docs/ on the working copy only, tracked nowhere.
+docs/security-audit.md

--- a/docs/runbooks/deploy-rbac-setup.md
+++ b/docs/runbooks/deploy-rbac-setup.md
@@ -1,0 +1,87 @@
+# Runbook: least-privilege deploy identity (deploy-rbac)
+
+One-time setup that replaces the cluster-admin kubeconfig in the Deploy
+workflow with a namespace-scoped ServiceAccount (`deployer`). After this,
+`.github/workflows/deploy.yml` uses `/home/suslik/.kube/deploy-config`, which
+can only roll Deployments in the `shelfy` namespace — not read Secrets, not
+touch other namespaces.
+
+> ⚠️ **Ordering:** run this on the k3s host **before** merging the PR that
+> switches `deploy.yml` to `deploy-config`. If the workflow points at a
+> kubeconfig that doesn't exist yet, the next deploy fails.
+
+## 1. Apply the RBAC (SA + Role + RoleBinding + token Secret)
+
+```bash
+kubectl apply -f infra/k8s/deploy-rbac.yaml
+```
+
+## 2. Build the scoped kubeconfig
+
+Run on the host, using your admin context (this is the only step that still
+needs admin — reading the CA + the SA token):
+
+```bash
+NS=shelfy
+SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+CA=$(kubectl -n "$NS" get secret deployer-token -o jsonpath='{.data.ca\.crt}')
+TOKEN=$(kubectl -n "$NS" get secret deployer-token -o jsonpath='{.data.token}' | base64 -d)
+
+install -m 600 /dev/null /home/suslik/.kube/deploy-config
+cat > /home/suslik/.kube/deploy-config <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: shelfy
+    cluster:
+      server: ${SERVER}
+      certificate-authority-data: ${CA}
+contexts:
+  - name: deployer
+    context:
+      cluster: shelfy
+      namespace: ${NS}
+      user: deployer
+current-context: deployer
+users:
+  - name: deployer
+    user:
+      token: ${TOKEN}
+EOF
+chmod 600 /home/suslik/.kube/deploy-config
+```
+
+## 3. Verify least privilege (read-only checks)
+
+```bash
+export KUBECONFIG=/home/suslik/.kube/deploy-config
+kubectl -n shelfy get deploy            # ✅ should list deployments
+kubectl -n shelfy auth can-i patch deploy   # ✅ yes
+kubectl -n shelfy auth can-i get secrets    # ✅ NO  (this is the point)
+kubectl -n kube-system get pods         # ✅ should be Forbidden
+unset KUBECONFIG
+```
+
+If `get secrets` returns `yes`, the binding is wrong — do not proceed.
+
+## 4. Merge the PR
+
+Once the checks above pass, merge the PR that points `deploy.yml` at
+`deploy-config`. The next deploy runs with the scoped identity.
+
+## Rotation
+
+The token is long-lived. To rotate: delete + recreate the Secret, then re-run
+step 2.
+
+```bash
+kubectl -n shelfy delete secret deployer-token
+kubectl apply -f infra/k8s/deploy-rbac.yaml   # recreates the empty Secret; control plane repopulates
+# then re-run step 2
+```
+
+## Follow-up: retire the admin kubeconfig from the deploy path
+
+After a few green deploys, confirm `/home/suslik/.kube/config` (cluster-admin)
+is no longer mounted by any workflow (`grep -rn '.kube/config' .github/`).
+Keep the admin config off the runner's reach where practical.

--- a/infra/docker-compose.runner.yml
+++ b/infra/docker-compose.runner.yml
@@ -1,3 +1,14 @@
+# ⚠️ DEPRECATED / DO NOT RUN — as of the CI-runner security migration, all CI
+# jobs run on GitHub-hosted `ubuntu-latest` (free & unmetered on this public
+# repo). This runner mounted /var/run/docker.sock (= root on the prod host) and
+# executed `pull_request` code, i.e. potentially untrusted fork PRs — the exact
+# "malicious PR -> RCE on production" path we closed. Kept only for reference.
+#
+# Tear the running container down and do not bring it back:
+#   docker compose -f infra/docker-compose.runner.yml down github-runner
+# Then remove the stale runner in repo Settings -> Actions -> Runners.
+#
+# ── Original documentation (historical) ──────────────────────────────────────
 # Self-hosted GitHub Actions runner for smeglofus/shelfy.
 #
 # Lives in its own compose file so it can go up/down/upgrade independently

--- a/infra/k8s/deploy-rbac.yaml
+++ b/infra/k8s/deploy-rbac.yaml
@@ -1,0 +1,62 @@
+# Least-privilege deploy identity for the Deploy workflow (H4 remediation).
+#
+# Replaces the cluster-admin kubeconfig previously mounted into the deploy step.
+# The `deployer` ServiceAccount can only get/list/patch/watch Deployments and
+# read ReplicaSets/Pods in the `shelfy` namespace — exactly what
+# `kubectl set image` + `kubectl rollout status` need, and nothing more. It
+# CANNOT read Secrets (so a compromised deploy token can't exfiltrate
+# shelfy-secrets) and cannot touch any other namespace.
+#
+# Apply this manifest and generate the kubeconfig once — see
+# docs/runbooks/deploy-rbac-setup.md. .github/workflows/deploy.yml mounts the
+# resulting kubeconfig from /home/suslik/.kube/deploy-config.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deployer
+  namespace: shelfy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deployer
+  namespace: shelfy
+rules:
+  # `kubectl set image deploy/...` needs get + patch on Deployments.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch", "watch"]
+  # `kubectl rollout status` watches the rollout via ReplicaSets + Pods.
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: deployer
+  namespace: shelfy
+subjects:
+  - kind: ServiceAccount
+    name: deployer
+    namespace: shelfy
+roleRef:
+  kind: Role
+  name: deployer
+  apiGroup: rbac.authorization.k8s.io
+---
+# Long-lived token for CI (k8s >= 1.24 no longer auto-creates SA token Secrets).
+# The token value is populated by the control plane at apply time; it is never
+# stored in git. Only the kubeconfig built from it (kept on the deploy host,
+# mode 600) carries the secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: deployer-token
+  namespace: shelfy
+  annotations:
+    kubernetes.io/service-account.name: deployer
+type: kubernetes.io/service-account-token

--- a/infra/k8s/pgadmin/pgadmin.yaml
+++ b/infra/k8s/pgadmin/pgadmin.yaml
@@ -74,9 +74,12 @@ spec:
       port: 80
       targetPort: 80
 ---
-# TODO(follow-up): add an explicit `host:` here — a host-less rule catches every
-# request on :80 that no other Ingress claims (the shelfy Ingresses win on their
-# hosts, so the app is unaffected, but this should not stay a catch-all).
+# Bound to an explicit, non-public host so this is NOT a catch-all. A host-less
+# rule would catch every request on :80 that no other Ingress claims, quietly
+# exposing the DB admin UI. Cloudflare only tunnels shelfy.cz, so
+# `pgadmin.shelfy.internal` is unreachable from the internet — resolve it via
+# LAN DNS / /etc/hosts when you need the UI, or skip the Ingress entirely and
+# use `kubectl -n shelfy port-forward svc/pgadmin 8080:80` (most secure).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -84,7 +87,8 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - http:
+    - host: pgadmin.shelfy.internal
+      http:
         paths:
           - path: /
             pathType: Prefix


### PR DESCRIPTION
Remediates the three highest-blast-radius findings from the 2026-07-13 security audit. k8s Medium/Low hardening is intentionally deferred.

## What changed

### C1 (Critical) — CI off the socket-mounting self-hosted runner
- All CI jobs (`backend / lint`, `backend / tests`, `frontend`, `security-scan`) → GitHub-hosted `ubuntu-latest`. Free & unmetered on this public repo, so no minute pressure.
- `backend-tests` rewritten to use a `services:` Postgres → **no host Docker socket needed** (that socket = root on the prod box, and CI runs `pull_request` = potentially untrusted fork code).
- `infra/docker-compose.runner.yml` marked **DEPRECATED**.

### H3 (High) — pgAdmin Ingress no longer a catch-all
- Bound to explicit `host: pgadmin.shelfy.internal` (was host-less → caught any unmatched Host on Traefik :80).

### H4 (High) — least-privilege deploy identity
- `infra/k8s/deploy-rbac.yaml`: `deployer` ServiceAccount, scoped to get/patch Deployments + read Pods/ReplicaSets in `shelfy` only (**no Secret access, no other namespaces**).
- `deploy.yml` now mounts the scoped kubeconfig instead of cluster-admin, and pins `bitnami/kubectl:1.31.3` (was `:latest`).

## ⚠️ Required BEFORE merge (H4 ordering)
Run `docs/runbooks/deploy-rbac-setup.md` on the k3s host first — apply the RBAC and generate `/home/suslik/.kube/deploy-config`. If deploy.yml points at a kubeconfig that doesn't exist yet, the next deploy fails.

## After merge
- Tear down the old CI runner: `docker compose -f infra/docker-compose.runner.yml down github-runner`, then remove it in Settings → Actions → Runners.
- Verify cloudflared only tunnels `shelfy.cz` (H3 verification).

## Recommended in the same sweep (not in this PR — your call)
- **H1** — enable branch protection on `main` (it currently auto-deploys with no review). One `gh api` call; command in the audit doc.
- **H2** — `rm .private/.env.prod.local.bak-pre-stripe-live` and rotate the live Stripe key / JWT / DB / R2 / runner PAT.

## Notes
- Deploy stays self-hosted (`shelfy-prod`) on purpose — it needs cluster access and only runs trusted `main`/dispatch code, never fork PRs.
- Internal `docs/security-audit.md` is gitignored (never published); it tracks all findings + status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved deployment security with least-privilege access controls.
  - Pinned deployment tooling to a specific version for more predictable releases.
  - Retired the vulnerable self-hosted CI runner configuration.

- **Infrastructure**
  - Updated CI jobs to use managed build environments and streamlined database testing.
  - Restricted pgAdmin access to its designated host.

- **Documentation**
  - Added deployment access setup, verification, and credential rotation guidance.
  - Documented the deprecation of the legacy CI runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->