### PR TITLE
feat(privacy): opt-in souhlas pro analytiku + Session Replay (cookie lišta)

### DIFF
--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -23,9 +23,27 @@ export function getE2EAccessToken(page: Page): string | null {
  *   that would wipe out the saved return-path and land the app on /books instead
  *   of the original destination.
  */
+/**
+ * Keep the analytics consent banner out of e2e. It renders app-wide and its
+ * "Privacy Policy" link would otherwise collide with page-level locators.
+ * Tests run with analytics declined — deterministic, no tracking during CI.
+ * Must be called before the page first navigates (addInitScript runs on load).
+ */
+export async function suppressConsentBanner(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('shelfy_analytics_consent', 'denied')
+    } catch {
+      /* storage disabled — banner may show, harmless */
+    }
+  })
+}
+
 export async function login(page: Page, alreadyOnLoginPage = false): Promise<void> {
   const email = process.env.E2E_ADMIN_EMAIL ?? 'admin@example.com'
   const password = process.env.E2E_ADMIN_PASSWORD ?? 'change-me'
+
+  await suppressConsentBanner(page)
 
   if (!alreadyOnLoginPage) {
     await page.goto('/login')
@@ -108,6 +126,7 @@ export async function createManualBook(page: Page, title: string, author = 'E2E 
 
 export async function navigateProtected(page: Page, path: string): Promise<void> {
   const escapedPath = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  await suppressConsentBanner(page)
   await page.goto(path)
   // Wait for networkidle so React's async auth bootstrap (POST /auth/refresh) can
   // complete and potentially redirect to /login before we inspect the URL.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { MergeUndoToast } from './components/MergeUndoToast'
 import { Toast } from './components/Toast'
 import { Navigation } from './components/Navigation'
 import { UpgradePrompt } from './components/UpgradePrompt'
+import { ConsentBanner } from './components/ConsentBanner'
 import { useToastStore } from './lib/toast-store'
 import { useAuth } from './contexts/AuthContext'
 
@@ -181,6 +182,7 @@ function AppShell() {
       )}
       <Toast />
       <MergeUndoToast />
+      <ConsentBanner />
     </div>
   )
 }

--- a/frontend/src/components/ConsentBanner.test.tsx
+++ b/frontend/src/components/ConsentBanner.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/analytics', () => ({ initAnalytics: vi.fn() }))
+
+import { initAnalytics } from '../lib/analytics'
+import { ConsentBanner } from './ConsentBanner'
+
+const KEY = 'shelfy_analytics_consent'
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('ConsentBanner', () => {
+  it('shows when the user has not decided yet', () => {
+    render(<ConsentBanner />)
+    expect(screen.getByRole('dialog', { name: 'consent.aria_label' })).toBeInTheDocument()
+  })
+
+  it('does not show once a choice is already stored', () => {
+    localStorage.setItem(KEY, 'granted')
+    render(<ConsentBanner />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('accept stores consent, starts analytics, and hides the banner', async () => {
+    render(<ConsentBanner />)
+    await userEvent.click(screen.getByRole('button', { name: 'consent.accept' }))
+
+    expect(localStorage.getItem(KEY)).toBe('granted')
+    expect(initAnalytics).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('decline stores denial, never starts analytics, and hides the banner', async () => {
+    render(<ConsentBanner />)
+    await userEvent.click(screen.getByRole('button', { name: 'consent.decline' }))
+
+    expect(localStorage.getItem(KEY)).toBe('denied')
+    expect(initAnalytics).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})

--- a/frontend/src/components/ConsentBanner.tsx
+++ b/frontend/src/components/ConsentBanner.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { ROUTES } from '../lib/routes'
+import { getConsent, setConsent } from '../lib/consent'
+import { initAnalytics } from '../lib/analytics'
+
+/**
+ * Cookie/analytics consent banner.
+ *
+ * Shown once, until the user makes a choice. Non-essential analytics
+ * (PostHog + Session Replay) stay off until "accept" is pressed. Per EDPB
+ * guidance, declining is exactly as easy as accepting (two equal buttons).
+ */
+export function ConsentBanner() {
+  const { t } = useTranslation()
+  const [visible, setVisible] = useState(() => getConsent() === null)
+
+  if (!visible) return null
+
+  function accept() {
+    setConsent('granted')
+    void initAnalytics()
+    setVisible(false)
+  }
+
+  function decline() {
+    setConsent('denied')
+    setVisible(false)
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label={t('consent.aria_label')}
+      style={{
+        position: 'fixed',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 10001,
+        background: 'var(--sh-surface)',
+        borderTop: '1px solid var(--sh-border)',
+        boxShadow: '0 -4px 20px rgba(0,0,0,0.08)',
+        padding: '16px 20px',
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+      }}
+    >
+      <p
+        style={{
+          margin: 0,
+          flex: '1 1 320px',
+          maxWidth: 640,
+          fontSize: 13,
+          lineHeight: 1.5,
+          color: 'var(--sh-text-main)',
+        }}
+      >
+        {t('consent.message')}{' '}
+        <a href={ROUTES.privacy} style={{ color: 'var(--sh-primary)' }}>
+          {t('consent.learn_more')}
+        </a>
+      </p>
+      <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+        <button type="button" className="sh-btn-secondary" style={{ fontSize: 13 }} onClick={decline}>
+          {t('consent.decline')}
+        </button>
+        <button type="button" className="sh-btn-primary" style={{ fontSize: 13 }} onClick={accept}>
+          {t('consent.accept')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -254,6 +254,19 @@
     "privacy_link": "Zásady ochrany soukromí",
     "terms_link": "Podmínky použití"
   },
+  "consent": {
+    "aria_label": "Souhlas s analytikou",
+    "message": "Shelfy používá produktovou analytiku (PostHog vč. anonymizovaného, maskovaného záznamu relací), aby se dala vylepšovat. Nezbytné funkce pro provoz běží vždy.",
+    "learn_more": "Více v Zásadách soukromí",
+    "accept": "Přijmout",
+    "decline": "Odmítnout",
+    "settings_title": "Analytika a soukromí",
+    "settings_description": "Souhlas s produktovou analytikou (PostHog vč. anonymizovaného záznamu relací). Můžeš ho kdykoliv změnit.",
+    "status_granted": "Zapnuto",
+    "status_denied": "Vypnuto",
+    "enable": "Zapnout",
+    "disable": "Vypnout"
+  },
   "app": {
     "update_available": "Je dostupná nová verze Shelfy — klikni pro aktualizaci.",
     "offline_ready": "Shelfy je připravené i offline.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -253,6 +253,19 @@
     "privacy_link": "Privacy Policy",
     "terms_link": "Terms of Service"
   },
+  "consent": {
+    "aria_label": "Analytics consent",
+    "message": "Shelfy uses product analytics (PostHog, incl. anonymized, masked session replay) to improve the app. Essential features always run.",
+    "learn_more": "More in the Privacy Policy",
+    "accept": "Accept",
+    "decline": "Decline",
+    "settings_title": "Analytics & privacy",
+    "settings_description": "Consent to product analytics (PostHog, incl. anonymized session replay). You can change it anytime.",
+    "status_granted": "Enabled",
+    "status_denied": "Disabled",
+    "enable": "Enable",
+    "disable": "Disable"
+  },
   "app": {
     "update_available": "A new version of Shelfy is available — click to update.",
     "offline_ready": "Shelfy is ready offline.",

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -20,18 +20,27 @@
 
 import type { PostHog } from 'posthog-js'
 
+import { hasAnalyticsConsent } from './consent'
+
 const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY as string | undefined
 const POSTHOG_HOST = (import.meta.env.VITE_POSTHOG_HOST as string | undefined) ?? 'https://eu.posthog.com'
 
 // Holds the PostHog instance after initAnalytics() resolves.
 let _ph: PostHog | undefined
+// Guards against double-init (called both on load and when consent is granted).
+let _initStarted = false
 
 /**
- * Initialize PostHog. Called once from main.tsx.
- * Safe to call when VITE_POSTHOG_KEY is absent — becomes a no-op.
+ * Initialize PostHog — only when a key is configured AND the user has opted in
+ * to analytics (see `consent.ts`). Called on load from main.tsx (no-op until
+ * consent) and again from the consent banner / settings when consent is granted.
+ * Safe and idempotent: no-op without a key, without consent, or if already started.
  */
 export async function initAnalytics(): Promise<void> {
   if (!POSTHOG_KEY) return
+  if (!hasAnalyticsConsent()) return
+  if (_initStarted) return
+  _initStarted = true
 
   try {
     const { default: posthog } = await import('posthog-js')
@@ -40,14 +49,16 @@ export async function initAnalytics(): Promise<void> {
       // Only create profiles for identified users — avoids anonymous event spam
       // and reduces PII stored for GDPR compliance.
       person_profiles: 'identified_only',
-      // localStorage instead of cookies — GDPR-friendly, no consent banner needed.
+      // localStorage instead of cookies. This still counts as non-essential
+      // device storage under ePrivacy, so it runs only after opt-in consent
+      // (gated above via hasAnalyticsConsent()).
       persistence: 'localStorage',
       // Disable auto-capture of clicks/forms — we track only explicit events.
       autocapture: false,
       capture_pageview: true,
       capture_pageleave: true,
-      // Session Replay — GDPR-conservative: enabled only when a key is present
-      // (this whole init is behind `if (!POSTHOG_KEY) return`, so no-op without one).
+      // Session Replay — runs only after opt-in consent (init is gated on
+      // hasAnalyticsConsent() above, so it never records without consent).
       // Mask ALL text and ALL inputs so recordings never carry book titles,
       // e-mails or any other content — only layout/interaction is captured.
       disable_session_recording: false,
@@ -59,6 +70,21 @@ export async function initAnalytics(): Promise<void> {
     _ph = posthog
   } catch {
     // Gracefully ignore load failures (network block, ad-blocker, etc.)
+    _initStarted = false
+  }
+}
+
+/**
+ * Stop analytics after a consent withdrawal. Halts capturing + session
+ * recording for the rest of this page session; the denied choice in
+ * `consent.ts` keeps it off on subsequent loads.
+ */
+export function disableAnalytics(): void {
+  try {
+    _ph?.stopSessionRecording?.()
+    _ph?.opt_out_capturing?.()
+  } catch {
+    // No-op if PostHog never initialized.
   }
 }
 

--- a/frontend/src/lib/consent.test.ts
+++ b/frontend/src/lib/consent.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { getConsent, hasAnalyticsConsent, onConsentChange, setConsent } from './consent'
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+describe('consent', () => {
+  it('returns null when nothing is stored', () => {
+    expect(getConsent()).toBeNull()
+    expect(hasAnalyticsConsent()).toBe(false)
+  })
+
+  it('persists and reads a granted choice', () => {
+    setConsent('granted')
+    expect(getConsent()).toBe('granted')
+    expect(hasAnalyticsConsent()).toBe(true)
+  })
+
+  it('treats denied as no analytics consent', () => {
+    setConsent('denied')
+    expect(getConsent()).toBe('denied')
+    expect(hasAnalyticsConsent()).toBe(false)
+  })
+
+  it('notifies subscribers on change', () => {
+    let seen: string | null = null
+    const off = onConsentChange((s) => { seen = s })
+    setConsent('granted')
+    expect(seen).toBe('granted')
+    off()
+    setConsent('denied')
+    expect(seen).toBe('granted') // unsubscribed — no further updates
+  })
+})

--- a/frontend/src/lib/consent.ts
+++ b/frontend/src/lib/consent.ts
@@ -1,0 +1,51 @@
+/**
+ * Analytics consent — single source of truth for whether the user has opted
+ * in to non-essential product analytics (PostHog + Session Replay).
+ *
+ * Under ePrivacy (CZ §89 zák. 127/2005 Sb.) storing/accessing non-essential
+ * data on the user's device — including localStorage, not just cookies —
+ * requires opt-in consent. Strictly-necessary storage (auth/session, CSRF)
+ * does NOT, and is never gated by this module.
+ *
+ * State is persisted in localStorage:
+ *   'granted' — user opted in; analytics may run.
+ *   'denied'  — user opted out; analytics must stay off.
+ *   null      — no choice yet; show the consent banner, analytics stays off.
+ */
+
+export type ConsentState = 'granted' | 'denied'
+
+const STORAGE_KEY = 'shelfy_analytics_consent'
+const CHANGE_EVENT = 'shelfy:consent-change'
+
+/** Current stored choice, or null when the user hasn't decided yet. */
+export function getConsent(): ConsentState | null {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY)
+    return value === 'granted' || value === 'denied' ? value : null
+  } catch {
+    return null
+  }
+}
+
+/** Persist a choice and notify listeners (banner ↔ settings stay in sync). */
+export function setConsent(state: ConsentState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, state)
+  } catch {
+    // Private-mode / storage-disabled — treat as ephemeral; still notify.
+  }
+  window.dispatchEvent(new CustomEvent<ConsentState>(CHANGE_EVENT, { detail: state }))
+}
+
+/** True only when the user has explicitly opted in. */
+export function hasAnalyticsConsent(): boolean {
+  return getConsent() === 'granted'
+}
+
+/** Subscribe to consent changes. Returns an unsubscribe function. */
+export function onConsentChange(listener: (state: ConsentState) => void): () => void {
+  const handler = (e: Event) => listener((e as CustomEvent<ConsentState>).detail)
+  window.addEventListener(CHANGE_EVENT, handler)
+  return () => window.removeEventListener(CHANGE_EVENT, handler)
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -23,7 +23,10 @@ if (_sentryDsn) {
         Sentry.replayIntegration({ maskAllText: true, blockAllMedia: true }),
       ],
       tracesSampleRate: 0.1,
-      replaysSessionSampleRate: 0.05,
+      // No proactive session recording — that's non-essential and would need
+      // consent (see consent.ts). Keep only crash-triggered replay, which is
+      // tied to error debugging (legitimate interest).
+      replaysSessionSampleRate: 0,
       replaysOnErrorSampleRate: 1.0,
     })
   })

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -53,7 +53,7 @@ export function PrivacyPage() {
             <li>Ukládáme jen to, co potřebujeme k provozu služby (e-mail, heslo, vaše knihy).</li>
             <li>Neprodáváme a nesdílíme vaše data s třetími stranami za účelem reklamy.</li>
             <li>Svá data si můžete kdykoliv stáhnout (JSON export) nebo smazat celý účet — obojí v Nastavení.</li>
-            <li>Nepoužíváme sledovací cookies. Analytika (PostHog) běží bez cookies.</li>
+            <li>Produktová analytika (PostHog) běží jen s vaším souhlasem — ten můžete kdykoliv odvolat v Nastavení. Nezbytné funkce (přihlášení) fungují vždy.</li>
             <li>Data jsou uložena na serveru v Česku, za Cloudflare ochranou.</li>
           </ul>
         </div>
@@ -253,14 +253,16 @@ export function PrivacyPage() {
             diagnostiku chyb a vylepšování použitelnosti. Záznam je <strong>anonymizovaný</strong>:
             veškerý text i všechna vstupní pole jsou při nahrávání maskované, takže se
             <strong> nezaznamenávají</strong> názvy knih, e-maily ani žádný jiný obsah, který
-            zadáte — pouze rozvržení stránky a interakce. I zde je právním základem oprávněný
-            zájem správce (čl. 6/1f GDPR) a proti zpracování můžete vznést námitku.
+            zadáte — pouze rozvržení stránky a interakce.
           </p>
           <p style={P}>
-            PostHog pracuje <strong>bez sledovacích cookies</strong>. Pro persistenci analytického
-            identifikátoru je využíván localStorage prohlížeče. Právním základem je oprávněný
-            zájem správce na vylepšování služby (čl. 6/1f GDPR). Proti tomuto zpracování
-            můžete vznést námitku na výše uvedeném kontaktním e-mailu.
+            Veškerá tato analytika (včetně záznamu relací) běží <strong>pouze s vaším
+            souhlasem</strong>, o který vás žádáme při první návštěvě. Do udělení souhlasu se
+            nespouští a neukládá nic do vašeho zařízení. Právním základem je tedy váš
+            <strong> souhlas</strong> (čl. 6/1a GDPR) a můžete jej kdykoliv
+            <strong> odvolat v Nastavení</strong> — od té chvíle se analytika zastaví.
+            PostHog pracuje bez cookies; pro persistenci analytického identifikátoru využívá
+            localStorage prohlížeče, který se zapíše až po vašem souhlasu.
           </p>
         </div>
 

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -125,13 +125,13 @@ export function PrivacyPage() {
                 <td style={TD}>Analytická data</td>
                 <td style={TD}>Anonymizované události používání (PostHog)</td>
                 <td style={TD}>Vylepšování služby</td>
-                <td style={TD}>Oprávněný zájem (čl. 6/1f)</td>
+                <td style={TD}>Souhlas (čl. 6/1a)</td>
               </tr>
               <tr>
                 <td style={TD}>Záznam relací</td>
                 <td style={TD}>Anonymizovaný záznam relací (PostHog Session Replay) — veškerý text i vstupy jsou maskované, nezaznamenávají se tak názvy knih, e-maily ani jiný obsah</td>
                 <td style={TD}>Diagnostika chyb a vylepšování použitelnosti</td>
-                <td style={TD}>Oprávněný zájem (čl. 6/1f)</td>
+                <td style={TD}>Souhlas (čl. 6/1a)</td>
               </tr>
               <tr>
                 <td style={TD}>Technické logy</td>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -13,7 +13,8 @@ import { useAddMember, useCreateLibrary, useLibraries, useLibraryMembers, useRem
 import { useToggleWishlist } from '../hooks/useWishlist'
 import { useResetOnboarding } from '../hooks/useOnboarding'
 import { useToastStore } from '../lib/toast-store'
-import { trackEvent } from '../lib/analytics'
+import { disableAnalytics, initAnalytics, trackEvent } from '../lib/analytics'
+import { getConsent, setConsent } from '../lib/consent'
 import type { LibraryRole } from '../lib/types'
 import { ROUTES } from '../lib/routes'
 import { useAuth } from '../contexts/AuthContext'
@@ -636,6 +637,19 @@ export function SettingsPage() {
   const [exportingData, setExportingData] = useState(false)
   const [exportingCsv, setExportingCsv] = useState(false)
   const [showImportModal, setShowImportModal] = useState(false)
+  const [analyticsConsent, setAnalyticsConsent] = useState(() => getConsent() === 'granted')
+
+  function toggleAnalyticsConsent() {
+    if (analyticsConsent) {
+      setConsent('denied')
+      disableAnalytics()
+      setAnalyticsConsent(false)
+    } else {
+      setConsent('granted')
+      void initAnalytics()
+      setAnalyticsConsent(true)
+    }
+  }
 
   const isOAuthOnly = user?.has_local_password === false
 
@@ -861,6 +875,27 @@ export function SettingsPage() {
               }}
             >
               {t('onboarding.settings_reset')}
+            </button>
+          </div>
+        </div>
+
+        <div className='stg-row'>
+          <div className='stg-row-label'>
+            <p className='stg-row-title'>{t('consent.settings_title')}</p>
+            <p className='stg-row-desc'>{t('consent.settings_description')}</p>
+          </div>
+          <div className='stg-row-control' style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <span className='stg-row-desc' style={{ margin: 0 }}>
+              {analyticsConsent ? t('consent.status_granted') : t('consent.status_denied')}
+            </span>
+            <button
+              type='button'
+              className='sh-btn-secondary'
+              style={{ fontSize: 13 }}
+              onClick={toggleAnalyticsConsent}
+              data-testid='toggle-analytics-consent'
+            >
+              {analyticsConsent ? t('consent.disable') : t('consent.enable')}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Proč

Analytika (PostHog vč. **Session Replay**) se dosud spouštěla hned při načtení
na základě oprávněného zájmu, bez souhlasu. Jenže dle ePrivacy (CZ §89 zák.
127/2005 Sb.) **localStorage spadá pod nezbytné-není device storage stejně jako
cookies** → pro produktovou analytiku je potřeba **opt-in souhlas**. Se zapnutým
Session Replay to platí dvojnásob. Tenhle PR to řeší „jak to má být správně".

## Co se mění

- **`lib/consent.ts`** (nový) — jediný zdroj pravdy o souhlasu (localStorage
  `shelfy_analytics_consent`, `granted|denied|null`), event pro synchronizaci.
- **`components/ConsentBanner.tsx`** (nový) — lišta při první návštěvě.
  „Odmítnout" je **stejně snadné jako „Přijmout"** (dvě rovnocenná tlačítka, per
  EDPB). Do souhlasu se do zařízení nic neukládá.
- **`lib/analytics.ts`** — `initAnalytics()` je nově gated za
  `hasAnalyticsConsent()` (no-op bez klíče i bez souhlasu, idempotentní);
  přidán `disableAnalytics()` pro odvolání (stop capturing + session recording).
- **`SettingsPage`** — v sekci *O aplikaci* nový přepínač **„Analytika a
  soukromí"** (zapnout/vypnout kdykoliv).
- **`PrivacyPage`** — právní základ analytiky sladěn z oprávněného zájmu
  (6/1f) na **souhlas (6/1a)** + „odvolat v Nastavení"; upraveno i shrnutí.
- **`main.tsx`** — Sentry **proaktivní** session replay vypnut
  (`replaysSessionSampleRate: 0`); zůstává jen **on-error** replay (vázaný na
  ladění chyb) + error monitoring. Konzistentní s consent modelem.
- i18n `cs`/`en` (`consent.*`).

## Chování

| Stav | Analytika/replay |
|---|---|
| Před rozhodnutím (`null`) | vypnuto, lišta se zobrazí |
| Přijmout | zapne se + init |
| Odmítnout | vypnuto, na dalších návštěvách zůstává vypnuto |
| Nastavení → vypnout | okamžitě zastaví + zůstane vypnuto |

Nezbytné funkce (přihlášení/CSRF cookies) nejsou nikdy gated.

## Test

- `npm run lint` → 0/0
- `npx vitest run` → **296 passed** (nové: `consent.test.ts`, `ConsentBanner.test.tsx`)
- tsc: žádná nová chyba v dotčených souborech (předchozí chyby v
  BookshelfViewPage/LocationsPage/ScanShelfPage jsou mimo tento PR a CI build
  je tsc nekontroluje).

## Pozn. pro reviewera

Pro **uzavřenou betu 5–10 lidí** by stačilo disclosure v pozvánce, ale tohle je
plnohodnotné consent UI použitelné i pro veřejné spuštění. Session Replay je
tím pádem legální i po veřejném launchi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an analytics consent banner with accept and decline options.
  - Added analytics consent controls to Settings, allowing users to enable or disable analytics.
  - Analytics and session replay now activate only after consent.
  - Updated privacy information and translations to explain consent-based analytics.

- **Bug Fixes**
  - Prevented analytics consent prompts from interrupting automated browser tests.

- **Tests**
  - Added coverage for consent storage, banner behavior, analytics controls, and consent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->