### PR TITLE
feat(analytics): scan funnel eventy + GDPR-safe session replay

### DIFF
--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -46,6 +46,15 @@ export async function initAnalytics(): Promise<void> {
       autocapture: false,
       capture_pageview: true,
       capture_pageleave: true,
+      // Session Replay — GDPR-conservative: enabled only when a key is present
+      // (this whole init is behind `if (!POSTHOG_KEY) return`, so no-op without one).
+      // Mask ALL text and ALL inputs so recordings never carry book titles,
+      // e-mails or any other content — only layout/interaction is captured.
+      disable_session_recording: false,
+      session_recording: {
+        maskAllInputs: true,
+        maskTextSelector: '*',
+      },
     })
     _ph = posthog
   } catch {

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -128,6 +128,12 @@ export function PrivacyPage() {
                 <td style={TD}>Oprávněný zájem (čl. 6/1f)</td>
               </tr>
               <tr>
+                <td style={TD}>Záznam relací</td>
+                <td style={TD}>Anonymizovaný záznam relací (PostHog Session Replay) — veškerý text i vstupy jsou maskované, nezaznamenávají se tak názvy knih, e-maily ani jiný obsah</td>
+                <td style={TD}>Diagnostika chyb a vylepšování použitelnosti</td>
+                <td style={TD}>Oprávněný zájem (čl. 6/1f)</td>
+              </tr>
+              <tr>
                 <td style={TD}>Technické logy</td>
                 <td style={TD}>IP adresa, user-agent, chybové záznamy (Sentry)</td>
                 <td style={TD}>Bezpečnost, diagnostika</td>
@@ -241,6 +247,14 @@ export function PrivacyPage() {
             Totéž platí pro interaktivní ukázku (demo) na úvodní stránce: měříme jen
             agregované, neosobní události (např. počet výsledků hledání nebo počet přidaných knih),
             <strong>nikdy</strong> názvy knih, fotografie ani text vyhledávání.
+          </p>
+          <p style={P}>
+            V rámci PostHog využíváme také <strong>záznam relací (Session Replay)</strong> pro
+            diagnostiku chyb a vylepšování použitelnosti. Záznam je <strong>anonymizovaný</strong>:
+            veškerý text i všechna vstupní pole jsou při nahrávání maskované, takže se
+            <strong> nezaznamenávají</strong> názvy knih, e-maily ani žádný jiný obsah, který
+            zadáte — pouze rozvržení stránky a interakce. I zde je právním základem oprávněný
+            zájem správce (čl. 6/1f GDPR) a proti zpracování můžete vznést námitku.
           </p>
           <p style={P}>
             PostHog pracuje <strong>bez sledovacích cookies</strong>. Pro persistenci analytického

--- a/frontend/src/pages/ScanShelfPage.demo.test.tsx
+++ b/frontend/src/pages/ScanShelfPage.demo.test.tsx
@@ -39,6 +39,7 @@ vi.mock('../lib/toast-store', () => ({
 }))
 
 import * as api from '../lib/api'
+import { trackEvent } from '../lib/analytics'
 import { ScanShelfPage } from './ScanShelfPage'
 import { DemoModeProvider } from '../features/demo/DemoContext'
 import { useDemoStore } from '../store/useDemoStore'
@@ -109,5 +110,21 @@ describe('ScanShelfPage — demo mode (#286)', () => {
     expect(api.scanShelf).not.toHaveBeenCalled()
     expect(api.getShelfScanResult).not.toHaveBeenCalled()
     expect(api.confirmShelfScan).not.toHaveBeenCalled()
+
+    // Real product/funnel events must never fire in the demo — the demo has its
+    // own analytics (demoAnalytics.ts). Guards the `if (isDemo)` branches.
+    const FUNNEL_EVENTS = [
+      'scan_opened',
+      'scan_photo_selected',
+      'scan_job_done',
+      'scan_job_failed',
+      'scan_review_reached',
+      'scan_abandoned',
+      'shelf_scanned',
+    ]
+    const firedFunnelEvents = vi.mocked(trackEvent).mock.calls
+      .map(([event]) => event)
+      .filter((event) => FUNNEL_EVENTS.includes(event))
+    expect(firedFunnelEvents).toEqual([])
   }, 20000) // multi-step wizard + simulated scan delay; generous for slow CI
 })

--- a/frontend/src/pages/ScanShelfPage.test.tsx
+++ b/frontend/src/pages/ScanShelfPage.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ScanShelfPage } from './ScanShelfPage'
+import { trackEvent } from '../lib/analytics'
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -108,6 +109,46 @@ function setReviewDraft(books: ReturnType<typeof makeReviewBook>[]) {
 
 async function restoreDraft() {
   await userEvent.click(screen.getByText('scan.restore_draft'))
+}
+
+// A draft parked on the `scan` step with one completed segment, so restoring it
+// lands on the scan step with the "go to review" button already available.
+function setScanDraftWithDoneSegment() {
+  const draft = {
+    version: 1,
+    step: 'scan',
+    selRoom: 'Living Room',
+    selFurniture: 'Bookshelf',
+    selShelf: 'Shelf 1',
+    newRoom: '',
+    newFurniture: '',
+    newShelf: '',
+    showNewLocation: false,
+    segments: [
+      {
+        jobId: 'job-1',
+        photoIndex: 0,
+        status: 'done',
+        books: [
+          {
+            title: 'Alpha',
+            author: null,
+            isbn: null,
+            observed_text: 'Alpha',
+            confidence: 'high',
+            suggested_title: null,
+            suggested_author: null,
+          },
+        ],
+      },
+    ],
+    editableBooks: [],
+    locationId: 'loc-1',
+    scanMode: 'replace',
+    appendAfterBookId: null,
+    savedAt: new Date().toISOString(),
+  }
+  localStorage.setItem(SCAN_DRAFT_KEY, JSON.stringify(draft))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -334,5 +375,57 @@ describe('ScanShelfPage – review step', () => {
       { position: 2, title: 'Inserted', author: null, isbn: null },
       { position: 3, title: 'Gamma', author: null, isbn: null },
     ])
+  })
+})
+
+// ── Funnel analytics (BOD 1 + BOD 3) ────────────────────────────────────────
+describe('ScanShelfPage – funnel analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it('fires scan_opened once on mount', () => {
+    renderWithProviders(<ScanShelfPage />)
+    const opened = vi.mocked(trackEvent).mock.calls.filter(([e]) => e === 'scan_opened')
+    expect(opened).toHaveLength(1)
+  })
+
+  it('fires scan_review_reached once when advancing to review, not on repeat visits', async () => {
+    setScanDraftWithDoneSegment()
+    renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+
+    await userEvent.click(screen.getByRole('button', { name: 'scan.go_to_review' }))
+    expect(vi.mocked(trackEvent).mock.calls.filter(([e]) => e === 'scan_review_reached')).toHaveLength(1)
+
+    // Go back to scan and return to review — must not fire again.
+    await userEvent.click(screen.getByRole('button', { name: /scan\.back_to_scan/ }))
+    await userEvent.click(screen.getByRole('button', { name: 'scan.go_to_review' }))
+    expect(vi.mocked(trackEvent).mock.calls.filter(([e]) => e === 'scan_review_reached')).toHaveLength(1)
+  })
+
+  it('fires scan_abandoned on unmount when review was reached but nothing was saved', async () => {
+    setScanDraftWithDoneSegment()
+    const { unmount } = renderWithProviders(<ScanShelfPage />)
+    await restoreDraft()
+    await userEvent.click(screen.getByRole('button', { name: 'scan.go_to_review' }))
+
+    vi.mocked(trackEvent).mockClear()
+    unmount()
+
+    expect(vi.mocked(trackEvent).mock.calls.filter(([e]) => e === 'scan_abandoned')).toHaveLength(1)
+  })
+
+  it('does not fire scan_abandoned on unmount when review was never reached', () => {
+    const { unmount } = renderWithProviders(<ScanShelfPage />)
+    vi.mocked(trackEvent).mockClear()
+    unmount()
+    expect(vi.mocked(trackEvent).mock.calls.filter(([e]) => e === 'scan_abandoned')).toHaveLength(0)
   })
 })

--- a/frontend/src/pages/ScanShelfPage.tsx
+++ b/frontend/src/pages/ScanShelfPage.tsx
@@ -102,6 +102,34 @@ export function ScanShelfPage() {
   // Demo-only: a brief simulated "scanning" state while the canned result lands.
   const [demoScanning, setDemoScanning] = useState(false)
 
+  // ── Funnel analytics (non-demo only) ──────────────────────────────────────
+  // Refs, not state: they must not trigger re-renders and must hold the latest
+  // value inside the unmount cleanup below.
+  const isDemoRef = useRef(isDemo)
+  isDemoRef.current = isDemo
+  // `scan_review_reached` and `scan_abandoned` are fired at most once per scan.
+  const reviewReachedRef = useRef(false)
+  // Set on a successful save so unmount doesn't misreport it as abandonment.
+  const scanSavedRef = useRef(false)
+
+  // BOD 1: explicit funnel entry — one `scan_opened` per mount, non-demo only.
+  // Lets PostHog build `scan_opened → … → shelf_scanned` without relying on the
+  // fragile `$pageview` path=/scan match.
+  useEffect(() => {
+    if (isDemo) return
+    trackEvent('scan_opened')
+  }, [isDemo])
+
+  // BOD 3: `scan_abandoned` — user reached review but left without saving.
+  // Runs on unmount / route change; refs keep it from firing after a save.
+  useEffect(() => {
+    return () => {
+      if (!isDemoRef.current && reviewReachedRef.current && !scanSavedRef.current) {
+        trackEvent('scan_abandoned')
+      }
+    }
+  }, [])
+
   const { data: booksAtLocation = [] } = useBooksByLocation(locationId)
   const existingShelfBooks = [...booksAtLocation].sort((a, b) => (a.shelf_position ?? 99999) - (b.shelf_position ?? 99999))
 
@@ -117,6 +145,8 @@ export function ScanShelfPage() {
           : seg
       ))
       setActiveJobId(null)
+      // BOD 3: scan job produced a result. Count only — never titles/authors.
+      if (!isDemo) trackEvent('scan_job_done', { book_count: data.books.length })
     } else if (data.status === 'failed') {
       showError(data.error_message ?? t('scan.error_failed'))
       setSegments(prev => prev.map(seg =>
@@ -125,12 +155,17 @@ export function ScanShelfPage() {
           : seg
       ))
       setActiveJobId(null)
+      // BOD 3: scan job failed. `reason` is the server-side error message when
+      // present (no user content), omitted otherwise.
+      if (!isDemo) {
+        trackEvent('scan_job_failed', data.error_message ? { reason: data.error_message } : undefined)
+      }
     }
     // Full dependency list is safe here: the polling query refreshes
     // `activeResult.data` every ~2s, but the guard above makes non-terminal
     // re-runs a no-op, and `setActiveJobId(null)` after a terminal status
     // short-circuits the follow-up run.
-  }, [activeResult.data, activeJobId, showError, t])
+  }, [activeResult.data, activeJobId, showError, t, isDemo])
 
 
   useEffect(() => {
@@ -265,6 +300,8 @@ export function ScanShelfPage() {
     e.target.value = ''
 
     const photoIndex = segments.length
+    // BOD 3: user picked a photo to scan. Only the index — no file data.
+    if (!isDemo) trackEvent('scan_photo_selected', { photo_index: photoIndex })
     scanMutation.mutate(
       { file, locationId: locationId ?? undefined },
       {
@@ -340,7 +377,13 @@ export function ScanShelfPage() {
     }
     setEditableBooks(allBooks)
     setStep('review')
-  }, [segments])
+    // BOD 3: reached the review step. Fire once per scan (guarded by the ref),
+    // so going back to the scan step and returning doesn't double-count.
+    if (!isDemo && !reviewReachedRef.current) {
+      reviewReachedRef.current = true
+      trackEvent('scan_review_reached')
+    }
+  }, [segments, isDemo])
 
   function removeSegment(index: number) {
     setSegments(prev => prev.filter((_, i) => i !== index))
@@ -466,6 +509,9 @@ export function ScanShelfPage() {
             useDemoActivity.getState().recordScan()
             trackDemoScanComplete(validBooks.length)
           } else {
+            // Mark saved BEFORE navigating so the unmount cleanup doesn't
+            // misreport this successful scan as `scan_abandoned`.
+            scanSavedRef.current = true
             trackEvent('shelf_scanned', { book_count: validBooks.length })
           }
           clearDraft()


### PR DESCRIPTION
## Proč

Dnes se posílá jen `shelf_scanned` až při úspěšném uložení, takže drop-off **uvnitř** scanu nevidíme. Tenhle PR přidává explicitní vstup do funnelu a stage eventy, takže v PostHogu půjde postavit čistý funnel a vidět, kde přesně lidi odpadají — nezávisle na fragilním `$pageview` path matchingu.

## Co se mění (3 body v jednom PR)

### BOD 1 — spolehlivý vstup do funnelu
- `scan_opened` — jednou při mountu `ScanShelfPage` (jen non-demo). Umožní funnel `scan_opened → … → shelf_scanned` bez závislosti na URL matchingu.

### BOD 2 — Session Replay (GDPR-safe)
- V `frontend/src/lib/analytics.ts` v `posthog.init(...)`:
  - `disable_session_recording: false`
  - `session_recording: { maskAllInputs: true, maskTextSelector: '*' }` — **veškerý text i vstupy maskované** (žádné názvy knih ani e-maily v nahrávkách).
- Zůstává **no-op bez `VITE_POSTHOG_KEY`** (celý init je za tou podmínkou).
- `person_profiles`, `persistence`, cookies **beze změny**.
- `PrivacyPage.tsx`: nový řádek v tabulce zpracování (sekce 2) + odstavec v sekci 7 (PostHog) o anonymizovaném záznamu relací. PrivacyPage nepoužívá i18n klíče (hardcoded CZ), takže do `cs.json`/`en.json` nic nepřibylo.

### BOD 3 — stage eventy pro drop-off (jen non-demo, žádné PII)
| Event | Kdy | Props |
|---|---|---|
| `scan_photo_selected` | výběr fotky v `handleFileSelect` | `{ photo_index }` |
| `scan_job_failed` | segment → `failed` | `{ reason }` pokud k dispozici |
| `scan_job_done` | segment → `done` | `{ book_count }` |
| `scan_review_reached` | přechod do review | — (1× za scan, ref guard) |
| `scan_abandoned` | review dosaženo, odchod bez uložení (unmount) | — (ref flag, nefalšuje po save) |
| `shelf_scanned` | **beze změny** | `{ book_count }` |

Reálné eventy jdou jen pro non-demo (drží existující vzor `if (isDemo) { …demoAnalytics } else { trackEvent(…) }`). Do `demoAnalytics.ts` se nesáhlo.

## Výsledný funnel
`scan_opened → scan_photo_selected → scan_job_done → scan_review_reached → shelf_scanned`

## Testy
- `ScanShelfPage.test.tsx`: `scan_opened` 1×/mount; `scan_review_reached` 1× i při návratu scan→review→scan→review; `scan_abandoned` na unmount po review bez save, a že se **nevolá**, když review nebylo dosaženo.
- `ScanShelfPage.demo.test.tsx`: žádný z funnel eventů se v demo režimu nevolá.

## Ověření
- `npm run lint` — 0/0 ✅
- `npm test -- --run` — 288 passed ✅
- `npm run build` — OK ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added anonymized Session Replay to help diagnose errors and improve usability. Text and input fields are masked.
  * Added analytics for key scan workflow milestones, including scan start, photo selection, completion, review, saving, and abandonment.
  * Scan failures may now include diagnostic details for improved troubleshooting.

* **Privacy**
  * Updated the privacy policy with details about Session Replay, data masking, usage, legal basis, and objection rights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->