### PR TITLE
feat(enrich): Knihovny.cz jako první metadatový zdroj pro české tituly (ADR 012)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,6 +41,9 @@ class Settings(BaseSettings):
     # Identifying User-Agent sent with Open Library requests — required
     # etiquette and lifts the anonymous 1 req/s rate limit to 3 req/s.
     open_library_user_agent: str = "Shelfy (https://shelfy.cz; support@shelfy.cz)"
+    # Knihovny.cz (Czech central library portal, VuFind API) — first choice
+    # for Czech-looking lookups, fallback otherwise (ADR 012). Kill-switch.
+    enable_knihovny_cz: bool = True
 
     # Observability / error tracking
     # Set SENTRY_DSN in .env to enable Sentry error reporting.

--- a/backend/app/services/metadata/knihovny.py
+++ b/backend/app/services/metadata/knihovny.py
@@ -1,0 +1,186 @@
+"""Knihovny.cz metadata fetcher — the Czech central library portal.
+
+Knihovny.cz (run by the Moravian Library, backed by Czech library
+catalogues incl. the National Library) exposes a public VuFind JSON API.
+Coverage of Czech titles — including annotations — is far better than
+Open Library's, so it is the first choice for Czech-looking lookups and
+a fallback for everything else (ADR 012).
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+import unicodedata
+
+import httpx
+
+from app.core.config import get_settings
+
+_API_URL = "https://www.knihovny.cz/api/v1/search"
+_FIELDS = (
+    "title",
+    "authors",
+    "isbns",
+    "publishers",
+    "publicationDates",
+    "languages",
+    "summary",
+)
+
+# Characters that only occur in Czech (and Slovak) orthography — a cheap,
+# reliable signal that a scanned title/author is a Czech book.
+_CZECH_CHARS = set("ěščřžýáíéúůďťňó" "ĚŠČŘŽÝÁÍÉÚŮĎŤŇÓ")
+
+
+def looks_czech(*texts: str | None) -> bool:
+    """True when any text carries Czech diacritics or a Czech ISBN prefix."""
+    for text in texts:
+        if not text:
+            continue
+        if any(ch in _CZECH_CHARS for ch in text):
+            return True
+        digits = re.sub(r"[^0-9Xx]", "", text)
+        # 978-80-… (ISBN-13) / 80-… (ISBN-10) is the Czech(oslovak) group.
+        if len(digits) == 13 and digits.startswith("97880"):
+            return True
+        if len(digits) == 10 and digits.startswith("80"):
+            return True
+    return False
+
+
+def _clean_author(raw: str) -> str:
+    # VuFind display form carries life dates: "Karel Čapek, 1890-1938".
+    return re.sub(r",\s*[0-9].*$", "", raw).strip()
+
+
+def _primary_author(record: dict[str, Any]) -> str | None:
+    authors = record.get("authors")
+    if not isinstance(authors, dict):
+        return None
+    primary = authors.get("primary")
+    # ``primary`` is a dict keyed by display name (or an empty list).
+    if isinstance(primary, dict):
+        for name in primary:
+            if isinstance(name, str) and name.strip():
+                return _clean_author(name)
+    return None
+
+
+def _first_str(record: dict[str, Any], field: str) -> str | None:
+    values = record.get(field)
+    first = values[0] if isinstance(values, list) and values else None
+    return first if isinstance(first, str) else None
+
+
+def _normalize_isbn_digits(raw: str) -> str | None:
+    digits = re.sub(r"[^0-9Xx]", "", raw).upper()
+    return digits if len(digits) in (10, 13) else None
+
+
+def _strip_diacritics(text: str) -> str:
+    decomposed = unicodedata.normalize("NFD", text.lower())
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
+def _author_matches(query_author: str | None, record_author: str | None) -> bool:
+    if not query_author or not record_author:
+        return False
+    query_tokens = [t for t in _strip_diacritics(query_author).split() if len(t) > 2]
+    record_norm = _strip_diacritics(record_author)
+    return any(token in record_norm for token in query_tokens)
+
+
+def _pick_record(records: list[dict[str, Any]], author: str | None) -> dict[str, Any] | None:
+    """Prefer records that match the author and actually carry an ISBN and
+    annotation; ties resolve to API relevance order."""
+    best: dict[str, Any] | None = None
+    best_score = -1
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        score = 0
+        if _author_matches(author, _primary_author(record)):
+            score += 4
+        if record.get("isbns"):
+            score += 2
+        if record.get("summary"):
+            score += 1
+        if score > best_score:
+            best = record
+            best_score = score
+    return best
+
+
+async def fetch_knihovny_metadata(
+    client: httpx.AsyncClient,
+    isbn: str | None,
+    title: str | None = None,
+    author: str | None = None,
+) -> dict[str, Any] | None:
+    if isbn:
+        lookfor, search_type = isbn, "ISN"
+    elif title:
+        lookfor, search_type = title, "Title"
+    else:
+        return None
+
+    params: list[tuple[str, str]] = [
+        ("lookfor", lookfor),
+        ("type", search_type),
+        ("limit", "5"),
+    ]
+    params.extend(("field[]", field) for field in _FIELDS)
+
+    response = await client.get(
+        _API_URL,
+        params=params,
+        headers={"User-Agent": get_settings().open_library_user_agent},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    records = payload.get("records") if isinstance(payload, dict) else None
+    if not isinstance(records, list) or not records:
+        return None
+
+    record = _pick_record(records, author)
+    if record is None:
+        return None
+
+    record_title = record.get("title") if isinstance(record.get("title"), str) else None
+    if not record_title:
+        return None
+
+    record_isbn = _first_str(record, "isbns")
+    resolved_isbn = _normalize_isbn_digits(record_isbn) if record_isbn else None
+    if isbn and resolved_isbn is None:
+        resolved_isbn = _normalize_isbn_digits(isbn)
+
+    publisher = _first_str(record, "publishers")
+    if publisher:
+        publisher = publisher.rstrip(", ").strip() or None
+
+    year: int | None = None
+    publication_date = _first_str(record, "publicationDates")
+    if publication_date:
+        match = re.search(r"\d{4}", publication_date)
+        if match:
+            year = int(match.group(0))
+
+    language = _first_str(record, "languages")
+    if language and not re.fullmatch(r"[A-Za-z]{2,3}", language):
+        language = None
+
+    return {
+        "title": record_title.strip(),
+        "author": _primary_author(record),
+        "isbn": resolved_isbn,
+        "publisher": publisher,
+        "language": language.lower() if language else None,
+        "description": _first_str(record, "summary"),
+        # Knihovny.cz nevrací volně použitelné obálky (ObalkyKnih má vlastní
+        # licenční podmínky) — obálku doplní gap-fill z Open Library.
+        "cover_image_url": None,
+        "publication_year": year,
+        "provider": "knihovny_cz",
+    }

--- a/backend/app/services/metadata/knihovny.py
+++ b/backend/app/services/metadata/knihovny.py
@@ -124,7 +124,7 @@ async def fetch_knihovny_metadata(
     else:
         return None
 
-    params: list[tuple[str, str]] = [
+    params: list[tuple[str, str | int | float | bool | None]] = [
         ("lookfor", lookfor),
         ("type", search_type),
         ("limit", "5"),

--- a/backend/app/services/metadata/service.py
+++ b/backend/app/services/metadata/service.py
@@ -10,6 +10,7 @@ import structlog
 from app.core.config import get_settings
 from app.core.metrics import EXTERNAL_API_CALLS_TOTAL, observe_external_api_latency
 from app.services.metadata.google_books import fetch_google_books_metadata
+from app.services.metadata.knihovny import fetch_knihovny_metadata, looks_czech
 from app.services.metadata.open_library import fetch_open_library_metadata
 
 # Open Library allows commercial reuse of its data, so hits can be cached
@@ -72,6 +73,30 @@ async def _open_library_lookup(
         observe_external_api_latency("open_library", start)
 
 
+async def _knihovny_lookup(
+    client: httpx.AsyncClient,
+    isbn: str | None,
+    title: str | None,
+    author: str | None,
+) -> tuple[dict[str, object] | None, bool]:
+    """Returns ``(metadata, errored)``."""
+    start = perf_counter()
+    try:
+        EXTERNAL_API_CALLS_TOTAL.labels(provider="knihovny_cz").inc()
+        return await fetch_knihovny_metadata(client, isbn, title=title, author=author), False
+    except Exception as exc:
+        logger.warning("knihovny_lookup_failed", isbn=isbn, title=title, author=author, error=str(exc))
+        return None, True
+    finally:
+        observe_external_api_latency("knihovny_cz", start)
+
+
+# Fields worth backfilling from a secondary provider when the primary hit
+# lacks them (knihovny.cz never returns covers; Open Library often lacks
+# Czech annotations).
+_GAP_FILL_FIELDS = ("cover_image_url", "description")
+
+
 async def enrich_metadata_with_fallback(
     isbn: str | None,
     title: str | None,
@@ -90,18 +115,51 @@ async def enrich_metadata_with_fallback(
             result: dict[str, object] | None = json.loads(cached)
             return result
 
-        # Open Library is the sole default provider — Google Books ToS
-        # forbids paid applications, so it only runs behind the explicit
-        # ``enable_google_books`` opt-in (see app/core/config.py), where it
-        # keeps its legacy primary-with-fallback position.
+        # Provider order (ADR 012): Czech-looking lookups (diacritics or a
+        # 978-80/80 ISBN prefix) hit knihovny.cz first — its coverage of
+        # Czech titles and annotations beats Open Library. Everything else
+        # keeps Open Library first with knihovny.cz as the fallback. Google
+        # Books ToS forbids paid applications, so it only runs behind the
+        # explicit ``enable_google_books`` opt-in, keeping its legacy
+        # primary-with-fallback position.
+        if settings.enable_knihovny_cz:
+            czech = looks_czech(isbn, title, author)
+            providers = (
+                [_knihovny_lookup, _open_library_lookup]
+                if czech
+                else [_open_library_lookup, _knihovny_lookup]
+            )
+        else:
+            providers = [_open_library_lookup]
+
         metadata: dict[str, object] | None = None
         errored = False
         async with httpx.AsyncClient() as client:
             if settings.enable_google_books:
                 metadata, errored = await _google_books_lookup(client, isbn, title, author)
-            if metadata is None:
-                metadata, open_library_errored = await _open_library_lookup(client, isbn, title, author)
-                errored = errored or open_library_errored
+            remaining = list(providers)
+            while metadata is None and remaining:
+                lookup = remaining.pop(0)
+                metadata, lookup_errored = await lookup(client, isbn, title, author)
+                errored = errored or lookup_errored
+
+            # Gap-fill: the winning record may lack a cover (knihovny.cz
+            # never has one) or an annotation (Open Library rarely has
+            # Czech ones) — backfill just those fields from the next
+            # provider in line. Best-effort, never fails the lookup.
+            # Skipped for Google results to preserve its legacy standalone
+            # behaviour.
+            if (
+                metadata is not None
+                and metadata.get("provider") in ("open_library", "knihovny_cz")
+                and remaining
+                and any(not metadata.get(field) for field in _GAP_FILL_FIELDS)
+            ):
+                secondary, _ = await remaining[0](client, isbn, title, author)
+                if secondary:
+                    for field in _GAP_FILL_FIELDS:
+                        if not metadata.get(field) and secondary.get(field):
+                            metadata[field] = secondary[field]
 
         if metadata is None:
             # Only cache a miss when the provider actually answered —

--- a/backend/tests/test_metadata_services.py
+++ b/backend/tests/test_metadata_services.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.core.config import get_settings
 from app.services.metadata.google_books import fetch_google_books_metadata
+from app.services.metadata.knihovny import fetch_knihovny_metadata, looks_czech
 from app.services.metadata.open_library import fetch_open_library_metadata
 from app.services.metadata.service import (
     CACHE_TTL_SECONDS,
@@ -119,6 +120,7 @@ def test_flag_enabled_restores_google_primary(monkeypatch: pytest.MonkeyPatch) -
     _use_redis(monkeypatch, FakeRedis())
     monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _google)
     monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _fail_if_called)
+    monkeypatch.setattr("app.services.metadata.service.fetch_knihovny_metadata", _fail_if_called)
 
     metadata = asyncio.run(enrich_metadata_with_fallback("9780132350884", title=None, author=None))
 
@@ -157,6 +159,7 @@ def test_cache_hit_skips_external_calls(monkeypatch: pytest.MonkeyPatch) -> None
     _use_redis(monkeypatch, fake_redis)
     monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
     monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _fail_if_called)
+    monkeypatch.setattr("app.services.metadata.service.fetch_knihovny_metadata", _fail_if_called)
 
     metadata = asyncio.run(enrich_metadata_with_fallback("9780134494166", title=None, author=None))
 
@@ -174,8 +177,13 @@ def test_definitive_miss_is_negatively_cached(monkeypatch: pytest.MonkeyPatch) -
     fake_redis = FakeRedis()
     _use_settings(monkeypatch)
     _use_redis(monkeypatch, fake_redis)
+    async def _knihovny_miss(_client: httpx.AsyncClient, _isbn: str | None, title: str | None = None, author: str | None = None) -> None:
+        calls.append("knihovny")
+        return None
+
     monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
     monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library_miss)
+    monkeypatch.setattr("app.services.metadata.service.fetch_knihovny_metadata", _knihovny_miss)
 
     first = asyncio.run(enrich_metadata_with_fallback("9799999999999", title=None, author=None))
     second = asyncio.run(enrich_metadata_with_fallback("9799999999999", title=None, author=None))
@@ -183,7 +191,7 @@ def test_definitive_miss_is_negatively_cached(monkeypatch: pytest.MonkeyPatch) -
     assert first is None
     assert second is None
     # The second lookup is served from the negative cache entry.
-    assert calls == ["open_library"]
+    assert calls == ["open_library", "knihovny"]
     assert fake_redis.storage["book-metadata:9799999999999"] == "null"
     assert fake_redis.ttls["book-metadata:9799999999999"] == NEGATIVE_CACHE_TTL_SECONDS
 
@@ -195,8 +203,12 @@ def test_provider_error_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_redis = FakeRedis()
     _use_settings(monkeypatch)
     _use_redis(monkeypatch, fake_redis)
+    async def _knihovny_miss(_client: httpx.AsyncClient, _isbn: str | None, title: str | None = None, author: str | None = None) -> None:
+        return None
+
     monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
     monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library_down)
+    monkeypatch.setattr("app.services.metadata.service.fetch_knihovny_metadata", _knihovny_miss)
 
     metadata = asyncio.run(enrich_metadata_with_fallback("9780201485677", title=None, author=None))
 
@@ -422,14 +434,174 @@ def test_title_author_lookup_without_isbn_uses_open_library_only(monkeypatch: py
         calls.append(("open_library", title, author))
         return {"title": "Clean Code", "author": "Martin", "provider": "open_library"}
 
+    async def _knihovny_miss(_client: httpx.AsyncClient, _isbn: str | None, title: str | None = None, author: str | None = None) -> None:
+        calls.append(("knihovny", title, author))
+        return None
+
     fake_redis = FakeRedis()
     _use_settings(monkeypatch, enable_google_books=False)
     _use_redis(monkeypatch, fake_redis)
     monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
     monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library)
+    monkeypatch.setattr("app.services.metadata.service.fetch_knihovny_metadata", _knihovny_miss)
 
     metadata = asyncio.run(enrich_metadata_with_fallback(None, title="Clean Code", author="Martin"))
 
     assert metadata is not None
-    assert calls == [("open_library", "Clean Code", "Martin")]
+    # Open Library first (non-Czech lookup); the incomplete record then
+    # triggers a knihovny.cz gap-fill attempt.
+    assert calls == [("open_library", "Clean Code", "Martin"), ("knihovny", "Clean Code", "Martin")]
     assert "book-metadata:title:clean code" in fake_redis.storage
+
+
+def test_looks_czech_detection() -> None:
+    assert looks_czech("Válka s mloky") is True
+    assert looks_czech(None, "nastávající maminky") is True
+    assert looks_czech("9788085126396") is True          # 978-80 = Czech ISBN group
+    assert looks_czech("8071360279") is True             # ISBN-10, group 80
+    assert looks_czech("Clean Code", "Robert C. Martin") is False
+    assert looks_czech("9780132350884") is False
+    assert looks_czech(None, None) is False
+
+
+def test_knihovny_client_normalizes_response_and_picks_matching_record() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/search"
+        assert request.url.params["type"] == "Title"
+        return httpx.Response(
+            200,
+            json={
+                "resultCount": 2,
+                "status": "OK",
+                "records": [
+                    {
+                        # Audiokniha bez ISBN a jiný autor — nesmí vyhrát
+                        "title": "Válka s mloky",
+                        "authors": {"primary": {"Jiný Autor, 1950-": []}, "secondary": [], "corporate": []},
+                        "isbns": [],
+                        "publishers": ["Radioservis,"],
+                        "publicationDates": ["c2009"],
+                        "languages": [],
+                        "summary": [],
+                    },
+                    {
+                        "title": "Válka s Mloky",
+                        "authors": {"primary": {"Karel Čapek, 1890-1938": []}, "secondary": [], "corporate": []},
+                        "isbns": ["978-80-85126-39-6"],
+                        "publishers": ["Zoologická zahrada hl. m. Prahy,"],
+                        "publicationDates": ["2014"],
+                        "languages": [],
+                        "summary": ["Slavná antiutopická sci-fi z roku 1936."],
+                    },
+                ],
+            },
+        )
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await fetch_knihovny_metadata(client, None, title="Válka s mloky", author="Karel Čapek")
+
+    metadata = asyncio.run(_run())
+
+    assert metadata is not None
+    assert metadata["provider"] == "knihovny_cz"
+    assert metadata["title"] == "Válka s Mloky"
+    # Životní data se z VuFind zobrazovací formy odstřihnou
+    assert metadata["author"] == "Karel Čapek"
+    assert metadata["isbn"] == "9788085126396"
+    assert metadata["publisher"] == "Zoologická zahrada hl. m. Prahy"
+    assert metadata["publication_year"] == 2014
+    assert metadata["description"] == "Slavná antiutopická sci-fi z roku 1936."
+    # Obálky knihovny.cz nevrací — doplní je gap-fill z Open Library
+    assert metadata["cover_image_url"] is None
+
+
+def test_knihovny_client_isbn_search_uses_isn_type() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["type"] == "ISN"
+        assert request.url.params["lookfor"] == "9788085126396"
+        return httpx.Response(200, json={"records": [], "status": "OK"})
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await fetch_knihovny_metadata(client, "9788085126396")
+
+    assert asyncio.run(_run()) is None
+
+
+def test_czech_lookup_prefers_knihovny_and_gap_fills_cover(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def _knihovny(_client: httpx.AsyncClient, isbn: str | None, title: str | None = None, author: str | None = None) -> dict[str, object]:
+        calls.append("knihovny")
+        return {
+            "title": "Válka s mloky",
+            "author": "Karel Čapek",
+            "isbn": "9788085126396",
+            "description": "Česká anotace.",
+            "cover_image_url": None,
+            "provider": "knihovny_cz",
+        }
+
+    async def _open_library(_client: httpx.AsyncClient, isbn: str | None, title: str | None = None, author: str | None = None) -> dict[str, object]:
+        calls.append("open_library")
+        return {
+            "title": "War with the Newts",
+            "description": None,
+            "cover_image_url": "https://covers.openlibrary.org/b/id/1-L.jpg",
+            "provider": "open_library",
+        }
+
+    _use_settings(monkeypatch, enable_google_books=False)
+    _use_redis(monkeypatch, FakeRedis())
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library)
+    monkeypatch.setattr("app.services.metadata.service.fetch_knihovny_metadata", _knihovny)
+
+    metadata = asyncio.run(enrich_metadata_with_fallback(None, title="Válka s mloky", author="Karel Čapek"))
+
+    assert metadata is not None
+    # Český dotaz → knihovny.cz první; Open Library jen doplní obálku
+    assert calls == ["knihovny", "open_library"]
+    assert metadata["provider"] == "knihovny_cz"
+    assert metadata["description"] == "Česká anotace."
+    assert metadata["cover_image_url"] == "https://covers.openlibrary.org/b/id/1-L.jpg"
+
+
+def test_non_czech_lookup_falls_back_to_knihovny_on_open_library_miss(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def _open_library_miss(_client: httpx.AsyncClient, _isbn: str | None, title: str | None = None, author: str | None = None) -> None:
+        calls.append("open_library")
+        return None
+
+    async def _knihovny(_client: httpx.AsyncClient, isbn: str | None, title: str | None = None, author: str | None = None) -> dict[str, object]:
+        calls.append("knihovny")
+        return dict(OPEN_LIBRARY_METADATA, provider="knihovny_cz")
+
+    _use_settings(monkeypatch, enable_google_books=False)
+    _use_redis(monkeypatch, FakeRedis())
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library_miss)
+    monkeypatch.setattr("app.services.metadata.service.fetch_knihovny_metadata", _knihovny)
+
+    metadata = asyncio.run(enrich_metadata_with_fallback(None, title="Clean Code", author="Martin"))
+
+    assert metadata is not None
+    assert calls == ["open_library", "knihovny"]
+    assert metadata["provider"] == "knihovny_cz"
+
+
+def test_knihovny_disabled_keeps_open_library_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _open_library_miss(_client: httpx.AsyncClient, _isbn: str | None, title: str | None = None, author: str | None = None) -> None:
+        return None
+
+    _use_settings(monkeypatch, enable_google_books=False, enable_knihovny_cz=False)
+    _use_redis(monkeypatch, FakeRedis())
+    monkeypatch.setattr("app.services.metadata.service.fetch_google_books_metadata", _fail_if_called)
+    monkeypatch.setattr("app.services.metadata.service.fetch_open_library_metadata", _open_library_miss)
+    monkeypatch.setattr("app.services.metadata.service.fetch_knihovny_metadata", _fail_if_called)
+
+    metadata = asyncio.run(enrich_metadata_with_fallback(None, title="Válka s mloky", author=None))
+
+    assert metadata is None

--- a/docs/adr/012-knihovny-cz-for-czech-metadata.md
+++ b/docs/adr/012-knihovny-cz-for-czech-metadata.md
@@ -1,0 +1,58 @@
+# ADR 012: Knihovny.cz jako první metadatový zdroj pro české tituly
+
+- **Status:** Accepted
+- **Date:** 2026-07-15
+- **Navazuje na:** ADR 009 (Open Library jako výchozí zdroj), issue #311
+
+## Context
+
+Open Library (ADR 009) funguje dobře pro anglické tituly, ale pokrytí
+českých knih je slabé: chybějí ISBN u vydání, anotace prakticky vždy a
+často i celé záznamy. Uživatelé s převážně českou knihovnou tak z funkce
+„obohatit" dostávají prázdná pole.
+
+Zvažované české zdroje (z issue #311):
+
+| Zdroj | Přístup | Poznámka |
+|---|---|---|
+| **Knihovny.cz** (MZK, centrální portál knihoven ČR) | veřejné VuFind JSON API | výborné pokrytí, **české anotace**, čistý JSON, bez registrace |
+| NK ČR Aleph X-Server / SRU | XML/MARC | X-Server má **IP allowlist** (ověřeno 403), MARCXML parsování je pracné |
+| ObalkyKnih.cz | API pro knihovny | obálky + anotace; **komerční užití vyžaduje dohodu** — Patrik ověří |
+| Wikidata | SPARQL, CC0 | řídké pokrytí knih |
+| Databázeknih.cz | žádné API | scraping proti podmínkám |
+| ISBNdb | $15–300/měs. | až kdyby zdarma zdroje nestačily |
+
+Knihovny.cz agreguje katalogy českých knihoven včetně fondů NK ČR,
+takže z praktického hlediska pokrývá totéž co přímý přístup do NK ČR,
+ale přes moderní, veřejně dostupné JSON API.
+
+## Decision
+
+1. **Knihovny.cz se přidává jako druhý provider** vedle Open Library
+   (backend `app/services/metadata/knihovny.py`, worker
+   `worker/knihovny_client.py` — zrcadlení dle zavedeného vzoru).
+2. **Pořadí providerů řídí heuristika `looks_czech`**: česká diakritika
+   v názvu/autorovi nebo ISBN skupina 978-80/80 → Knihovny.cz první,
+   Open Library fallback; jinak Open Library první, Knihovny.cz fallback.
+3. **Gap-fill:** vítězný záznam se doplní o `cover_image_url` a
+   `description` z dalšího provideru v pořadí (Knihovny.cz nevrací volně
+   použitelné obálky; Open Library nemívá české anotace). Best-effort,
+   výsledek se cachuje včetně doplněných polí.
+4. Google Books zůstává beze změny za `ENABLE_GOOGLE_BOOKS` (ADR 009) a
+   gap-fill se na jeho výsledky nevztahuje.
+5. Kill-switch `ENABLE_KNIHOVNY_CZ` (default zapnuto) v backendu i workeru.
+
+## Consequences
+
+- České tituly dostanou z obohacení ISBN, nakladatele, rok a českou
+  anotaci; obálka se dotáhne z Open Library, pokud ji má.
+- Pro české knihy se typicky volají oba providery (gap-fill obálky) —
+  akceptovatelné: enrichment je rate-limitovaný (1,5 s mezi knihami)
+  a výsledky se cachují 7 dní (backend) / 24 h (worker).
+- Obálky českých knih zůstávají slabé místo — ObalkyKnih.cz by je
+  vyřešilo, ale vyžaduje licenční dohodu (obchodní krok mimo kód).
+- Závislost na dostupnosti knihovny.cz je měkká: výpadek = fallback na
+  Open Library, kill-switch pro úplné vypnutí.
+- Stejná logika výběru zdroje se nabízí i pro ověřování skenu
+  (worker/catalog_match.py) — české hřbety by proti knihovny.cz
+  matchovaly lépe než proti Open Library; ponecháno jako follow-up.

--- a/worker/celery_app.py
+++ b/worker/celery_app.py
@@ -28,6 +28,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 from catalog_match import apply_catalog_match, normalize_for_compare
 from gemini_parser import parse_gemini_candidates
+from knihovny_client import fetch_knihovny_metadata, looks_czech
 from settings import worker_settings
 
 CACHE_TTL_SECONDS = 24 * 60 * 60
@@ -921,6 +922,21 @@ async def _fetch_open_library_metadata(isbn: str | None, title: str | None = Non
     }
 
 
+async def _fetch_knihovny_metadata(isbn: str | None, title: str | None = None, author: str | None = None) -> dict[str, object] | None:
+    start = perf_counter()
+    try:
+        async with httpx.AsyncClient() as client:
+            return await fetch_knihovny_metadata(client, isbn, title=title, author=author)
+    finally:
+        logger.info("external_api_call", provider="knihovny_cz", isbn=isbn, title=title, author=author, processing_step="metadata_lookup", latency_seconds=perf_counter() - start)
+
+
+# Fields worth backfilling from a secondary provider when the primary hit
+# lacks them (knihovny.cz never returns covers; Open Library often lacks
+# Czech annotations).
+_GAP_FILL_FIELDS = ("cover_image_url", "description")
+
+
 async def _enrich_metadata_with_fallback(isbn: str | None, title: str | None = None, author: str | None = None) -> dict[str, object] | None:
     cache = _get_redis_client()
     cache_key = _cache_key(isbn, title)
@@ -932,20 +948,52 @@ async def _enrich_metadata_with_fallback(isbn: str | None, title: str | None = N
 
     metadata: dict[str, object] | None = None
 
-    # Open Library is the sole default provider — Google Books ToS forbids
-    # paid applications, so it only runs behind the explicit opt-in flag
-    # (mirrors app/services/metadata/service.py in the backend).
+    # Google Books ToS forbids paid applications, so it only runs behind the
+    # explicit opt-in flag (mirrors app/services/metadata/service.py).
     if worker_settings.enable_google_books:
         try:
             metadata = await _fetch_google_books_metadata(isbn, title=title, author=author)
         except Exception:
             metadata = None
 
-    if metadata is None:
+    # Provider order (ADR 012): Czech-looking lookups (diacritics or a
+    # 978-80/80 ISBN prefix) hit knihovny.cz first; everything else keeps
+    # Open Library first with knihovny.cz as the fallback.
+    if worker_settings.enable_knihovny_cz:
+        providers = (
+            [_fetch_knihovny_metadata, _fetch_open_library_metadata]
+            if looks_czech(isbn, title, author)
+            else [_fetch_open_library_metadata, _fetch_knihovny_metadata]
+        )
+    else:
+        providers = [_fetch_open_library_metadata]
+
+    remaining = list(providers)
+    while metadata is None and remaining:
+        fetch = remaining.pop(0)
         try:
-            metadata = await _fetch_open_library_metadata(isbn, title=title, author=author)
+            metadata = await fetch(isbn, title=title, author=author)
         except Exception:
             metadata = None
+
+    # Gap-fill: the winning record may lack a cover (knihovny.cz never has
+    # one) or an annotation (Open Library rarely has Czech ones) — backfill
+    # just those fields from the next provider in line. Best-effort. Skipped
+    # for Google results to preserve its legacy standalone behaviour.
+    if (
+        metadata is not None
+        and metadata.get("provider") in ("open_library", "knihovny_cz")
+        and remaining
+        and any(not metadata.get(field) for field in _GAP_FILL_FIELDS)
+    ):
+        try:
+            secondary = await remaining[0](isbn, title=title, author=author)
+        except Exception:
+            secondary = None
+        if secondary:
+            for field in _GAP_FILL_FIELDS:
+                if not metadata.get(field) and secondary.get(field):
+                    metadata[field] = secondary[field]
 
     if metadata is not None:
         cache.setex(cache_key, CACHE_TTL_SECONDS, json.dumps(metadata))

--- a/worker/knihovny_client.py
+++ b/worker/knihovny_client.py
@@ -124,7 +124,7 @@ async def fetch_knihovny_metadata(
     else:
         return None
 
-    params: list[tuple[str, str]] = [
+    params: list[tuple[str, str | int | float | bool | None]] = [
         ("lookfor", lookfor),
         ("type", search_type),
         ("limit", "5"),

--- a/worker/knihovny_client.py
+++ b/worker/knihovny_client.py
@@ -1,0 +1,186 @@
+"""Knihovny.cz metadata fetcher — the Czech central library portal.
+
+Knihovny.cz (run by the Moravian Library, backed by Czech library
+catalogues incl. the National Library) exposes a public VuFind JSON API.
+Coverage of Czech titles — including annotations — is far better than
+Open Library's, so it is the first choice for Czech-looking lookups and
+a fallback for everything else (ADR 012).
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+import unicodedata
+
+import httpx
+
+from settings import worker_settings
+
+_API_URL = "https://www.knihovny.cz/api/v1/search"
+_FIELDS = (
+    "title",
+    "authors",
+    "isbns",
+    "publishers",
+    "publicationDates",
+    "languages",
+    "summary",
+)
+
+# Characters that only occur in Czech (and Slovak) orthography — a cheap,
+# reliable signal that a scanned title/author is a Czech book.
+_CZECH_CHARS = set("ěščřžýáíéúůďťňó" "ĚŠČŘŽÝÁÍÉÚŮĎŤŇÓ")
+
+
+def looks_czech(*texts: str | None) -> bool:
+    """True when any text carries Czech diacritics or a Czech ISBN prefix."""
+    for text in texts:
+        if not text:
+            continue
+        if any(ch in _CZECH_CHARS for ch in text):
+            return True
+        digits = re.sub(r"[^0-9Xx]", "", text)
+        # 978-80-… (ISBN-13) / 80-… (ISBN-10) is the Czech(oslovak) group.
+        if len(digits) == 13 and digits.startswith("97880"):
+            return True
+        if len(digits) == 10 and digits.startswith("80"):
+            return True
+    return False
+
+
+def _clean_author(raw: str) -> str:
+    # VuFind display form carries life dates: "Karel Čapek, 1890-1938".
+    return re.sub(r",\s*[0-9].*$", "", raw).strip()
+
+
+def _primary_author(record: dict[str, Any]) -> str | None:
+    authors = record.get("authors")
+    if not isinstance(authors, dict):
+        return None
+    primary = authors.get("primary")
+    # ``primary`` is a dict keyed by display name (or an empty list).
+    if isinstance(primary, dict):
+        for name in primary:
+            if isinstance(name, str) and name.strip():
+                return _clean_author(name)
+    return None
+
+
+def _first_str(record: dict[str, Any], field: str) -> str | None:
+    values = record.get(field)
+    first = values[0] if isinstance(values, list) and values else None
+    return first if isinstance(first, str) else None
+
+
+def _normalize_isbn_digits(raw: str) -> str | None:
+    digits = re.sub(r"[^0-9Xx]", "", raw).upper()
+    return digits if len(digits) in (10, 13) else None
+
+
+def _strip_diacritics(text: str) -> str:
+    decomposed = unicodedata.normalize("NFD", text.lower())
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
+def _author_matches(query_author: str | None, record_author: str | None) -> bool:
+    if not query_author or not record_author:
+        return False
+    query_tokens = [t for t in _strip_diacritics(query_author).split() if len(t) > 2]
+    record_norm = _strip_diacritics(record_author)
+    return any(token in record_norm for token in query_tokens)
+
+
+def _pick_record(records: list[dict[str, Any]], author: str | None) -> dict[str, Any] | None:
+    """Prefer records that match the author and actually carry an ISBN and
+    annotation; ties resolve to API relevance order."""
+    best: dict[str, Any] | None = None
+    best_score = -1
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        score = 0
+        if _author_matches(author, _primary_author(record)):
+            score += 4
+        if record.get("isbns"):
+            score += 2
+        if record.get("summary"):
+            score += 1
+        if score > best_score:
+            best = record
+            best_score = score
+    return best
+
+
+async def fetch_knihovny_metadata(
+    client: httpx.AsyncClient,
+    isbn: str | None,
+    title: str | None = None,
+    author: str | None = None,
+) -> dict[str, Any] | None:
+    if isbn:
+        lookfor, search_type = isbn, "ISN"
+    elif title:
+        lookfor, search_type = title, "Title"
+    else:
+        return None
+
+    params: list[tuple[str, str]] = [
+        ("lookfor", lookfor),
+        ("type", search_type),
+        ("limit", "5"),
+    ]
+    params.extend(("field[]", field) for field in _FIELDS)
+
+    response = await client.get(
+        _API_URL,
+        params=params,
+        headers={"User-Agent": worker_settings.open_library_user_agent},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    records = payload.get("records") if isinstance(payload, dict) else None
+    if not isinstance(records, list) or not records:
+        return None
+
+    record = _pick_record(records, author)
+    if record is None:
+        return None
+
+    record_title = record.get("title") if isinstance(record.get("title"), str) else None
+    if not record_title:
+        return None
+
+    record_isbn = _first_str(record, "isbns")
+    resolved_isbn = _normalize_isbn_digits(record_isbn) if record_isbn else None
+    if isbn and resolved_isbn is None:
+        resolved_isbn = _normalize_isbn_digits(isbn)
+
+    publisher = _first_str(record, "publishers")
+    if publisher:
+        publisher = publisher.rstrip(", ").strip() or None
+
+    year: int | None = None
+    publication_date = _first_str(record, "publicationDates")
+    if publication_date:
+        match = re.search(r"\d{4}", publication_date)
+        if match:
+            year = int(match.group(0))
+
+    language = _first_str(record, "languages")
+    if language and not re.fullmatch(r"[A-Za-z]{2,3}", language):
+        language = None
+
+    return {
+        "title": record_title.strip(),
+        "author": _primary_author(record),
+        "isbn": resolved_isbn,
+        "publisher": publisher,
+        "language": language.lower() if language else None,
+        "description": _first_str(record, "summary"),
+        # Knihovny.cz nevrací volně použitelné obálky (ObalkyKnih má vlastní
+        # licenční podmínky) — obálku doplní gap-fill z Open Library.
+        "cover_image_url": None,
+        "publication_year": year,
+        "provider": "knihovny_cz",
+    }

--- a/worker/settings.py
+++ b/worker/settings.py
@@ -41,6 +41,9 @@ class WorkerSettings(BaseSettings):
     google_books_api_key: str | None = None       # unused unless enable_google_books
     # Identifying User-Agent for Open Library (lifts rate limit to 3 req/s).
     open_library_user_agent: str = "Shelfy (https://shelfy.cz; support@shelfy.cz)"
+    # Knihovny.cz (Czech central library portal, VuFind API) — first choice
+    # for Czech-looking lookups, fallback otherwise (ADR 012). Kill-switch.
+    enable_knihovny_cz: bool = True
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/worker/tests/test_celery_app.py
+++ b/worker/tests/test_celery_app.py
@@ -494,6 +494,7 @@ def test_enrichment_cache_hit_skips_external_calls(monkeypatch) -> None:
 
     monkeypatch.setattr(celery_app, "_fetch_google_books_metadata", _raise)
     monkeypatch.setattr(celery_app, "_fetch_open_library_metadata", _raise)
+    monkeypatch.setattr(celery_app, "_fetch_knihovny_metadata", _raise)
 
     result = celery_app.asyncio.run(celery_app._enrich_metadata_with_fallback("9780134494166"))
 
@@ -518,8 +519,12 @@ def test_enrichment_default_uses_open_library_and_skips_google(monkeypatch) -> N
     async def _open_library(isbn, title=None, author=None):
         return {"title": "Refactoring", "isbn": isbn, "provider": "open_library"}
 
+    async def _knihovny_miss(_isbn, title=None, author=None):
+        return None
+
     monkeypatch.setattr(celery_app, "_fetch_google_books_metadata", _google_must_not_be_called)
     monkeypatch.setattr(celery_app, "_fetch_open_library_metadata", _open_library)
+    monkeypatch.setattr(celery_app, "_fetch_knihovny_metadata", _knihovny_miss)
     monkeypatch.setattr(celery_app.worker_settings, "enable_google_books", False)
 
     result = celery_app.asyncio.run(celery_app._enrich_metadata_with_fallback("9780201485677"))
@@ -959,3 +964,91 @@ def test_open_library_description_backfill_failure_keeps_metadata(monkeypatch) -
     assert metadata is not None
     assert metadata["title"] == "Clean Architecture"
     assert metadata["description"] is None
+
+
+def test_enrichment_czech_lookup_prefers_knihovny_and_gap_fills(monkeypatch) -> None:
+    stored = {}
+
+    class FakeRedis:
+        def get(self, _key):
+            return None
+
+        def setex(self, key, ttl, payload):
+            stored[key] = payload
+
+    monkeypatch.setattr(celery_app, "_get_redis_client", lambda: FakeRedis())
+    monkeypatch.setattr(celery_app.worker_settings, "enable_google_books", False)
+
+    calls = []
+
+    async def _knihovny(_isbn, title=None, author=None):
+        calls.append("knihovny")
+        return {
+            "title": "Válka s mloky",
+            "author": "Karel Čapek",
+            "isbn": "9788085126396",
+            "description": "Česká anotace.",
+            "cover_image_url": None,
+            "provider": "knihovny_cz",
+        }
+
+    async def _open_library(_isbn, title=None, author=None):
+        calls.append("open_library")
+        return {
+            "title": "War with the Newts",
+            "cover_image_url": "https://covers.openlibrary.org/b/id/1-L.jpg",
+            "provider": "open_library",
+        }
+
+    monkeypatch.setattr(celery_app, "_fetch_knihovny_metadata", _knihovny)
+    monkeypatch.setattr(celery_app, "_fetch_open_library_metadata", _open_library)
+
+    result = celery_app.asyncio.run(
+        celery_app._enrich_metadata_with_fallback(None, title="Válka s mloky", author="Karel Čapek")
+    )
+
+    assert result is not None
+    # Český dotaz → knihovny.cz první; Open Library jen doplní obálku
+    assert calls == ["knihovny", "open_library"]
+    assert result["provider"] == "knihovny_cz"
+    assert result["description"] == "Česká anotace."
+    assert result["cover_image_url"] == "https://covers.openlibrary.org/b/id/1-L.jpg"
+    assert stored  # výsledek se cachuje včetně gap-fillu
+
+
+def test_enrichment_non_czech_falls_back_to_knihovny(monkeypatch) -> None:
+    class FakeRedis:
+        def get(self, _key):
+            return None
+
+        def setex(self, key, ttl, payload):
+            pass
+
+    monkeypatch.setattr(celery_app, "_get_redis_client", lambda: FakeRedis())
+    monkeypatch.setattr(celery_app.worker_settings, "enable_google_books", False)
+
+    calls = []
+
+    async def _open_library_miss(_isbn, title=None, author=None):
+        calls.append("open_library")
+        return None
+
+    async def _knihovny(_isbn, title=None, author=None):
+        calls.append("knihovny")
+        return {
+            "title": "Clean Code",
+            "description": "x",
+            "cover_image_url": "y",
+            "provider": "knihovny_cz",
+        }
+
+    monkeypatch.setattr(celery_app, "_fetch_open_library_metadata", _open_library_miss)
+    monkeypatch.setattr(celery_app, "_fetch_knihovny_metadata", _knihovny)
+
+    result = celery_app.asyncio.run(
+        celery_app._enrich_metadata_with_fallback(None, title="Clean Code", author="Martin")
+    )
+
+    assert result is not None
+    assert calls == ["open_library", "knihovny"]
+    assert result["provider"] == "knihovny_cz"

--- a/worker/tests/test_knihovny_client.py
+++ b/worker/tests/test_knihovny_client.py
@@ -1,0 +1,98 @@
+"""Tests for knihovny_client — Knihovny.cz VuFind API fetcher (mirror of backend tests)."""
+from pathlib import Path
+import sys
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import asyncio
+
+import knihovny_client
+
+
+class TestLooksCzech:
+    def test_diacritics(self):
+        assert knihovny_client.looks_czech("Válka s mloky") is True
+        assert knihovny_client.looks_czech(None, "nastávající maminky") is True
+
+    def test_czech_isbn_groups(self):
+        assert knihovny_client.looks_czech("9788085126396") is True   # 978-80
+        assert knihovny_client.looks_czech("8071360279") is True      # ISBN-10, 80
+
+    def test_non_czech(self):
+        assert knihovny_client.looks_czech("Clean Code", "Robert C. Martin") is False
+        assert knihovny_client.looks_czech("9780132350884") is False
+        assert knihovny_client.looks_czech(None, None) is False
+
+
+def test_fetch_normalizes_response_and_picks_matching_record() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/search"
+        assert request.url.params["type"] == "Title"
+        return httpx.Response(
+            200,
+            json={
+                "resultCount": 2,
+                "status": "OK",
+                "records": [
+                    {
+                        # Audiokniha bez ISBN a jiný autor — nesmí vyhrát
+                        "title": "Válka s mloky",
+                        "authors": {"primary": {"Jiný Autor, 1950-": []}, "secondary": [], "corporate": []},
+                        "isbns": [],
+                        "publishers": ["Radioservis,"],
+                        "publicationDates": ["c2009"],
+                        "languages": [],
+                        "summary": [],
+                    },
+                    {
+                        "title": "Válka s Mloky",
+                        "authors": {"primary": {"Karel Čapek, 1890-1938": []}, "secondary": [], "corporate": []},
+                        "isbns": ["978-80-85126-39-6"],
+                        "publishers": ["Zoologická zahrada hl. m. Prahy,"],
+                        "publicationDates": ["2014"],
+                        "languages": [],
+                        "summary": ["Slavná antiutopická sci-fi z roku 1936."],
+                    },
+                ],
+            },
+        )
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await knihovny_client.fetch_knihovny_metadata(
+                client, None, title="Válka s mloky", author="Karel Čapek"
+            )
+
+    metadata = asyncio.run(_run())
+
+    assert metadata is not None
+    assert metadata["provider"] == "knihovny_cz"
+    assert metadata["title"] == "Válka s Mloky"
+    assert metadata["author"] == "Karel Čapek"
+    assert metadata["isbn"] == "9788085126396"
+    assert metadata["publisher"] == "Zoologická zahrada hl. m. Prahy"
+    assert metadata["publication_year"] == 2014
+    assert metadata["description"] == "Slavná antiutopická sci-fi z roku 1936."
+    assert metadata["cover_image_url"] is None
+
+
+def test_fetch_isbn_search_uses_isn_type_and_handles_miss() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["type"] == "ISN"
+        assert request.url.params["lookfor"] == "9788085126396"
+        return httpx.Response(200, json={"records": [], "status": "OK"})
+
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return await knihovny_client.fetch_knihovny_metadata(client, "9788085126396")
+
+    assert asyncio.run(_run()) is None
+
+
+def test_fetch_without_identifiers_returns_none() -> None:
+    async def _run() -> dict[str, object] | None:
+        async with httpx.AsyncClient() as client:
+            return await knihovny_client.fetch_knihovny_metadata(client, None, title=None)
+
+    assert asyncio.run(_run()) is None


### PR DESCRIPTION
## Problém
Open Library funguje pro anglické tituly, ale pokrytí českých knih je slabé — obohacení českých titulů vracelo prázdná pole (bez ISBN, bez anotace, často bez záznamu).

## Řešení (ADR 012, řeší #311)
Nový provider **Knihovny.cz** — centrální portál knihoven ČR (MZK), veřejné VuFind JSON API, agreguje i fondy NK ČR (přímý X-Server NK ČR má IP allowlist — empiricky ověřeno 403).

- **Pořadí providerů:** heuristika `looks_czech` (česká diakritika v názvu/autorovi, nebo ISBN skupina 978-80/80) → **Knihovny.cz první**, Open Library fallback; jinak obráceně.
- **Výběr záznamu:** preferuje shodu autora + přítomné ISBN a anotaci (VuFind vrací i audioknihy apod.); životní data autora (`Karel Čapek, 1890-1938`) se odstřihují.
- **Gap-fill:** vítězný záznam se doplní o `cover_image_url`/`description` z dalšího provideru v pořadí — Knihovny.cz nevrací volně použitelné obálky (ObalkyKnih má vlastní licenci), Open Library nemá české anotace. Google výsledky se gap-fillu nedotýkají.
- **Kill-switch** `ENABLE_KNIHOVNY_CZ` (default zapnuto), zrcadleno backend + worker dle zavedeného vzoru.

Ověřeno živě proti API: `Válka s mloky` → ISBN 978-80-…, nakladatel, rok, česká anotace; dotaz `nastávající maminky` vrací relevantní české tituly s ISBN.

## Testy
- Backend: 6 nových testů (klient + pořadí providerů + gap-fill + kill-switch) + úpravy stávajících (knihovny.cz vždy zapatchované, ať testy nesahají na síť); mypy strict OK.
- Worker: `test_knihovny_client.py` + 2 chain testy — **nově běží v CI** (PR #331).
- ADR: `docs/adr/012-knihovny-cz-for-czech-metadata.md` — včetně srovnání zdrojů z #311 (ObalkyKnih zůstává jako obchodní follow-up na obálky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Knihovny.cz metadata lookup for Czech titles.
  - Czech-language records are prioritized automatically, with fallback to other metadata sources.
  - Missing descriptions and cover images can be filled from another provider.
  - Added a configuration switch to enable or disable Knihovny.cz lookups.

- **Bug Fixes**
  - Improved metadata matching and normalization for ISBNs, authors, publishers, publication years, and languages.

- **Documentation**
  - Documented provider selection, fallback behavior, enrichment, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->