### PR TITLE
feat(scan): ověření výsledků skenu proti Open Library katalogu

### DIFF
--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -126,13 +126,19 @@ async def get_shelf_scan_result(
 
             raw_confidence = raw.get("confidence") if isinstance(raw.get("confidence"), str) else None
             has_title = bool(title and title != "Unknown title")
-            # Map worker confidence (high/medium/low) to UI confidence (auto/needs_review)
-            if raw_confidence == "high" and has_title:
-                confidence = "auto"
-            elif raw_confidence == "low" or not has_title:
+            # Map worker confidence (high/medium/low/needs_review) to UI
+            # confidence (auto/needs_review)
+            if raw_confidence in ("low", "needs_review") or not has_title:
                 confidence = "needs_review"
             else:
-                confidence = "auto" if has_title else "needs_review"
+                confidence = "auto"
+
+            suggested_title = (
+                raw.get("suggested_title") if isinstance(raw.get("suggested_title"), str) else None
+            )
+            suggested_author = (
+                raw.get("suggested_author") if isinstance(raw.get("suggested_author"), str) else None
+            )
 
             books.append(ScannedBookItem(
                 position=idx,
@@ -141,6 +147,8 @@ async def get_shelf_scan_result(
                 isbn=isbn,
                 observed_text=observed_text,
                 confidence=confidence,
+                suggested_title=suggested_title,
+                suggested_author=suggested_author,
             ))
 
         return ShelfScanResultResponse(

--- a/backend/app/schemas/scan.py
+++ b/backend/app/schemas/scan.py
@@ -13,6 +13,10 @@ class ScannedBookItem(BaseModel):
     isbn: str | None = None
     observed_text: str | None = None
     confidence: str = "auto"  # "auto" | "needs_review"
+    # Closest catalog record when it only partially matches the scanned
+    # text — shown in the review UI as a one-click correction.
+    suggested_title: str | None = None
+    suggested_author: str | None = None
 
 
 class ShelfScanResponse(BaseModel):

--- a/backend/tests/test_scan_api.py
+++ b/backend/tests/test_scan_api.py
@@ -208,6 +208,12 @@ async def test_get_scan_result_done_job_with_books(
                         # confidence="medium" + title=="Unknown title" → not has_title → "needs_review" (line 133)
                         {"title": "Unknown title", "author": None, "isbn": None,
                          "observed_text": None, "confidence": "medium"},
+                        # worker "needs_review" (quality flags / catalog mismatch)
+                        # → "needs_review" even with a title; suggestions pass through
+                        {"title": "Nastavení miminka", "author": None, "isbn": None,
+                         "observed_text": "nastávající maminky", "confidence": "needs_review",
+                         "suggested_title": "Nastávající maminky",
+                         "suggested_author": "Marie Nováková"},
                         # non-dict entry → isinstance check fires → continue (line 120-121)
                         "not_a_dict",
                     ],
@@ -222,12 +228,19 @@ async def test_get_scan_result_done_job_with_books(
     data = resp.json()
     assert data["status"] == "done"
     assert data["location_id"] == str(loc_id)
-    # "not_a_dict" is skipped → only 4 book items returned
-    assert len(data["books"]) == 4
+    # "not_a_dict" is skipped → only 5 book items returned
+    assert len(data["books"]) == 5
     assert data["books"][0]["confidence"] == "auto"          # high + has_title
     assert data["books"][1]["confidence"] == "needs_review"  # low
     assert data["books"][2]["confidence"] == "auto"          # medium + has_title
     assert data["books"][3]["confidence"] == "needs_review"  # medium + "Unknown title"
+    # worker needs_review propagates even when a title is present
+    assert data["books"][4]["confidence"] == "needs_review"
+    assert data["books"][4]["title"] == "Nastavení miminka"
+    assert data["books"][4]["suggested_title"] == "Nastávající maminky"
+    assert data["books"][4]["suggested_author"] == "Marie Nováková"
+    # rows without a catalog suggestion serialize it as null
+    assert data["books"][0]["suggested_title"] is None
 
 
 # ── POST /api/v1/scan/confirm ─────────────────────────────────────────────────

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7553,6 +7553,28 @@
             "type": "string",
             "title": "Confidence",
             "default": "auto"
+          },
+          "suggested_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggested Title"
+          },
+          "suggested_author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggested Author"
           }
         },
         "type": "object",

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -332,6 +332,8 @@
     "back_to_scan": "Zpět na skenování",
     "needs_review": "Potřebuje upřesnění",
     "observed": "Z hřbetu",
+    "catalog_suggestion": "Katalog navrhuje",
+    "apply_suggestion": "Použít návrh",
     "book_title": "Název",
     "book_title_placeholder": "Zadejte název knihy",
     "book_author": "Autor",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -404,6 +404,8 @@
     "back_to_scan": "Back to scanning",
     "needs_review": "Needs review",
     "observed": "From spine",
+    "catalog_suggestion": "Catalog suggests",
+    "apply_suggestion": "Apply suggestion",
     "book_title": "Title",
     "book_title_placeholder": "Enter book title",
     "book_author": "Author",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -306,6 +306,9 @@ export interface ScannedBookItem {
   isbn: string | null
   observed_text: string | null
   confidence: 'auto' | 'needs_review'
+  // Closest catalog record on a partial match — one-click correction in review
+  suggested_title?: string | null
+  suggested_author?: string | null
 }
 
 export interface ShelfScanResponse {

--- a/frontend/src/pages/ScanShelfPage.tsx
+++ b/frontend/src/pages/ScanShelfPage.tsx
@@ -25,6 +25,8 @@ interface ReviewBookItem extends ConfirmBookItem {
   observedText: string | null
   confidence: ScannedBookItem['confidence'] | null
   isManual?: boolean
+  suggestedTitle?: string | null
+  suggestedAuthor?: string | null
 }
 
 interface ScanSegment {
@@ -309,12 +311,16 @@ export function ScanShelfPage() {
         const observed = (b.observed_text ?? '').toLowerCase()
         const noVisibleText = observed.includes('no visible text') || observed.includes('no readable text')
         const lowConfidence = b.confidence === 'needs_review' || b.confidence === 'low'
+        // A catalog suggestion means there IS a concrete reading — keep it
+        // in the inputs so the user can compare it with the suggestion.
+        const hasSuggestion = Boolean(b.suggested_title || b.suggested_author)
 
-        const normalizedTitle = (!noVisibleText && !lowConfidence)
+        const keepScanned = !noVisibleText && (!lowConfidence || hasSuggestion)
+        const normalizedTitle = keepScanned
           ? (b.title ?? b.observed_text ?? '')
           : ''
 
-        const normalizedAuthor = (!noVisibleText && !lowConfidence)
+        const normalizedAuthor = keepScanned
           ? (b.author ?? null)
           : null
 
@@ -327,6 +333,8 @@ export function ScanShelfPage() {
           isbn: b.isbn ?? null,
           observedText: b.observed_text ?? null,
           confidence: b.confidence ?? null,
+          suggestedTitle: b.suggested_title ?? null,
+          suggestedAuthor: b.suggested_author ?? null,
         })
       }
     }
@@ -341,6 +349,20 @@ export function ScanShelfPage() {
   function updateBook(localId: string, field: keyof ConfirmBookItem, value: string | null) {
     setEditableBooks(prev => prev.map((b) =>
       b.localId === localId ? { ...b, [field]: value } : b
+    ))
+  }
+
+  function applySuggestion(localId: string) {
+    setEditableBooks(prev => prev.map((b) =>
+      b.localId === localId
+        ? {
+            ...b,
+            title: b.suggestedTitle ?? b.title,
+            author: b.suggestedAuthor ?? b.author,
+            suggestedTitle: null,
+            suggestedAuthor: null,
+          }
+        : b
     ))
   }
 
@@ -1037,6 +1059,32 @@ export function ScanShelfPage() {
                         </button>
                       </div>
                     </div>
+                    {!book.isManual && (book.suggestedTitle || book.suggestedAuthor) && (
+                      <div style={{
+                        display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap',
+                        marginBottom: 10, fontSize: 12,
+                      }}>
+                        <span style={{ color: 'var(--sh-text-muted)' }}>
+                          {t('scan.catalog_suggestion')}:{' '}
+                          <strong style={{ color: 'var(--sh-text-main)' }}>
+                            {book.suggestedTitle ?? book.title}
+                          </strong>
+                          {book.suggestedAuthor ? ` — ${book.suggestedAuthor}` : ''}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => applySuggestion(book.localId)}
+                          style={{
+                            background: 'none', border: '1px solid var(--sh-teal)',
+                            borderRadius: 'var(--sh-radius-sm)', cursor: 'pointer',
+                            color: 'var(--sh-teal)', fontSize: 11, fontWeight: 600,
+                            padding: '2px 8px',
+                          }}
+                        >
+                          {t('scan.apply_suggestion')}
+                        </button>
+                      </div>
+                    )}
                     <div className="sh-review-fields">
                       <div>
                         <label className="sh-form-label--sm" style={{ fontSize: 11, marginBottom: 4 }}>{t('scan.book_title')}</label>

--- a/worker/catalog_match.py
+++ b/worker/catalog_match.py
@@ -1,0 +1,119 @@
+"""Fuzzy matching of shelf-scan results against a library catalog.
+
+The vision model occasionally misreads spine text onto the nearest plausible
+words ("nastávající maminky" → "nastavení miminka").  Comparing the scanned
+title/author against the closest Open Library record lets us either adopt the
+catalog form (near-identical match — fixes casing/diacritics/minor OCR noise)
+or surface it as a suggestion for human review (partial match).
+
+Pure logic only — no I/O — so it stays trivially testable.  The Open Library
+lookups live in celery_app.py next to the other provider calls.
+
+Design principles:
+  • Adopting silently is only allowed for near-identical text (>= ADOPT).
+  • A partial match never overwrites data — it downgrades confidence and
+    attaches a suggestion; the human decides.
+  • No match at all is NOT a negative signal: Open Library's coverage of
+    Czech books is thin, so absence must never flag a row.
+"""
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+import re
+import unicodedata
+
+# Combined score at/above which the catalog form replaces the scanned text.
+ADOPT_THRESHOLD = 0.92
+# Title similarity must also individually clear this bar before adopting.
+ADOPT_TITLE_THRESHOLD = 0.90
+# Combined score at/above which the catalog form is attached as a suggestion.
+SUGGEST_THRESHOLD = 0.55
+
+# Weight of the title score when an author is available on both sides.
+_TITLE_WEIGHT = 0.75
+
+
+def normalize_for_compare(text: str) -> str:
+    """Lowercase, strip diacritics and punctuation — OCR noise the comparison
+    should see through (casing and diacritics are exactly what we want to be
+    able to adopt from the catalog)."""
+    decomposed = unicodedata.normalize("NFD", text.lower())
+    without_marks = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return re.sub(r"[^a-z0-9]+", " ", without_marks).strip()
+
+
+def similarity(a: str | None, b: str | None) -> float:
+    if not a or not b:
+        return 0.0
+    norm_a = normalize_for_compare(a)
+    norm_b = normalize_for_compare(b)
+    if not norm_a or not norm_b:
+        return 0.0
+    return SequenceMatcher(None, norm_a, norm_b).ratio()
+
+
+def evaluate_match(
+    scanned_title: str | None,
+    scanned_author: str | None,
+    catalog_title: str | None,
+    catalog_author: str | None,
+) -> tuple[str, float]:
+    """Compare a scanned row against its closest catalog candidate.
+
+    Returns ``(decision, score)`` where decision is:
+        "adopt"   — near-identical; safe to take the catalog form verbatim
+        "suggest" — plausibly the same book; attach as suggestion, human decides
+        "none"    — too different; ignore the candidate
+    """
+    title_score = similarity(scanned_title, catalog_title)
+
+    if scanned_author and catalog_author:
+        author_score = similarity(scanned_author, catalog_author)
+        score = _TITLE_WEIGHT * title_score + (1 - _TITLE_WEIGHT) * author_score
+    else:
+        score = title_score
+
+    if score >= ADOPT_THRESHOLD and title_score >= ADOPT_TITLE_THRESHOLD:
+        return "adopt", score
+    if score >= SUGGEST_THRESHOLD:
+        return "suggest", score
+    return "none", score
+
+
+def apply_catalog_match(
+    item: dict[str, object],
+    catalog_title: str | None,
+    catalog_author: str | None,
+) -> str:
+    """Mutate a shelf-scan row according to the match decision.
+
+    Returns the decision string so the caller can log/aggregate.
+    """
+    title = item.get("title") if isinstance(item.get("title"), str) else None
+    author = item.get("author") if isinstance(item.get("author"), str) else None
+
+    decision, score = evaluate_match(title, author, catalog_title, catalog_author)
+
+    if decision == "adopt":
+        if isinstance(catalog_title, str) and catalog_title.strip():
+            item["title"] = catalog_title.strip()
+        if isinstance(catalog_author, str) and catalog_author.strip():
+            item["author"] = catalog_author.strip()
+        flags = item.setdefault("quality_flags", [])
+        if isinstance(flags, list):
+            flags.append("catalog_adopted")
+    elif decision == "suggest":
+        if isinstance(catalog_title, str) and catalog_title.strip():
+            item["suggested_title"] = catalog_title.strip()
+        if isinstance(catalog_author, str) and catalog_author.strip():
+            item["suggested_author"] = catalog_author.strip()
+        # Only downgrade when there is actually something to review.
+        if "suggested_title" in item or "suggested_author" in item:
+            item["confidence"] = "needs_review"
+            flags = item.setdefault("quality_flags", [])
+            if isinstance(flags, list):
+                flags.append("catalog_mismatch")
+        else:
+            decision = "none"
+
+    return decision

--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -26,6 +26,7 @@ from redis import Redis
 from sqlalchemy import DateTime, Enum as SAEnum, ForeignKey, Integer, String, Text, Uuid, create_engine, exc, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+from catalog_match import apply_catalog_match, normalize_for_compare
 from gemini_parser import parse_gemini_candidates
 from settings import worker_settings
 
@@ -469,6 +470,116 @@ async def _extract_shelf_metadata_with_gemini(image_bytes: bytes) -> list[dict[s
             })
 
     return normalized_results or None
+
+
+# ---------------------------------------------------------------------------
+# Shelf-scan verification against the Open Library catalog
+# ---------------------------------------------------------------------------
+#
+# Vision output is grounded against the catalog: a near-identical match
+# adopts the catalog form (fixes casing/diacritics/small OCR misreads), a
+# partial match becomes a suggestion + needs_review. Absence of a match is
+# NOT a signal — Open Library's coverage of Czech books is thin.
+# Decision logic lives in catalog_match.py; only the I/O is here.
+
+CATALOG_VERIFY_TTL_SECONDS = 24 * 60 * 60
+# Open Library allows 3 req/s with an identifying User-Agent.
+_CATALOG_VERIFY_CONCURRENCY = 3
+_CATALOG_VERIFY_TIMEOUT_SECONDS = 30.0
+
+
+def _catalog_cache_key(title: str, author: str | None) -> str:
+    return f"catalog-verify:{normalize_for_compare(title)}|{normalize_for_compare(author or '')}"
+
+
+async def _lookup_catalog_candidate(
+    client: httpx.AsyncClient,
+    title: str,
+    author: str | None,
+) -> dict[str, object] | None:
+    """Closest Open Library candidate for a scanned title/author, or None."""
+    params: dict[str, object] = {"title": title, "limit": 1, "fields": "key,title,author_name"}
+    if author:
+        params["author"] = author
+    response = await client.get(
+        "https://openlibrary.org/search.json",
+        params=params,
+        headers={"User-Agent": worker_settings.open_library_user_agent},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    docs = response.json().get("docs") or []
+    if not docs or not isinstance(docs[0], dict):
+        return None
+    doc = docs[0]
+    candidate_title = doc.get("title") if isinstance(doc.get("title"), str) else None
+    if not candidate_title:
+        return None
+    authors = doc.get("author_name") or []
+    candidate_author = authors[0] if authors and isinstance(authors[0], str) else None
+    return {"title": candidate_title, "author": candidate_author}
+
+
+async def _verify_shelf_books_against_catalog(books: list[dict[str, object]]) -> dict[str, int]:
+    """Verify scanned rows against Open Library; mutates rows in place.
+
+    Best-effort at every level: cache errors, lookup errors and timeouts
+    leave the affected row exactly as the vision model produced it.
+    """
+    cache = _get_redis_client()
+    semaphore = asyncio.Semaphore(_CATALOG_VERIFY_CONCURRENCY)
+    stats = {"adopt": 0, "suggest": 0, "none": 0, "no_candidate": 0}
+
+    async with httpx.AsyncClient() as client:
+
+        async def _verify(item: dict[str, object]) -> None:
+            title = item.get("title")
+            if not isinstance(title, str) or not title.strip():
+                return
+            author = item.get("author") if isinstance(item.get("author"), str) else None
+
+            cache_key = _catalog_cache_key(title, author)
+            cached = None
+            try:
+                cached = cache.get(cache_key)
+            except Exception:
+                cached = None
+
+            if cached is not None:
+                candidate = json.loads(cached)
+            else:
+                async with semaphore:
+                    try:
+                        candidate = await _lookup_catalog_candidate(client, title, author)
+                    except Exception:
+                        # Lookup failure is not a definitive miss — skip the
+                        # row without caching so a retry can succeed.
+                        stats["no_candidate"] += 1
+                        return
+                try:
+                    cache.setex(cache_key, CATALOG_VERIFY_TTL_SECONDS, json.dumps(candidate))
+                except Exception:
+                    pass
+
+            if not isinstance(candidate, dict):
+                stats["no_candidate"] += 1
+                return
+
+            catalog_title = candidate.get("title") if isinstance(candidate.get("title"), str) else None
+            catalog_author = candidate.get("author") if isinstance(candidate.get("author"), str) else None
+            decision = apply_catalog_match(item, catalog_title, catalog_author)
+            stats[decision] += 1
+            if decision != "none":
+                logger.info(
+                    "shelf_scan_catalog_match",
+                    decision=decision,
+                    scanned_title=title,
+                    catalog_title=catalog_title,
+                )
+
+        await asyncio.gather(*(_verify(item) for item in books))
+
+    return stats
 
 
 async def _extract_spine_metadata_with_gemini(image_bytes: bytes) -> list[dict[str, object]] | None:
@@ -969,6 +1080,21 @@ def process_shelf_scan(self, job_id: str, location_id: str | None = None) -> Non
                 logger.warning("shelf_scan_no_results", job_id=job_id)
                 return
 
+            # Ground the vision output against the Open Library catalog —
+            # adopts near-identical catalog forms, attaches suggestions for
+            # partial matches. Best-effort: any failure keeps vision results.
+            if worker_settings.enable_catalog_verify:
+                try:
+                    verify_stats = asyncio.run(
+                        asyncio.wait_for(
+                            _verify_shelf_books_against_catalog(vision_results),
+                            timeout=_CATALOG_VERIFY_TIMEOUT_SECONDS,
+                        )
+                    )
+                    logger.info("shelf_scan_catalog_verified", **verify_stats)
+                except Exception as verify_exc:
+                    logger.warning("shelf_scan_catalog_verify_failed", error=str(verify_exc))
+
             # Log confidence summary for observability
             conf_counts = {"high": 0, "medium": 0, "low": 0, "needs_review": 0}
             for r in vision_results:
@@ -1000,6 +1126,10 @@ def process_shelf_scan(self, job_id: str, location_id: str | None = None) -> Non
                 quality_flags = local_result.get("quality_flags")
                 if quality_flags:
                     item["quality_flags"] = quality_flags
+                if isinstance(local_result.get("suggested_title"), str):
+                    item["suggested_title"] = local_result["suggested_title"]
+                if isinstance(local_result.get("suggested_author"), str):
+                    item["suggested_author"] = local_result["suggested_author"]
                 processed_books.append(item)
 
             job.status = ProcessingJobStatus.DONE

--- a/worker/settings.py
+++ b/worker/settings.py
@@ -29,6 +29,11 @@ class WorkerSettings(BaseSettings):
     enrichment_max_per_minute: int = 30           # max enrichment API calls per minute
     enrichment_max_per_day: int = 900             # max enrichment API calls per day
 
+    # Shelf-scan verification against Open Library (fuzzy match of scanned
+    # title/author; adopts near-identical catalog forms, suggests partial
+    # matches for review). Kill-switch in case of OL instability.
+    enable_catalog_verify: bool = True
+
     # Metadata providers — mirrors app/core/config.py. Google Books ToS
     # forbids paid applications, so it stays disabled unless a separate
     # agreement with Google exists.

--- a/worker/tests/test_catalog_match.py
+++ b/worker/tests/test_catalog_match.py
@@ -1,0 +1,137 @@
+"""Tests for catalog_match — fuzzy verification of shelf scans against Open Library."""
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import catalog_match
+
+
+class TestNormalizeForCompare:
+    def test_strips_diacritics_and_case(self):
+        assert catalog_match.normalize_for_compare("Tibetská KNIHA") == "tibetska kniha"
+
+    def test_strips_punctuation(self):
+        assert catalog_match.normalize_for_compare("Vojna a mír!") == "vojna a mir"
+
+    def test_collapses_whitespace(self):
+        assert catalog_match.normalize_for_compare("  a   b  ") == "a b"
+
+
+class TestSimilarity:
+    def test_identical(self):
+        assert catalog_match.similarity("Válka s mloky", "Válka s mloky") == 1.0
+
+    def test_diacritics_and_case_insensitive(self):
+        assert catalog_match.similarity("Valka s mloky", "Válka s Mloky") == 1.0
+
+    def test_none_inputs(self):
+        assert catalog_match.similarity(None, "x") == 0.0
+        assert catalog_match.similarity("x", None) == 0.0
+        assert catalog_match.similarity(None, None) == 0.0
+
+    def test_unrelated_titles_score_low(self):
+        score = catalog_match.similarity(
+            "Válka s mloky", "Harry Potter and the Philosopher's Stone"
+        )
+        assert score < catalog_match.SUGGEST_THRESHOLD
+
+
+class TestEvaluateMatch:
+    def test_diacritics_only_difference_adopts(self):
+        decision, score = catalog_match.evaluate_match(
+            "Tibetska kniha o zivote a smrti",
+            "sogjal rinpočhe",
+            "Tibetská kniha o životě a smrti",
+            "Sogjal Rinpočhe",
+        )
+        assert decision == "adopt"
+        assert score == 1.0
+
+    def test_ocr_misread_becomes_suggestion(self):
+        """The canonical failure mode: vision snaps to nearby plausible words."""
+        decision, _score = catalog_match.evaluate_match(
+            "Nastavení miminka", None, "Nastávající maminky", None
+        )
+        assert decision == "suggest"
+
+    def test_unrelated_book_ignored(self):
+        decision, _score = catalog_match.evaluate_match(
+            "Válka s mloky", "Karel Čapek", "Harry Potter", "J. K. Rowling"
+        )
+        assert decision == "none"
+
+    def test_author_mismatch_blocks_silent_adopt(self):
+        """Identical title but different author must not be adopted silently."""
+        decision, _score = catalog_match.evaluate_match(
+            "Válka s mloky", "Karel Čapek", "Válka s mloky", "Jaroslav Hašek"
+        )
+        assert decision == "suggest"
+
+    def test_missing_authors_fall_back_to_title_only(self):
+        decision, score = catalog_match.evaluate_match(
+            "Válka s mloky", None, "Válka s mloky", None
+        )
+        assert decision == "adopt"
+        assert score == 1.0
+
+
+class TestApplyCatalogMatch:
+    def test_adopt_replaces_fields_and_flags(self):
+        item: dict[str, object] = {
+            "title": "tibetska kniha o zivote a smrti",
+            "author": "sogjal rinpočhe",
+            "confidence": "medium",
+        }
+        decision = catalog_match.apply_catalog_match(
+            item, "Tibetská kniha o životě a smrti", "Sogjal Rinpočhe"
+        )
+        assert decision == "adopt"
+        assert item["title"] == "Tibetská kniha o životě a smrti"
+        assert item["author"] == "Sogjal Rinpočhe"
+        assert "catalog_adopted" in item["quality_flags"]
+        # Adoption is not a reason for review
+        assert item["confidence"] == "medium"
+
+    def test_adopt_fills_missing_author(self):
+        item: dict[str, object] = {"title": "Válka s mloky", "author": None}
+        decision = catalog_match.apply_catalog_match(item, "Válka s mloky", "Karel Čapek")
+        assert decision == "adopt"
+        assert item["author"] == "Karel Čapek"
+
+    def test_suggest_attaches_suggestion_and_downgrades(self):
+        item: dict[str, object] = {
+            "title": "Nastavení miminka",
+            "author": None,
+            "confidence": "high",
+        }
+        decision = catalog_match.apply_catalog_match(item, "Nastávající maminky", None)
+        assert decision == "suggest"
+        # Scanned values stay untouched — the human decides
+        assert item["title"] == "Nastavení miminka"
+        assert item["suggested_title"] == "Nastávající maminky"
+        assert item["confidence"] == "needs_review"
+        assert "catalog_mismatch" in item["quality_flags"]
+
+    def test_none_leaves_item_untouched(self):
+        item: dict[str, object] = {
+            "title": "Válka s mloky",
+            "author": "Karel Čapek",
+            "confidence": "high",
+        }
+        decision = catalog_match.apply_catalog_match(item, "Harry Potter", "J. K. Rowling")
+        assert decision == "none"
+        assert item == {
+            "title": "Válka s mloky",
+            "author": "Karel Čapek",
+            "confidence": "high",
+        }
+
+    def test_suggest_appends_to_existing_flags(self):
+        item: dict[str, object] = {
+            "title": "Nastavení miminka",
+            "author": None,
+            "confidence": "needs_review",
+            "quality_flags": ["author_has_separator"],
+        }
+        catalog_match.apply_catalog_match(item, "Nastávající maminky", None)
+        assert item["quality_flags"] == ["author_has_separator", "catalog_mismatch"]

--- a/worker/tests/test_celery_app.py
+++ b/worker/tests/test_celery_app.py
@@ -694,3 +694,119 @@ def test_worker_logs_include_job_id(monkeypatch, capsys) -> None:
 
     output = capsys.readouterr().out
     assert "\"job_id\": \"" + str(job_id) + "\"" in output
+
+
+class _FakeVerifyRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def get(self, key: str):
+        return self.store.get(key)
+
+    def setex(self, key: str, _ttl: int, value: str) -> None:
+        self.store[key] = value
+
+
+def _patch_catalog_transport(monkeypatch, handler) -> None:
+    """Route the worker's internally-created AsyncClient through a MockTransport."""
+    transport = httpx.MockTransport(handler)
+    original_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        celery_app.httpx,
+        "AsyncClient",
+        lambda **_kwargs: original_client(transport=transport),
+    )
+
+
+def test_verify_shelf_books_adopts_and_suggests(monkeypatch) -> None:
+    fake_redis = _FakeVerifyRedis()
+    monkeypatch.setattr(celery_app, "_get_redis_client", lambda: fake_redis)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/search.json"
+        title = request.url.params["title"]
+        if "zivote" in title:
+            return httpx.Response(200, json={"docs": [
+                {"key": "/works/OL1W", "title": "Tibetská kniha o životě a smrti",
+                 "author_name": ["Sogjal Rinpočhe"]},
+            ]})
+        if title == "Nastavení miminka":
+            return httpx.Response(200, json={"docs": [
+                {"key": "/works/OL2W", "title": "Nastávající maminky", "author_name": []},
+            ]})
+        return httpx.Response(200, json={"docs": []})
+
+    _patch_catalog_transport(monkeypatch, handler)
+
+    books: list[dict[str, object]] = [
+        # Near-identical (diacritics only) → adopt the catalog form
+        {"title": "tibetska kniha o zivote a smrti", "author": "sogjal rinpočhe",
+         "confidence": "medium"},
+        # OCR misread → keep scanned text, attach suggestion, needs_review
+        {"title": "Nastavení miminka", "author": None, "confidence": "high"},
+        # No catalog hit → untouched
+        {"title": "Zcela neznámá kniha", "author": None, "confidence": "high"},
+        # No title → skipped entirely
+        {"title": None, "author": None, "confidence": "low"},
+    ]
+
+    stats = celery_app.asyncio.run(celery_app._verify_shelf_books_against_catalog(books))
+
+    assert books[0]["title"] == "Tibetská kniha o životě a smrti"
+    assert books[0]["author"] == "Sogjal Rinpočhe"
+    assert books[0]["confidence"] == "medium"
+    assert "catalog_adopted" in books[0]["quality_flags"]
+
+    assert books[1]["title"] == "Nastavení miminka"
+    assert books[1]["suggested_title"] == "Nastávající maminky"
+    assert books[1]["confidence"] == "needs_review"
+
+    assert books[2]["title"] == "Zcela neznámá kniha"
+    assert books[2]["confidence"] == "high"
+    assert "suggested_title" not in books[2]
+
+    assert stats == {"adopt": 1, "suggest": 1, "none": 0, "no_candidate": 1}
+    # Lookups are cached for repeat scans of the same shelf
+    assert len(fake_redis.store) == 3
+
+
+def test_verify_shelf_books_survives_lookup_failure(monkeypatch) -> None:
+    monkeypatch.setattr(celery_app, "_get_redis_client", lambda: _FakeVerifyRedis())
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    _patch_catalog_transport(monkeypatch, handler)
+
+    books: list[dict[str, object]] = [
+        {"title": "Válka s mloky", "author": "Karel Čapek", "confidence": "high"},
+    ]
+
+    stats = celery_app.asyncio.run(celery_app._verify_shelf_books_against_catalog(books))
+
+    # Row stays exactly as the vision model produced it
+    assert books[0] == {"title": "Válka s mloky", "author": "Karel Čapek", "confidence": "high"}
+    assert stats["no_candidate"] == 1
+
+
+def test_verify_shelf_books_uses_cache(monkeypatch) -> None:
+    fake_redis = _FakeVerifyRedis()
+    monkeypatch.setattr(celery_app, "_get_redis_client", lambda: fake_redis)
+
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(200, json={"docs": [
+            {"key": "/works/OL1W", "title": "Válka s mloky", "author_name": ["Karel Čapek"]},
+        ]})
+
+    _patch_catalog_transport(monkeypatch, handler)
+
+    books1: list[dict[str, object]] = [{"title": "Válka s mloky", "author": "Karel Čapek"}]
+    books2: list[dict[str, object]] = [{"title": "Válka s mloky", "author": "Karel Čapek"}]
+
+    celery_app.asyncio.run(celery_app._verify_shelf_books_against_catalog(books1))
+    celery_app.asyncio.run(celery_app._verify_shelf_books_against_catalog(books2))
+
+    assert call_count["n"] == 1


### PR DESCRIPTION
## Problém
Vision model občas přečte hřbet na nejbližší pravděpodobná slova — např. *nastávající maminky* → *nastavení miminka*. Prompt to nevyřeší; potřebujeme výstup ukotvit proti reálnému katalogu.

## Řešení
Po shelf-scanu se každá rozpoznaná kniha fuzzy-porovná (bez diakritiky, case-insensitive, SequenceMatcher) s nejbližším záznamem Open Library:

| Shoda | Akce |
|---|---|
| ≥ 0.92 (téměř identická) | **Převezme se katalogový tvar** — opraví diakritiku, casing, drobné přešmyky. Jiný autor tiché převzetí blokuje. |
| ≥ 0.55 (částečná) | Sken zůstává, přidá se `suggested_title`/`suggested_author`, confidence → `needs_review`. Review UI ukáže „Katalog navrhuje: …" s tlačítkem **Použít návrh**. |
| < 0.55 / bez záznamu | Beze změny — pokrytí českých knih v OL je slabé, absence nesmí být signál. |

Rozhodovací logika je v novém čistém modulu `worker/catalog_match.py` (bez I/O, testovatelný lokálně); I/O v `celery_app.py` vedle ostatních OL volání.

**Robustnost:** výpadek OL / redis / timeout nechá řádky přesně tak, jak je vrátil vision model. Kill-switch `ENABLE_CATALOG_VERIFY`. Souběžnost 3 (OL limit 3 req/s s identifikujícím User-Agent), cache 24 h, celkový timeout 30 s.

## Oprava navíc
Worker confidence `needs_review` se v `GET /scan/shelf/{job_id}` mapovalo na `auto` — quality heuristiky (merged author apod.) se tak v UI **nikdy neprojevily**. Opraveno; review UI navíc u řádku s návrhem neblankuje naskenovaný název (je co porovnávat).

## Testy
- `worker/tests/test_catalog_match.py` — 17 testů prahů a aplikace rozhodnutí (ověřeno lokálně, modul je bez závislostí); kanonický případ *nastavení miminka* → suggest je pokrytý explicitně
- `worker/tests/test_celery_app.py` — integrační testy verifikace (adopt + suggest + cache + odolnost proti 500)
- `backend/tests/test_scan_api.py` — mapování needs_review + průchod suggested polí
- frontend: eslint OK, všech 284 vitest testů prochází
- OpenAPI artefakt aktualizován ručně (lokálně není Python toolchain) — pokud verify krok spadne, opravím podle CI diffu

🤖 Generated with [Claude Code](https://claude.com/claude-code)