### PR TITLE
feat(settings): feedback link (support@shelfy.cz) v Nastavení + levém panelu

### DIFF
--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { ROUTES } from '../lib/routes'
+import { SUPPORT_CONTACT_EMAIL } from '../lib/legal'
 import { useAuth } from '../contexts/AuthContext'
 import { useLibraries } from '../hooks/useLibrary'
 import { useLibraryStore } from '../store/useLibraryStore'
@@ -370,6 +371,18 @@ export function Navigation() {
               <IconLogout size={20} />
               <span>{t('nav.logout', 'Logout')}</span>
             </button>
+            <a
+              href={`mailto:${SUPPORT_CONTACT_EMAIL}?subject=${encodeURIComponent('Shelfy — zpětná vazba')}`}
+              data-testid="nav-feedback"
+              style={{
+                padding: '6px 16px',
+                fontSize: 12,
+                color: 'var(--sh-text-muted)',
+                textDecoration: 'none',
+              }}
+            >
+              {t('nav.feedback')}
+            </a>
           </>
         )}
       </nav>

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -16,7 +16,8 @@
     "actions": "Akce",
     "logout": "Odhlásit",
     "wishlist": "Wishlist",
-    "go_home": "Shelfy — přejít na knihy"
+    "go_home": "Shelfy — přejít na knihy",
+    "feedback": "Zpětná vazba"
   },
   "toast": {
     "book_saved": "Změny uloženy.",
@@ -213,6 +214,9 @@
     "preferences_title": "Předvolby",
     "data_title": "Data a export",
     "about_title": "O aplikaci",
+    "feedback_title": "Zpětná vazba",
+    "feedback_description": "Narazil jsi na chybu nebo máš nápad? Napiš nám — každá zpráva pomůže.",
+    "feedback_button": "Napsat nám",
     "dark_mode_title": "Tmavý režim",
     "dark_mode_description": "Přepínání motivu se ukládá lokálně v prohlížeči.",
     "dark_mode_on": "Zapnuto",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -16,7 +16,8 @@
     "actions": "Actions",
     "logout": "Logout",
     "wishlist": "Wishlist",
-    "go_home": "Shelfy — go to books"
+    "go_home": "Shelfy — go to books",
+    "feedback": "Feedback"
   },
   "toast": {
     "book_saved": "Changes saved successfully.",
@@ -212,6 +213,9 @@
     "preferences_title": "Preferences",
     "data_title": "Data & export",
     "about_title": "About & legal",
+    "feedback_title": "Feedback",
+    "feedback_description": "Hit a bug or have an idea? Drop us a line — every message helps.",
+    "feedback_button": "Contact us",
     "dark_mode_title": "Dark mode",
     "dark_mode_description": "Theme preference is stored locally in your browser.",
     "dark_mode_on": "On",

--- a/frontend/src/lib/legal.ts
+++ b/frontend/src/lib/legal.ts
@@ -9,3 +9,4 @@ export const LEGAL_DOC_EFFECTIVE_DATE = '12. května 2026'
 
 export const PRIVACY_CONTACT_EMAIL = 'privacy@shelfy.cz'
 export const TERMS_CONTACT_EMAIL = 'info@shelfy.cz'
+export const SUPPORT_CONTACT_EMAIL = 'support@shelfy.cz'

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -16,6 +16,7 @@ import { useToastStore } from '../lib/toast-store'
 import { trackEvent } from '../lib/analytics'
 import type { LibraryRole } from '../lib/types'
 import { ROUTES } from '../lib/routes'
+import { SUPPORT_CONTACT_EMAIL } from '../lib/legal'
 import { useAuth } from '../contexts/AuthContext'
 import { setLanguage } from '../i18n'
 import { useSettingsStore } from '../store/useSettingsStore'
@@ -839,6 +840,23 @@ export function SettingsPage() {
       {/* ── About & legal ── */}
       <div className='stg-section' data-testid='section-about'>
         <h3 className='stg-section-title'>{t('settings.about_title')}</h3>
+
+        <div className='stg-row'>
+          <div className='stg-row-label'>
+            <p className='stg-row-title'>{t('settings.feedback_title')}</p>
+            <p className='stg-row-desc'>{t('settings.feedback_description')}</p>
+          </div>
+          <div className='stg-row-control'>
+            <a
+              className='sh-btn-secondary'
+              href={`mailto:${SUPPORT_CONTACT_EMAIL}?subject=${encodeURIComponent('Shelfy — zpětná vazba')}`}
+              style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', fontSize: 13 }}
+              data-testid='feedback-link'
+            >
+              {t('settings.feedback_button')}
+            </a>
+          </div>
+        </div>
 
         <div className='stg-row'>
           <div className='stg-row-label'>


### PR DESCRIPTION
## Proč

Před náborem prvních testerů appka nemá viditelnou cestu „napsat nám / nahlásit
problém". Patička po přihlášení není, tak to jde **jemně do Nastavení a levého
panelu**, ať to zůstane přehledné.

## Co se mění

- **`SettingsPage`** → sekce *O aplikaci*: nový řádek **„Zpětná vazba"** s
  tlačítkem `mailto:support@shelfy.cz` (předvyplněný předmět „Shelfy — zpětná vazba").
- **`Navigation`** (desktop sidebar): nenápadný **muted textový odkaz** pod
  „Odhlásit" — jen pro přihlášené (uvnitř `!isDemo` bloku, v demu se nezobrazí).
- **`lib/legal.ts`**: `SUPPORT_CONTACT_EMAIL = 'support@shelfy.cz'` (support@
  reálně existuje a přeposílá na osobní schránku).
- i18n `cs`/`en` (`settings.feedback_*`, `nav.feedback`).

## Poznámky

- Mobilní bottom-nav záměrně nechávám čistou (málo místa) — na mobilu je feedback
  dostupný přes Nastavení.
- `support@` je zvolený schválně (na rozdíl od `info@`/`privacy@` reálně existuje
  jako schránka na Wedosu).

## Test

- `npm run lint` → 0/0
- `npx vitest run` → **288 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)