### PR TITLE
perf(enrich): rychlejší batch obohacení + průběžná zpětná vazba

### DIFF
--- a/frontend/src/hooks/useEnrich.ts
+++ b/frontend/src/hooks/useEnrich.ts
@@ -1,10 +1,21 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
 
 import { useTranslation } from 'react-i18next'
 
 import { enrichAll, enrichBook, enrichByLocation, formatApiError } from '../lib/api'
 import { useToastStore } from '../lib/toast-store'
 import { BOOKS_QUERY_KEY } from './useBooks'
+
+/** Batch enrichment runs in the background (~1 s per book in the worker) —
+ *  refresh the list a few times over the next minutes so results show up
+ *  progressively without a manual reload. */
+function scheduleStaggeredRefetch(queryClient: QueryClient, delaysSeconds: number[]) {
+  for (const delay of delaysSeconds) {
+    setTimeout(() => {
+      void queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
+    }, delay * 1000)
+  }
+}
 
 export function useEnrichBook() {
   const queryClient = useQueryClient()
@@ -17,10 +28,7 @@ export function useEnrichBook() {
       enrichBook(bookId, force),
     onSuccess: async () => {
       showInfo(t('toast.enrich_started', 'Enrichment started. Data will update shortly.'))
-      // Invalidate after a delay to give the worker time to process
-      setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
-      }, 3000)
+      scheduleStaggeredRefetch(queryClient, [3, 8])
     },
     onError: (error: unknown) => {
       showError(formatApiError(error))
@@ -31,14 +39,15 @@ export function useEnrichBook() {
 export function useEnrichByLocation() {
   const queryClient = useQueryClient()
   const showError = useToastStore((s) => s.showError)
+  const showInfo = useToastStore((s) => s.showInfo)
+  const { t } = useTranslation()
 
   return useMutation({
     mutationFn: ({ locationId, force }: { locationId: string; force?: boolean }) =>
       enrichByLocation(locationId, force),
-    onSuccess: async () => {
-      setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
-      }, 5000)
+    onSuccess: async (data) => {
+      showInfo(t('toast.enrich_batch_started', { count: data.book_count }))
+      scheduleStaggeredRefetch(queryClient, [5, 15, 30, 60, 120])
     },
     onError: (error: unknown) => {
       showError(formatApiError(error))
@@ -49,13 +58,14 @@ export function useEnrichByLocation() {
 export function useEnrichAll() {
   const queryClient = useQueryClient()
   const showError = useToastStore((s) => s.showError)
+  const showInfo = useToastStore((s) => s.showInfo)
+  const { t } = useTranslation()
 
   return useMutation({
     mutationFn: ({ force }: { force?: boolean } = {}) => enrichAll(force),
-    onSuccess: async () => {
-      setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: BOOKS_QUERY_KEY })
-      }, 10000)
+    onSuccess: async (data) => {
+      showInfo(t('toast.enrich_batch_started', { count: data.book_count }))
+      scheduleStaggeredRefetch(queryClient, [5, 15, 30, 60, 120, 240])
     },
     onError: (error: unknown) => {
       showError(formatApiError(error))

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -35,7 +35,8 @@
     "borrowers_merged": "Dlužníci sloučeni.",
     "bulk_anonymized_one": "Anonymizován 1 dlužník.",
     "bulk_anonymized_few": "Anonymizováni {{count}} dlužníci.",
-    "bulk_anonymized_other": "Anonymizováno {{count}} dlužníků."
+    "bulk_anonymized_other": "Anonymizováno {{count}} dlužníků.",
+    "enrich_batch_started": "Obohacení {{count}} knih běží na pozadí — potrvá pár minut a projevuje se průběžně."
   },
   "bulk": {
     "selected": "{{count}} vybráno",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -34,7 +34,8 @@
     "borrower_saved": "Borrower saved.",
     "borrowers_merged": "Borrowers merged.",
     "bulk_anonymized_one": "1 borrower anonymized.",
-    "bulk_anonymized_other": "{{count}} borrowers anonymized."
+    "bulk_anonymized_other": "{{count}} borrowers anonymized.",
+    "enrich_batch_started": "Enriching {{count}} books in the background — this takes a few minutes and updates progressively."
   },
   "bulk": {
     "selected": "{{count}} selected",

--- a/worker/settings.py
+++ b/worker/settings.py
@@ -23,11 +23,14 @@ class WorkerSettings(BaseSettings):
     sentry_dsn: str | None = None
     environment: str = "production"
 
-    # Enrichment rate limiting (SaaS-friendly defaults). The per-minute cap
-    # also keeps us far below Open Library's identified 3 req/s limit.
-    enrichment_delay_seconds: float = 1.5         # delay between API calls per book
-    enrichment_max_per_minute: int = 30           # max enrichment API calls per minute
-    enrichment_max_per_day: int = 900             # max enrichment API calls per day
+    # Enrichment rate limiting. Open Library allows 3 req/s with an
+    # identifying User-Agent; one book costs at most ~2 provider calls
+    # (primary + gap-fill), and the loop is sequential, so 0.5 s between
+    # books stays well under that. The old 1.5 s / 30 per-minute defaults
+    # made "enrich all" on a ~100-book library take 5+ silent minutes.
+    enrichment_delay_seconds: float = 0.5         # delay between books
+    enrichment_max_per_minute: int = 100          # max enrichment lookups per minute
+    enrichment_max_per_day: int = 2000            # max enrichment lookups per day
 
     # Shelf-scan verification against Open Library (fuzzy match of scanned
     # title/author; adopts near-identical catalog forms, suggests partial


### PR DESCRIPTION
## Problém
„Obohatit vše" na ~100 knihách trvalo 5+ minut a UI o tom nijak neinformovalo — vypadalo to, že se nic neděje (jediný refetch po 10 s, pak nic). Příčina: konzervativní limity ve workeru (1,5 s pauza mezi knihami + 30 volání/min; po vyčerpání limitu se zbytek dávky přeplánuje o minutu později).

## Řešení
**Worker** — limity srovnané s tím, co Open Library reálně povoluje (3 req/s s identifikujícím User-Agent; jedna kniha = max ~2 volání včetně gap-fillu, smyčka je sekvenční):
- pauza mezi knihami 1,5 s → **0,5 s**
- 30 → **100 volání/min**, 900 → **2000/den**
- ~90 knih tedy nově zabere **~1,5 minuty** místo 5+

**Frontend** — po kliknutí na „Obohatit vše"/„Obohatit polici" se ukáže toast *„Obohacení N knih běží na pozadí — potrvá pár minut a projevuje se průběžně."* a seznam knih se odstupňovaně invaliduje (5 s → 4 min), takže výsledky naskakují průběžně bez ručního reloadu.

## Testy
Frontend: eslint čistý, všech 284 vitest testů prochází. Worker: jen změna konstant v settings (testy limity mockují).

🤖 Generated with [Claude Code](https://claude.com/claude-code)