### PR TITLE
ci: spouštět worker testy při každém PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,37 @@ jobs:
       - name: Verify OpenAPI artifact is up to date
         run: git diff --exit-code docs/openapi.yaml
 
+  # ── Worker tests (Pytest, no DB — external I/O is monkeypatched) ──────────
+  worker-tests:
+    name: worker / tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: worker/requirements*.txt
+
+      # pyzbar needs the zbar shared library at import time (mirrors the
+      # worker Dockerfile).
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libzbar0
+
+      - name: Install worker dependencies
+        working-directory: worker
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Pytest
+        working-directory: worker
+        run: pytest tests -v --tb=short
+
   # ── Backend tests (Pytest + coverage gate) ────────────────────────────────
   # Runs unconditionally in parallel with backend-lint — a lint failure never
   # prevents tests from producing a result (which was the original blind spot).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,11 @@ jobs:
 
       - name: Pytest
         working-directory: worker
+        env:
+          # Shelf-scan tests mock the Gemini HTTP call itself, but the code
+          # under test bails out early when no API key is configured (locally
+          # it comes from worker/.env, which is not in the repo).
+          GEMINI_API_KEY: test-key
         run: pytest tests -v --tb=short
 
   # ── Backend tests (Pytest + coverage gate) ────────────────────────────────

--- a/worker/requirements-dev.txt
+++ b/worker/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.3.4


### PR DESCRIPTION
## Problém
`worker/tests/` (Gemini parser, text_normalize, catalog_match, celery tasky — dnes 60+ testů) CI **vůbec nespouštělo**; worker adresář procházel jen Trivy scanem. Testy tak běžely jen ručně u vývojáře.

## Řešení
Nový job **worker / tests** (GitHub-hosted, jako ostatní joby po #327):
- `libzbar0` přes apt (pyzbar ji potřebuje při importu — zrcadlí worker Dockerfile)
- nový `worker/requirements-dev.txt` = `-r requirements.txt` + pytest
- `pytest tests -v` v `worker/` — bez DB, externí I/O je v testech mockované

🤖 Generated with [Claude Code](https://claude.com/claude-code)