### PR TITLE
chore(legal): kontaktní e-mail v Zásadách soukromí privacy@ → support@

### DIFF
--- a/frontend/src/lib/legal.ts
+++ b/frontend/src/lib/legal.ts
@@ -7,6 +7,5 @@ export const LEGAL_ENTITY_SEAT = '—'
 export const LEGAL_DOC_VERSION = '2.1'
 export const LEGAL_DOC_EFFECTIVE_DATE = '12. května 2026'
 
-export const PRIVACY_CONTACT_EMAIL = 'privacy@shelfy.cz'
 export const TERMS_CONTACT_EMAIL = 'info@shelfy.cz'
 export const SUPPORT_CONTACT_EMAIL = 'support@shelfy.cz'

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { LEGAL_DOC_EFFECTIVE_DATE, LEGAL_DOC_VERSION, LEGAL_ENTITY_ICO, LEGAL_ENTITY_NAME, LEGAL_ENTITY_SEAT, PRIVACY_CONTACT_EMAIL } from '../lib/legal'
+import { LEGAL_DOC_EFFECTIVE_DATE, LEGAL_DOC_VERSION, LEGAL_ENTITY_ICO, LEGAL_ENTITY_NAME, LEGAL_ENTITY_SEAT, SUPPORT_CONTACT_EMAIL } from '../lib/legal'
 
 const SECTION: CSSProperties = { marginBottom: 32 }
 const H2: CSSProperties = { fontSize: 18, fontWeight: 700, margin: '0 0 8px' }
@@ -67,7 +67,7 @@ export function PrivacyPage() {
               <tr><td style={{ ...TD, fontWeight: 600 }}>IČO</td><td style={TD}>{LEGAL_ENTITY_ICO}</td></tr>
               {/* TODO: doplnit sídlo po ověření s právníkem */}
               <tr><td style={{ ...TD, fontWeight: 600 }}>Sídlo</td><td style={TD}>{LEGAL_ENTITY_SEAT}</td></tr>
-              <tr><td style={{ ...TD, fontWeight: 600 }}>E-mail</td><td style={TD}><a href={`mailto:${PRIVACY_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{PRIVACY_CONTACT_EMAIL}</a></td></tr>
+              <tr><td style={{ ...TD, fontWeight: 600 }}>E-mail</td><td style={TD}><a href={`mailto:${SUPPORT_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{SUPPORT_CONTACT_EMAIL}</a></td></tr>
               <tr><td style={{ ...TD, fontWeight: 600 }}>Web</td><td style={TD}>https://shelfy.cz</td></tr>
             </tbody>
           </table>
@@ -230,7 +230,7 @@ export function PrivacyPage() {
           </ul>
           <p style={P}>
             Práva, která nelze uplatnit přímo v aplikaci, vyřídíme na základě žádosti zaslané na{' '}
-            <a href={`mailto:${PRIVACY_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{PRIVACY_CONTACT_EMAIL}</a>.
+            <a href={`mailto:${SUPPORT_CONTACT_EMAIL}`} style={{ color: 'var(--sh-primary)' }}>{SUPPORT_CONTACT_EMAIL}</a>.
             Na žádost odpovíme nejpozději do 30 dnů.
           </p>
         </div>


### PR DESCRIPTION
Nahrazuje `privacy@shelfy.cz` za **`support@shelfy.cz`** ve všech výskytech
(kontrolce/správce e-mail row + řádek o uplatnění práv na PrivacyPage).

- `lib/legal.ts`: odstraněna konstanta `PRIVACY_CONTACT_EMAIL` (byl to jediný
  výskyt privacy@ v kódu).
- `PrivacyPage.tsx`: používá `SUPPORT_CONTACT_EMAIL`.

Důvod: support@ je jediná reálná schránka na Wedosu; privacy@ byl jen alias.

Test: `npm run lint` 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)