### PR TITLE
fix(monitoring): Prometheus scrape přes host-gateway místo LAN IP

### DIFF
--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -11,4 +11,9 @@ scrape_configs:
       # Backend runs in k3s since 2026-07-12; scraped via the LAN-only NodePort
       # (infra/k8s/overlays/prod/backend-nodeport.yaml). Interim until the
       # monitoring stack itself moves into the cluster.
-      - targets: ["192.168.88.3:30800"]
+      #
+      # host.docker.internal resolves to the host via the compose
+      # ``extra_hosts: host-gateway`` entry — a hardcoded LAN IP broke here
+      # once already when DHCP handed the box a new address (.3 → .33) and
+      # the scrape silently died with "no route to host".
+      - targets: ["host.docker.internal:30800"]


### PR DESCRIPTION
## Problém
Stroj dostal z DHCP novou IP (`192.168.88.3` → `192.168.88.33`) a Prometheus scrape backendu (k3s NodePort 30800) tiše umřel s *no route to host*. Grafana i Prometheus běžely dál, jen bez čerstvých byznys metrik.

## Řešení
Target v `prometheus.yml` nově `host.docker.internal:30800`. Párová změna v **gitignorovaném** `infra/docker-compose.prod.yml` (`extra_hosts: ["host.docker.internal:host-gateway"]` u služby prometheus) je aplikovaná přímo na serveru — do repa jít nemůže.

Stabilní vůči jakékoli budoucí změně LAN IP. Po merge restartuji prometheus kontejner a ověřím, že target je UP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus monitoring connectivity by resolving the backend through the Docker host instead of a fixed local network address.
  * Monitoring is now more resilient to host IP address changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->