### PR TITLE
fix(enrich): obohacení doplní ISBN a anotaci i při hledání podle názvu

### DIFF
--- a/backend/app/services/metadata/open_library.py
+++ b/backend/app/services/metadata/open_library.py
@@ -6,9 +6,96 @@ import httpx
 
 from app.core.config import get_settings
 
+# Fields requested from search.json. ``editions`` gives the best-matching
+# edition (ranked by the ``lang`` param), which carries the edition-level
+# ISBN — the work-level ``isbn`` list mixes all editions together.
+_SEARCH_FIELDS = ",".join([
+    "key",
+    "title",
+    "author_name",
+    "publisher",
+    "first_publish_year",
+    "language",
+    "cover_i",
+    "isbn",
+    "editions",
+    "editions.key",
+    "editions.isbn_13",
+    "editions.isbn_10",
+    "editions.publish_date",
+    "editions.publishers",
+    "editions.languages",
+    "editions.cover_i",
+])
+
 
 def _headers() -> dict[str, str]:
     return {"User-Agent": get_settings().open_library_user_agent}
+
+
+def _parse_year(publish_date: str) -> int | None:
+    for token in publish_date.replace(",", " ").split():
+        if len(token) == 4 and token.isdigit():
+            return int(token)
+    return None
+
+
+def _pick_isbn(edition: dict[str, Any], doc: dict[str, Any]) -> str | None:
+    """Prefer the matched edition's ISBN-13, then its ISBN-10, then any
+    ISBN-13 from the work-level list (which spans all editions)."""
+    for field in ("isbn_13", "isbn_10"):
+        values = edition.get(field)
+        first = values[0] if isinstance(values, list) and values else None
+        if isinstance(first, str):
+            return first
+    isbns = [i for i in (doc.get("isbn") or []) if isinstance(i, str)]
+    isbn_13s = [i for i in isbns if len(i) == 13 and i.startswith(("978", "979"))]
+    if isbn_13s:
+        return isbn_13s[0]
+    return isbns[0] if isbns else None
+
+
+async def _fetch_work_description(client: httpx.AsyncClient, work_key: str | None) -> str | None:
+    """Descriptions live on the work record, not in search results or the
+    books API — fetched separately and best-effort (never fails the lookup)."""
+    if not work_key or not work_key.startswith("/works/"):
+        return None
+    try:
+        response = await client.get(
+            f"https://openlibrary.org{work_key}.json",
+            headers=_headers(),
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    description = data.get("description")
+    if isinstance(description, dict):
+        description = description.get("value")
+    if isinstance(description, str) and description.strip():
+        return description.strip()
+    return None
+
+
+async def _find_work_key_by_isbn(client: httpx.AsyncClient, isbn: str) -> str | None:
+    try:
+        response = await client.get(
+            "https://openlibrary.org/search.json",
+            params={"q": f"isbn:{isbn}", "fields": "key", "limit": 1},
+            headers=_headers(),
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        docs = response.json().get("docs") or []
+    except (httpx.HTTPError, ValueError):
+        return None
+    if not docs:
+        return None
+    key = docs[0].get("key")
+    return key if isinstance(key, str) else None
 
 
 async def fetch_open_library_metadata(
@@ -17,6 +104,8 @@ async def fetch_open_library_metadata(
     title: str | None = None,
     author: str | None = None,
 ) -> dict[str, Any] | None:
+    resolved_isbn = isbn
+    work_key: str | None = None
     if isbn:
         bib_key = f"ISBN:{isbn}"
         response = await client.get(
@@ -33,7 +122,14 @@ async def fetch_open_library_metadata(
     elif title:
         response = await client.get(
             "https://openlibrary.org/search.json",
-            params={"title": title, "author": author or "", "limit": 1},
+            params={
+                "title": title,
+                "author": author or "",
+                "limit": 1,
+                "fields": _SEARCH_FIELDS,
+                # Prefer Czech editions when the work has one; harmless otherwise.
+                "lang": "cs",
+            },
             headers=_headers(),
             timeout=10.0,
         )
@@ -43,15 +139,27 @@ async def fetch_open_library_metadata(
         if not docs:
             return None
         doc = docs[0]
+        editions = (doc.get("editions") or {}).get("docs") or []
+        edition = editions[0] if editions and isinstance(editions[0], dict) else {}
+        resolved_isbn = _pick_isbn(edition, doc)
+        work_key = doc.get("key") if isinstance(doc.get("key"), str) else None
+        edition_language = (edition.get("languages") or [None])[0]
+        doc_language = (doc.get("language") or [None])[0]
+        language = edition_language or doc_language
+        cover_i = edition.get("cover_i") or doc.get("cover_i")
         entry = {
             "title": doc.get("title"),
             "authors": [{"name": (doc.get("author_name") or [None])[0]}],
-            "publishers": [{"name": (doc.get("publisher") or [None])[0]}],
-            "publish_date": str(doc.get("first_publish_year") or ""),
-            "languages": [{"key": f"/languages/{(doc.get('language') or [None])[0]}"}] if doc.get("language") else [],
+            "publishers": [
+                {"name": (edition.get("publishers") or doc.get("publisher") or [None])[0]}
+            ],
+            "publish_date": str(
+                edition.get("publish_date") or doc.get("first_publish_year") or ""
+            ),
+            "languages": [{"key": f"/languages/{language}"}] if language else [],
             "description": None,
             "cover": {
-                "large": f"https://covers.openlibrary.org/b/id/{doc.get('cover_i')}-L.jpg" if doc.get("cover_i") else None,
+                "large": f"https://covers.openlibrary.org/b/id/{cover_i}-L.jpg" if cover_i else None,
                 "medium": None,
                 "small": None,
             },
@@ -60,23 +168,31 @@ async def fetch_open_library_metadata(
         return None
 
     publish_date = str(entry.get("publish_date", ""))
-    year: int | None = None
-    for token in publish_date.replace(",", " ").split():
-        if len(token) == 4 and token.isdigit():
-            year = int(token)
-            break
+    year = _parse_year(publish_date)
 
     cover = entry.get("cover") or {}
+
+    description = (
+        (entry.get("description") or {}).get("value")
+        if isinstance(entry.get("description"), dict)
+        else entry.get("description")
+    )
+    if not description:
+        # The books API (ISBN path) never returns descriptions and the search
+        # path sets none — resolve the work record and pull it from there.
+        if work_key is None and isbn:
+            work_key = await _find_work_key_by_isbn(client, isbn)
+        description = await _fetch_work_description(client, work_key)
 
     # ``cover_image_url`` deliberately points at covers.openlibrary.org —
     # covers are hotlinked at display time, never copied into our storage.
     return {
         "title": entry.get("title"),
         "author": (entry.get("authors") or [{}])[0].get("name"),
-        "isbn": isbn,
+        "isbn": resolved_isbn,
         "publisher": (entry.get("publishers") or [{}])[0].get("name"),
         "language": ((entry.get("languages") or [{}])[0].get("key") or "").split("/")[-1] or None,
-        "description": (entry.get("description") or {}).get("value") if isinstance(entry.get("description"), dict) else entry.get("description"),
+        "description": description,
         "publication_year": year,
         "cover_image_url": cover.get("large") or cover.get("medium") or cover.get("small"),
         "provider": "open_library",

--- a/backend/tests/test_metadata_services.py
+++ b/backend/tests/test_metadata_services.py
@@ -273,6 +273,148 @@ def test_open_library_title_search_sends_user_agent() -> None:
     assert seen_user_agents == [get_settings().open_library_user_agent]
 
 
+def test_open_library_title_search_returns_edition_isbn_and_description() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/search.json":
+            # ISBN must be part of the requested fields, otherwise the search
+            # response never contains it.
+            assert "isbn" in request.url.params["fields"]
+            assert "editions" in request.url.params["fields"]
+            return httpx.Response(
+                200,
+                json={
+                    "docs": [
+                        {
+                            "key": "/works/OL1W",
+                            "title": "Malý princ",
+                            "author_name": ["Antoine de Saint-Exupéry"],
+                            "publisher": ["Gallimard"],
+                            "first_publish_year": 1943,
+                            "language": ["fre", "cze"],
+                            "cover_i": 111,
+                            "isbn": ["2070612759", "9782070612758"],
+                            "editions": {
+                                "numFound": 1,
+                                "docs": [
+                                    {
+                                        "key": "/books/OL1M",
+                                        "isbn_13": ["9788000012345"],
+                                        "publish_date": "2015",
+                                        "publishers": ["Albatros"],
+                                        "languages": ["cze"],
+                                        "cover_i": 777,
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                },
+            )
+        assert request.url.path == "/works/OL1W.json"
+        return httpx.Response(
+            200,
+            json={"description": {"value": "Slavná novela o malém princi."}},
+        )
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await fetch_open_library_metadata(client, None, title="Malý princ", author="Saint-Exupéry")
+
+    metadata = asyncio.run(_run())
+
+    assert metadata is not None
+    # ISBN comes from the best-matching edition, not the mixed work-level list.
+    assert metadata["isbn"] == "9788000012345"
+    assert metadata["description"] == "Slavná novela o malém princi."
+    assert metadata["publisher"] == "Albatros"
+    assert metadata["publication_year"] == 2015
+    assert metadata["language"] == "cze"
+    assert metadata["cover_image_url"] == "https://covers.openlibrary.org/b/id/777-L.jpg"
+
+
+def test_open_library_title_search_falls_back_to_work_level_isbn13() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/search.json"
+        return httpx.Response(
+            200,
+            json={
+                "docs": [
+                    {
+                        "title": "Clean Code",
+                        "author_name": ["Robert C. Martin"],
+                        "first_publish_year": 2008,
+                        "isbn": ["0132350882", "9780132350884"],
+                    }
+                ]
+            },
+        )
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await fetch_open_library_metadata(client, None, title="Clean Code", author=None)
+
+    metadata = asyncio.run(_run())
+
+    assert metadata is not None
+    assert metadata["isbn"] == "9780132350884"
+
+
+def test_open_library_isbn_lookup_backfills_description_from_work() -> None:
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        if request.url.path == "/api/books":
+            return httpx.Response(
+                200,
+                json={
+                    "ISBN:9780134494166": {
+                        "title": "Clean Architecture",
+                        "authors": [{"name": "Robert C. Martin"}],
+                        "publish_date": "2017",
+                    }
+                },
+            )
+        if request.url.path == "/search.json":
+            assert request.url.params["q"] == "isbn:9780134494166"
+            return httpx.Response(200, json={"docs": [{"key": "/works/OL2W"}]})
+        assert request.url.path == "/works/OL2W.json"
+        return httpx.Response(200, json={"description": "Software architecture patterns."})
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await fetch_open_library_metadata(client, "9780134494166", title=None, author=None)
+
+    metadata = asyncio.run(_run())
+
+    assert metadata is not None
+    assert metadata["isbn"] == "9780134494166"
+    assert metadata["description"] == "Software architecture patterns."
+    assert calls == ["/api/books", "/search.json", "/works/OL2W.json"]
+
+
+def test_open_library_description_backfill_failure_keeps_metadata() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/books":
+            return httpx.Response(
+                200,
+                json={"ISBN:9780134494166": {"title": "Clean Architecture", "publish_date": "2017"}},
+            )
+        # Work resolution is best-effort — a failing works lookup must not
+        # break the whole enrichment.
+        return httpx.Response(500)
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await fetch_open_library_metadata(client, "9780134494166", title=None, author=None)
+
+    metadata = asyncio.run(_run())
+
+    assert metadata is not None
+    assert metadata["title"] == "Clean Architecture"
+    assert metadata["description"] is None
+
+
 def test_title_author_lookup_without_isbn_uses_open_library_only(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[str, object, object]] = []
 

--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -625,10 +625,95 @@ async def _fetch_google_books_metadata(isbn: str | None, title: str | None = Non
     }
 
 
+# Fields requested from search.json. ``editions`` gives the best-matching
+# edition (ranked by the ``lang`` param), which carries the edition-level
+# ISBN — the work-level ``isbn`` list mixes all editions together.
+_OPEN_LIBRARY_SEARCH_FIELDS = ",".join([
+    "key",
+    "title",
+    "author_name",
+    "publisher",
+    "first_publish_year",
+    "language",
+    "cover_i",
+    "isbn",
+    "editions",
+    "editions.key",
+    "editions.isbn_13",
+    "editions.isbn_10",
+    "editions.publish_date",
+    "editions.publishers",
+    "editions.languages",
+    "editions.cover_i",
+])
+
+
+def _pick_open_library_isbn(edition: dict[str, object], doc: dict[str, object]) -> str | None:
+    """Prefer the matched edition's ISBN-13, then its ISBN-10, then any
+    ISBN-13 from the work-level list (which spans all editions)."""
+    for field in ("isbn_13", "isbn_10"):
+        values = edition.get(field)
+        first = values[0] if isinstance(values, list) and values else None
+        if isinstance(first, str):
+            return first
+    isbns = [i for i in (doc.get("isbn") or []) if isinstance(i, str)]
+    isbn_13s = [i for i in isbns if len(i) == 13 and i.startswith(("978", "979"))]
+    if isbn_13s:
+        return isbn_13s[0]
+    return isbns[0] if isbns else None
+
+
+async def _fetch_open_library_work_description(client: httpx.AsyncClient, work_key: str | None) -> str | None:
+    """Descriptions live on the work record, not in search results or the
+    books API — fetched separately and best-effort (never fails the lookup)."""
+    if not work_key or not isinstance(work_key, str) or not work_key.startswith("/works/"):
+        return None
+    headers = {"User-Agent": worker_settings.open_library_user_agent}
+    try:
+        response = await client.get(
+            f"https://openlibrary.org{work_key}.json",
+            headers=headers,
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    description = data.get("description")
+    if isinstance(description, dict):
+        description = description.get("value")
+    if isinstance(description, str) and description.strip():
+        return description.strip()
+    return None
+
+
+async def _find_open_library_work_key_by_isbn(client: httpx.AsyncClient, isbn: str) -> str | None:
+    headers = {"User-Agent": worker_settings.open_library_user_agent}
+    try:
+        response = await client.get(
+            "https://openlibrary.org/search.json",
+            params={"q": f"isbn:{isbn}", "fields": "key", "limit": 1},
+            headers=headers,
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        docs = response.json().get("docs") or []
+    except (httpx.HTTPError, ValueError):
+        return None
+    if not docs:
+        return None
+    key = docs[0].get("key")
+    return key if isinstance(key, str) else None
+
+
 async def _fetch_open_library_metadata(isbn: str | None, title: str | None = None, author: str | None = None) -> dict[str, object] | None:
     start = perf_counter()
-    try:
-        async with httpx.AsyncClient() as client:
+    resolved_isbn = isbn
+    work_key: str | None = None
+    async with httpx.AsyncClient() as client:
+        try:
             headers = {"User-Agent": worker_settings.open_library_user_agent}
             if isbn:
                 bib_key = f"ISBN:{isbn}"
@@ -641,7 +726,14 @@ async def _fetch_open_library_metadata(isbn: str | None, title: str | None = Non
             elif title:
                 response = await client.get(
                     "https://openlibrary.org/search.json",
-                    params={"title": title, "author": author or "", "limit": 1},
+                    params={
+                        "title": title,
+                        "author": author or "",
+                        "limit": 1,
+                        "fields": _OPEN_LIBRARY_SEARCH_FIELDS,
+                        # Prefer Czech editions when the work has one; harmless otherwise.
+                        "lang": "cs",
+                    },
                     headers=headers,
                     timeout=10.0,
                 )
@@ -649,48 +741,66 @@ async def _fetch_open_library_metadata(isbn: str | None, title: str | None = Non
                 return None
             response.raise_for_status()
             payload = response.json()
-    finally:
-        logger.info("external_api_call", provider="open_library", isbn=isbn, title=title, author=author, processing_step="metadata_lookup", latency_seconds=perf_counter() - start)
+        finally:
+            logger.info("external_api_call", provider="open_library", isbn=isbn, title=title, author=author, processing_step="metadata_lookup", latency_seconds=perf_counter() - start)
 
-    if isbn:
-        bib_key = f"ISBN:{isbn}"
-        book_data = payload.get(bib_key)
-        if not book_data:
-            return None
-    else:
-        docs = payload.get("docs") or []
-        if not docs:
-            return None
-        doc = docs[0]
-        book_data = {
-            "title": doc.get("title"),
-            "authors": [{"name": (doc.get("author_name") or [None])[0]}],
-            "publishers": [{"name": (doc.get("publisher") or [None])[0]}],
-            "publish_date": str((doc.get("first_publish_year") or "")),
-            "languages": [{"key": f"/languages/{(doc.get('language') or [None])[0]}"}] if doc.get("language") else [],
-            "description": None,
-            "cover": {
-                "large": f"https://covers.openlibrary.org/b/id/{doc.get('cover_i')}-L.jpg" if doc.get("cover_i") else None,
-            },
-        }
+        if isbn:
+            bib_key = f"ISBN:{isbn}"
+            book_data = payload.get(bib_key)
+            if not book_data:
+                return None
+        else:
+            docs = payload.get("docs") or []
+            if not docs:
+                return None
+            doc = docs[0]
+            editions = (doc.get("editions") or {}).get("docs") or []
+            edition = editions[0] if editions and isinstance(editions[0], dict) else {}
+            resolved_isbn = _pick_open_library_isbn(edition, doc)
+            work_key = doc.get("key") if isinstance(doc.get("key"), str) else None
+            edition_language = (edition.get("languages") or [None])[0]
+            doc_language = (doc.get("language") or [None])[0]
+            language = edition_language or doc_language
+            cover_i = edition.get("cover_i") or doc.get("cover_i")
+            book_data = {
+                "title": doc.get("title"),
+                "authors": [{"name": (doc.get("author_name") or [None])[0]}],
+                "publishers": [
+                    {"name": (edition.get("publishers") or doc.get("publisher") or [None])[0]}
+                ],
+                "publish_date": str(edition.get("publish_date") or doc.get("first_publish_year") or ""),
+                "languages": [{"key": f"/languages/{language}"}] if language else [],
+                "description": None,
+                "cover": {
+                    "large": f"https://covers.openlibrary.org/b/id/{cover_i}-L.jpg" if cover_i else None,
+                },
+            }
 
-    publish_date = str(book_data.get("publish_date", ""))
-    publication_year: int | None = None
-    for token in publish_date.replace(",", " ").split():
-        if len(token) == 4 and token.isdigit():
-            publication_year = int(token)
-            break
+        publish_date = str(book_data.get("publish_date", ""))
+        publication_year: int | None = None
+        for token in publish_date.replace(",", " ").split():
+            if len(token) == 4 and token.isdigit():
+                publication_year = int(token)
+                break
 
-    cover_data = book_data.get("cover") or {}
-    language_key = ((book_data.get("languages") or [{}])[0].get("key") or "").split("/")[-1] or None
-    description = book_data.get("description")
-    if isinstance(description, dict):
-        description = description.get("value")
+        cover_data = book_data.get("cover") or {}
+        language_key = ((book_data.get("languages") or [{}])[0].get("key") or "").split("/")[-1] or None
+        description = book_data.get("description")
+        if isinstance(description, dict):
+            description = description.get("value")
+
+        if not description:
+            # The books API (ISBN path) never returns descriptions and the
+            # search path sets none — resolve the work record and pull it
+            # from there.
+            if work_key is None and isbn:
+                work_key = await _find_open_library_work_key_by_isbn(client, isbn)
+            description = await _fetch_open_library_work_description(client, work_key)
 
     return {
         "title": book_data.get("title"),
         "author": (book_data.get("authors") or [{}])[0].get("name"),
-        "isbn": isbn,
+        "isbn": resolved_isbn,
         "publisher": (book_data.get("publishers") or [{}])[0].get("name"),
         "language": language_key,
         "description": description,
@@ -1093,10 +1203,12 @@ def _enrich_single_book(session: Session, book_id: uuid.UUID, force: bool = Fals
         session.commit()
         return "no_metadata"
 
+    metadata_isbn = normalize_isbn(metadata["isbn"]) if isinstance(metadata.get("isbn"), str) else None
+
     if force:
         # Overwrite mode: allow replacing stale metadata with fresher match
-        if isinstance(metadata.get("isbn"), str):
-            book.isbn = metadata["isbn"]
+        if metadata_isbn:
+            book.isbn = metadata_isbn
         if isinstance(metadata.get("publisher"), str):
             book.publisher = metadata["publisher"]
         if isinstance(metadata.get("language"), str):
@@ -1113,8 +1225,8 @@ def _enrich_single_book(session: Session, book_id: uuid.UUID, force: bool = Fals
             book.author = metadata["author"]
     else:
         # Fill in missing data only (don't overwrite user edits)
-        if not book.isbn and isinstance(metadata.get("isbn"), str):
-            book.isbn = metadata["isbn"]
+        if not book.isbn and metadata_isbn:
+            book.isbn = metadata_isbn
         if not book.publisher and isinstance(metadata.get("publisher"), str):
             book.publisher = metadata["publisher"]
         if not book.language and isinstance(metadata.get("language"), str):

--- a/worker/tests/test_celery_app.py
+++ b/worker/tests/test_celery_app.py
@@ -694,3 +694,153 @@ def test_worker_logs_include_job_id(monkeypatch, capsys) -> None:
 
     output = capsys.readouterr().out
     assert "\"job_id\": \"" + str(job_id) + "\"" in output
+
+
+def _patch_open_library_transport(monkeypatch, handler) -> None:
+    """Route the worker's internally-created AsyncClient through a MockTransport."""
+    transport = httpx.MockTransport(handler)
+    original_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        celery_app.httpx,
+        "AsyncClient",
+        lambda **_kwargs: original_client(transport=transport),
+    )
+
+
+def test_open_library_title_search_returns_edition_isbn_and_description(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/search.json":
+            # ISBN must be part of the requested fields, otherwise the search
+            # response never contains it.
+            assert "isbn" in request.url.params["fields"]
+            assert "editions" in request.url.params["fields"]
+            return httpx.Response(
+                200,
+                json={
+                    "docs": [
+                        {
+                            "key": "/works/OL1W",
+                            "title": "Malý princ",
+                            "author_name": ["Antoine de Saint-Exupéry"],
+                            "publisher": ["Gallimard"],
+                            "first_publish_year": 1943,
+                            "language": ["fre", "cze"],
+                            "cover_i": 111,
+                            "isbn": ["2070612759", "9782070612758"],
+                            "editions": {
+                                "numFound": 1,
+                                "docs": [
+                                    {
+                                        "key": "/books/OL1M",
+                                        "isbn_13": ["9788000012345"],
+                                        "publish_date": "2015",
+                                        "publishers": ["Albatros"],
+                                        "languages": ["cze"],
+                                        "cover_i": 777,
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                },
+            )
+        assert request.url.path == "/works/OL1W.json"
+        return httpx.Response(200, json={"description": {"value": "Slavná novela o malém princi."}})
+
+    _patch_open_library_transport(monkeypatch, handler)
+
+    metadata = celery_app.asyncio.run(
+        celery_app._fetch_open_library_metadata(None, title="Malý princ", author="Saint-Exupéry")
+    )
+
+    assert metadata is not None
+    # ISBN comes from the best-matching edition, not the mixed work-level list.
+    assert metadata["isbn"] == "9788000012345"
+    assert metadata["description"] == "Slavná novela o malém princi."
+    assert metadata["publisher"] == "Albatros"
+    assert metadata["publication_year"] == 2015
+    assert metadata["language"] == "cze"
+    assert metadata["cover_image_url"] == "https://covers.openlibrary.org/b/id/777-L.jpg"
+
+
+def test_open_library_title_search_falls_back_to_work_level_isbn13(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/search.json"
+        return httpx.Response(
+            200,
+            json={
+                "docs": [
+                    {
+                        "title": "Clean Code",
+                        "author_name": ["Robert C. Martin"],
+                        "first_publish_year": 2008,
+                        "isbn": ["0132350882", "9780132350884"],
+                    }
+                ]
+            },
+        )
+
+    _patch_open_library_transport(monkeypatch, handler)
+
+    metadata = celery_app.asyncio.run(
+        celery_app._fetch_open_library_metadata(None, title="Clean Code")
+    )
+
+    assert metadata is not None
+    assert metadata["isbn"] == "9780132350884"
+
+
+def test_open_library_isbn_lookup_backfills_description_from_work(monkeypatch) -> None:
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        if request.url.path == "/api/books":
+            return httpx.Response(
+                200,
+                json={
+                    "ISBN:9780134494166": {
+                        "title": "Clean Architecture",
+                        "authors": [{"name": "Robert C. Martin"}],
+                        "publish_date": "2017",
+                    }
+                },
+            )
+        if request.url.path == "/search.json":
+            assert request.url.params["q"] == "isbn:9780134494166"
+            return httpx.Response(200, json={"docs": [{"key": "/works/OL2W"}]})
+        assert request.url.path == "/works/OL2W.json"
+        return httpx.Response(200, json={"description": "Software architecture patterns."})
+
+    _patch_open_library_transport(monkeypatch, handler)
+
+    metadata = celery_app.asyncio.run(
+        celery_app._fetch_open_library_metadata("9780134494166")
+    )
+
+    assert metadata is not None
+    assert metadata["isbn"] == "9780134494166"
+    assert metadata["description"] == "Software architecture patterns."
+    assert calls == ["/api/books", "/search.json", "/works/OL2W.json"]
+
+
+def test_open_library_description_backfill_failure_keeps_metadata(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/books":
+            return httpx.Response(
+                200,
+                json={"ISBN:9780134494166": {"title": "Clean Architecture", "publish_date": "2017"}},
+            )
+        # Work resolution is best-effort — a failing works lookup must not
+        # break the whole enrichment.
+        return httpx.Response(500)
+
+    _patch_open_library_transport(monkeypatch, handler)
+
+    metadata = celery_app.asyncio.run(
+        celery_app._fetch_open_library_metadata("9780134494166")
+    )
+
+    assert metadata is not None
+    assert metadata["title"] == "Clean Architecture"
+    assert metadata["description"] is None


### PR DESCRIPTION
## Problém
Funkce „obohatit" nedoplňovala ISBN ani anotaci u knih naskenovaných z police (ty typicky ISBN nemají):

- Open Library `search.json` se volal **bez parametru `fields`**, takže odpověď ISBN vůbec neobsahovala — do výsledku se jen echoval vstupní ISBN (`None`).
- Anotace (description) se při hledání podle názvu nastavovala natvrdo na `None`; a books API (ISBN lookup, `jscmd=data`) ji nevrací nikdy.
- Rok vydání byl vždy rokem **prvního** vydání, nakladatel první z celého seznamu.

## Řešení
- `search.json` nově žádá `fields` včetně `isbn`, `key` a `editions.*`; `lang=cs` preferuje české vydání, pokud existuje.
- ISBN se bere z nejlépe odpovídajícího vydání (ISBN-13 přednostně), fallback na work-level seznam.
- Anotace se dotahuje z `/works/{key}.json` — **best-effort**: výpadek works endpointu lookup neshodí. U ISBN lookupu se work key dohledá přes `search.json?q=isbn:…`.
- Rok / nakladatel / obálka preferují konkrétní matched vydání.
- Worker nově prohání ISBN z metadat přes `normalize_isbn` před zápisem do knihy.

Opraveno v obou kopiích logiky (worker `celery_app.py` i backend `app/services/metadata/open_library.py`).

## Testy
- Backend: 4 nové testy v `test_metadata_services.py` (edition ISBN + popis, fallback na work-level ISBN-13, backfill popisu u ISBN lookupu, odolnost proti výpadku works endpointu).
- Worker: zrcadlové testy v `worker/tests/test_celery_app.py` (pozn.: worker testy zatím v CI neběží — navrženo řešit zvlášť).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved Open Library book matching, prioritizing the most relevant edition and Czech-language results.
  - More accurately identifies ISBN-13, ISBN-10, publication year, language, publisher, and cover details.
  - Retrieves fuller book descriptions from Open Library work records when available.
  - Preserves existing metadata when supplemental description requests fail.
  - Normalizes ISBNs consistently during metadata enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->