### PR TITLE
fix(scan): normalizace celo-malého textu z rozpoznávání

### DIFF
--- a/worker/tests/test_celery_app.py
+++ b/worker/tests/test_celery_app.py
@@ -208,6 +208,18 @@ def test_normalize_vision_result_preserves_mixed_case() -> None:
     assert result["author"] == "J.K. Rowling"
 
 
+def test_normalize_vision_result_lowercase_casing() -> None:
+    """Fully lowercase output: title → sentence case, author → proper case."""
+    result = celery_app._normalize_vision_result({
+        "title": "nastávající maminka",
+        "author": "kateřina novotná",
+        "isbn": None,
+    })
+    assert result is not None
+    assert result["title"] == "Nastávající maminka"
+    assert result["author"] == "Kateřina Novotná"
+
+
 def test_normalize_vision_result_czech_casing() -> None:
     """Czech ALL CAPS: title → sentence case with diacritics, author → proper case."""
     result = celery_app._normalize_vision_result({

--- a/worker/tests/test_text_normalize.py
+++ b/worker/tests/test_text_normalize.py
@@ -57,8 +57,41 @@ class TestNormalizeCasing:
         # "KAFKA" is 5 letters, all caps → normalize
         assert text_normalize.normalize_casing("KAFKA") == "Kafka"
 
-    def test_lowercase_stays_lowercase(self):
-        assert text_normalize.normalize_casing("already lowercase") == "already lowercase"
+    def test_lowercase_title_gets_sentence_case(self):
+        assert text_normalize.normalize_casing("nastávající maminka") == "Nastávající maminka"
+
+    def test_lowercase_multiword_title(self):
+        result = text_normalize.normalize_casing("válka s mloky")
+        assert result == "Válka s mloky"
+
+    def test_lowercase_author_gets_proper_case(self):
+        assert text_normalize.normalize_casing("karel čapek", mode="proper") == "Karel Čapek"
+
+    def test_lowercase_author_particles_stay_lowercase(self):
+        result = text_normalize.normalize_casing("johann wolfgang von goethe", mode="proper")
+        assert result == "Johann Wolfgang von Goethe"
+
+    def test_all_caps_author_particles_stay_lowercase(self):
+        result = text_normalize.normalize_casing("JOHANN WOLFGANG VON GOETHE", mode="proper")
+        assert result == "Johann Wolfgang von Goethe"
+
+    def test_lowercase_acronym_restored(self):
+        assert text_normalize.normalize_casing("dějiny usa a nato") == "Dějiny USA a NATO"
+
+    def test_lowercase_roman_numeral_restored(self):
+        assert text_normalize.normalize_casing("dějiny evropy xiv") == "Dějiny evropy XIV"
+
+    def test_single_letter_left_alone(self):
+        # Below the lowercase threshold — too short to judge
+        assert text_normalize.normalize_casing("k") == "k"
+
+    def test_lowercase_czech_conjunction_not_roman_numeral(self):
+        # "i" and "v" in lowercase text are Czech words, not numerals I/V
+        assert text_normalize.normalize_casing("válka i mír") == "Válka i mír"
+        assert text_normalize.normalize_casing("muž v davu") == "Muž v davu"
+
+    def test_lowercase_multiletter_roman_numeral_restored(self):
+        assert text_normalize.normalize_casing("karel iv.", mode="proper") == "Karel IV."
 
     def test_sentence_case_only_first_word(self):
         result = text_normalize.normalize_casing("THE WAR OF THE WORLDS")
@@ -190,6 +223,13 @@ class TestNormalizeBookFields:
         text_normalize.normalize_book_fields(book)
         assert book["title"] == "Harry Potter"
         assert book["author"] == "J.K. Rowling"
+
+    def test_lowercase_fields_normalized(self):
+        """Fully lowercase output gets the same treatment as ALL CAPS."""
+        book = {"title": "nastávající maminka", "author": "karel čapek"}
+        text_normalize.normalize_book_fields(book)
+        assert book["title"] == "Nastávající maminka"
+        assert book["author"] == "Karel Čapek"
 
 
 # ── _is_roman_numeral ──────────────────────────────────────────────

--- a/worker/text_normalize.py
+++ b/worker/text_normalize.py
@@ -1,7 +1,7 @@
 """Post-processing text normalization for OCR / Gemini recognized book metadata.
 
 Handles:
-- ALL-CAPS to natural title case (Czech + English aware)
+- ALL-CAPS and all-lowercase to natural title case (Czech + English aware)
 - Whitespace / punctuation cleanup
 - Duplicate word removal
 - Confidence-based field nullification
@@ -45,6 +45,11 @@ _SMALL_WORDS = _SMALL_WORDS_EN | _SMALL_WORDS_CS
 # Minimum length for an ALL-CAPS string to be treated as "probably shouting"
 _ALL_CAPS_THRESHOLD = 4
 
+# Minimum letter count for an all-lowercase string to be normalized.
+# Lower than the caps threshold — a fully lowercase title/author is almost
+# always a transcription artifact, not a stylistic choice.
+_ALL_LOWER_THRESHOLD = 2
+
 
 def _is_roman_numeral(word: str) -> bool:
     """Check if a word is a valid Roman numeral (I, II, III, IV, etc.)."""
@@ -66,12 +71,29 @@ def _is_all_caps(text: str) -> bool:
     return all(ch.isupper() for ch in letters)
 
 
-def _capitalize_word(word: str, is_first: bool, mode: str) -> str:
+def _is_all_lower(text: str) -> bool:
+    """Return True if every letter in text is lowercase.
+
+    Spines and vision output sometimes come through fully lowercase
+    ("karel čapek") — that's a transcription artifact worth fixing, unlike
+    mixed case which reflects a deliberate choice.
+    """
+    letters = [ch for ch in text if ch.isalpha()]
+    if len(letters) < _ALL_LOWER_THRESHOLD:
+        return False
+    return all(ch.islower() for ch in letters)
+
+
+def _capitalize_word(word: str, is_first: bool, mode: str, *, single_letter_roman: bool = True) -> str:
     """Capitalize a single word with awareness of acronyms, Roman numerals, and language conventions.
 
     Modes:
         "sentence" — only first word capitalized (Czech-style title case)
         "proper"   — every word capitalized (for author names / proper nouns)
+
+    ``single_letter_roman=False`` skips Roman-numeral detection for single
+    letters — in lowercase source text "i" and "v" are far more likely Czech
+    conjunctions/prepositions than numerals.
     """
     # Preserve explicitly uppercase words (acronyms)
     upper = word.upper()
@@ -79,7 +101,7 @@ def _capitalize_word(word: str, is_first: bool, mode: str) -> str:
         return upper
 
     # Preserve Roman numerals
-    if _is_roman_numeral(word):
+    if _is_roman_numeral(word) and (single_letter_roman or len(word.strip(".,;:!?()")) > 1):
         return word.upper()
 
     if not word:
@@ -91,28 +113,39 @@ def _capitalize_word(word: str, is_first: bool, mode: str) -> str:
             return word[0].upper() + word[1:].lower()
         return word.lower()
 
-    # "proper" mode: capitalize every word (for names)
+    # "proper" mode: capitalize every word (for names); name particles
+    # (von, van, de, ...) stay lowercase unless they start the name.
+    if not is_first and word.lower() in _NAME_PARTICLES:
+        return word.lower()
     return word[0].upper() + word[1:].lower()
 
 
 def normalize_casing(text: str, mode: str = "sentence") -> str:
-    """Convert ALL-CAPS text to natural case.
+    """Convert ALL-CAPS or all-lowercase text to natural case.
 
-    Only normalizes if the text appears to be all caps.
-    Preserves acronyms (USA, NATO), Roman numerals (II, III, XIV),
-    and diacritics.  If the text is mixed case or short, returns it as-is.
+    Only normalizes if the text is uniformly cased — mixed case reflects a
+    deliberate choice and is returned as-is.  Preserves acronyms (USA, NATO),
+    Roman numerals (II, III, XIV), and diacritics.
 
     Modes:
         "sentence" — first word capitalized, rest lowercase (Czech-safe default)
         "proper"   — every word capitalized (for proper nouns / author names)
     """
-    if not text or not _is_all_caps(text):
+    if not text or not (_is_all_caps(text) or _is_all_lower(text)):
         return text
+
+    # In ALL-CAPS source a lone "I"/"V" was printed uppercase, so trust it as
+    # a numeral; in lowercase source it's almost certainly a Czech word.
+    single_letter_roman = _is_all_caps(text)
 
     words = text.split()
     result: list[str] = []
     for i, word in enumerate(words):
-        result.append(_capitalize_word(word, is_first=(i == 0), mode=mode))
+        result.append(
+            _capitalize_word(
+                word, is_first=(i == 0), mode=mode, single_letter_roman=single_letter_roman
+            )
+        )
 
     return " ".join(result)
 
@@ -198,7 +231,8 @@ def normalize_book_fields(
 
     Args:
         book: Dict with at least 'title' and 'author' keys.
-        apply_casing: Whether to apply ALL-CAPS normalization.
+        apply_casing: Whether to apply uniform-casing (ALL-CAPS / all-lowercase)
+            normalization.
 
     Returns:
         The same dict (mutated in-place) with normalized fields.


### PR DESCRIPTION
## Problém
Když vision model přepíše hřbet celý malými písmeny (`karel čapek`, `nastávající maminka`), normalizace to nechala být — [`normalize_casing`](../blob/main/worker/text_normalize.py) opravovala jen text psaný CELÝMI VELKÝMI.

## Řešení
Celo-malý text se nově normalizuje stejně jako ALL-CAPS:
- **název** → větná sazba: `nastávající maminka` → `Nastávající maminka`
- **autor** → proper case: `karel čapek` → `Karel Čapek`
- smíšený casing se dál nechává beze změny (záměr uživatele/nakladatele)

Dvě jemnosti navíc:
- jmenné částice zůstávají malé i v proper case: `johann wolfgang von goethe` → `Johann Wolfgang von Goethe` (platí nově i pro ALL-CAPS vstup)
- jednopísmenné římské číslice se uznávají jen u ALL-CAPS zdroje — v malém textu jsou „i"/„v" česká slova: `válka i mír` → `Válka i mír` (nikoli ~~Válka I mír~~); vícepísmenné fungují dál: `karel iv.` → `Karel IV.`, `dějiny evropy xiv` → `Dějiny evropy XIV`

## Testy
12 nových testů v `worker/tests/` (lowercase title/author, částice, římské číslice vs. české spojky, akronymy `dějiny usa` → `Dějiny USA`, vision-result pipeline). Celá sada ověřena lokálně — modul je bez závislostí. (Pozn.: worker testy zatím v CI neběží — navrženo řešit zvlášť.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text normalization for fully lowercase OCR results.
  * Titles are converted to sentence case, while author names receive proper capitalization.
  * Preserved formatting for acronyms and Roman numerals.
  * Improved handling of name particles such as “de” and “von”.
  * Added regression coverage for lowercase book metadata normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->